### PR TITLE
fix: detect regex based on context

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -5,8 +5,10 @@ const codeOutput = document.getElementById('output')
 
 const fullExample = `
 // hello-world.js
+
 import { planet } from '../space'
 
+const u = /* evaluate */ 1 / 234 + 56 / 7
 export const test = (str) => /^\\/[0-5]\\/$/g.test(str)
 
 // jsx

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -147,12 +147,10 @@ function isRegexStart(str) {
 export function tokenize(code) {
   let current = ''
   let type = -1
+  let nonSpaceType = -1
   /** @type {Array<[number, string]>} */
   const tokens = []
-  // string.type = 0 for string or string template
-  // string.type = 1 for regex
-  const string = { entered: false, type: 0 }
-  
+
   // comment.type = 0 for single line comments
   // comment.type = 1 for multi-line comments
   const comment = { entered: false, type: 0 }
@@ -173,20 +171,20 @@ export function tokenize(code) {
       return T_KEYWORD
     } else if (token === '\n') {
       return T_BREAK
-    } else if (
-       (
-        // is quoted string
-        (isStringQuotation(chr0) && !isStringQuotation(chr1)) ||
-        // is regex
-        (!jsx.tag && isRegexStart(chr0 + chr1) && token[token.length - 1] === '/')
-      )
-    ) {
-      return T_STRING
     } else if (token === ' ') {
       return T_SPACE
-    } else if (signs.has(chr0)) {
+    } else if (token.split('').every(ch => signs.has(ch))) {
       return T_SIGN
     } else if (
+      (
+       // is quoted string
+       (isStringQuotation(chr0) && !isStringQuotation(chr1)) ||
+       // is regex
+       (!jsx.tag && isRegexStart(chr0 + chr1) && token[token.length - 1] === '/')
+     )
+   ) {
+     return T_STRING
+   } else if (
       !inJsxLiterals() && 
       (
         isIdentifierChar(chr0) &&
@@ -203,6 +201,7 @@ export function tokenize(code) {
   const append = () => {
     if (current) {
       type = classify(current)
+      if (type !== T_SPACE && type !== T_BREAK) nonSpaceType = type
       tokens.push([type, current])
     }
     current = ''
@@ -222,26 +221,46 @@ export function tokenize(code) {
       jsx.tag = !(isOpenElementEnd || isCloseElementEnd)
     }
     // if it's not in a jsx tag declaration or a string, close child if next is jsx close tag
-    if (!jsx.tag && !string.entered && (curr === '<' && isIdentifierChar(next) || c_n === '</')) {
+    if (!jsx.tag && (curr === '<' && isIdentifierChar(next) || c_n === '</')) {
       jsx.tag = true
       jsx.child = false
     }
 
     if (
-      !string.entered && 
       (isStringQuotation(curr) || !jsx.tag && isRegexStart(c_n))
     ) {
-      string.entered = true
-      string.type = isStringQuotation(curr) ? 0 : 1
       append()
-      current = curr
-    } else if (string.entered) {
-      current += curr
-      if (string.type === 0 && isStringQuotation(curr)) {
-        string.entered = false
+      if (!(nonSpaceType === T_SIGN || nonSpaceType === T_COMMENT)) {
+        current = curr
         append()
-      } else if (string.type === 1 && prev !== '\\' && curr === '/') {
-        string.entered = false
+        continue
+      }
+      let j = i + 1
+      let strEnd = i
+      const inString = () => j < code.length && code[j] !== '\n'
+      // string quotation
+      if (isStringQuotation(curr)) {
+        for (; inString(); j++) {
+          if (isStringQuotation(code[j])) {
+            strEnd = j
+            break
+          }
+        }
+      } else {
+        // regex
+        for (; inString(); j++) {
+          if (code[j] === '/' && code[j - 1] !== '\\') {
+            strEnd = j
+            break
+          }
+        }
+      }
+      if (strEnd !== i) {
+        current = code.slice(i, strEnd + 1)
+        append()
+        i = j
+      } else {
+        current = curr
         append()
       }
     } else if (


### PR DESCRIPTION
* only allow sign and comment types before regex
* remove `string` state, traverse the whole string / regex at once instead of detect in each main loop