### PR TITLE
Fix: detection end of expression

### DIFF
--- a/docs/pages/index.js
+++ b/docs/pages/index.js
@@ -77,8 +77,10 @@ const _iu = /* evaluate */ (19) / 234 + 56 / 7;
 `.trim()
 
 
+const example = fullExample
+
 export default function Page() {
-  const [text, setText] = useState(fullExample)
+  const [text, setText] = useState(example)
   const [output, setOutput] = useState(highlight(text))
   function onChange(event) {
     const code = event.target.value || ''

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -228,13 +228,13 @@ export function tokenize(code) {
       append()
       const [lastType, lastToken] = last
       // Special cases that are not considered as regex:
-      // * (expr) / expr: `()[]` before `/` is still in expression
+      // * (expr1) / expr2: `()` before `/` operator is still in expression
       // * <non comment start>/ expr: non comment start before `/` is not regex
       if (
         isRegexChar && 
         lastType && 
         !(
-          (lastType === T_SIGN && !'()[]'.includes(lastToken)) || 
+          (lastType === T_SIGN && !'()'.includes(lastToken)) || 
           lastType === T_COMMENT
         )
       ) {

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -126,12 +126,16 @@ function encode(str) {
     .replace(/[^\S\r\n]/g, '&nbsp;')
 }
 
+function isChar(chr) {
+  return /^[\w_]+$/.test(chr)
+}
+
 function isIdentifierChar(chr) {
-  return /^[a-zA-Z_$_$]$/.test(chr)
+  return /^[a-zA-Z_$]$/.test(chr)
 }
 
 function isIdentifier(str) {
-  return isIdentifierChar(str[0]) && (str.length === 1 || /^[\w_$]+$/.test(str.slice(1)))
+  return isIdentifierChar(str[0]) && (str.length === 1 || isChar(str.slice(1)))
 }
 
 function isStringQuotation(chr) {
@@ -179,7 +183,7 @@ export function tokenize(code) {
     } else if (
       !inJsxLiterals() && 
       (
-        isIdentifierChar(chr0) &&
+        isChar(chr0) &&
         chr0 === chr0.toUpperCase() ||
         token === 'null'
       )
@@ -245,10 +249,11 @@ export function tokenize(code) {
       const start = i++
       let foundClose = false
       
-      const isNotEof = () => i < code.length && code[i] !== '\n'
+      // end of line of end of file
+      const isEol = () => i >= code.length || code[i] === '\n'
       // string quotation
       if (isQuotationChar) {
-        for (; isNotEof(); i++) {
+        for (; !isEol(); i++) {
           if (isStringQuotation(code[i])) {
             foundClose = true
             break
@@ -256,11 +261,11 @@ export function tokenize(code) {
         }
       } else {
         // regex
-        for (; isNotEof(); i++) {
+        for (; !isEol(); i++) {
           if (code[i] === '/' && code[i - 1] !== '\\') {
             foundClose = true
             // append regex flags
-            while (start !== i && /^[a-z]$/.test(code[i + 1]) && isNotEof()) {
+            while (start !== i && /^[a-z]$/.test(code[i + 1]) && !isEol()) {
               i++
             };
             break
@@ -304,7 +309,7 @@ export function tokenize(code) {
     } else {
       if (
         (isJsxLiterals && !jsxBrackets.has(curr)) ||
-        isIdentifierChar(curr) === isIdentifierChar(current[current.length - 1]) &&
+        isChar(curr) === isChar(current[current.length - 1]) &&
         !signs.has(curr)
       ) {
         current += curr

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -276,7 +276,7 @@ export function tokenize(code) {
         // If it doesn't match any of the above, just leave it as operator and move on
         current = curr
         append()
-        i = start + 1
+        i = start
       }
     } else if (isCommentStart(c_n)) {
       const start = i

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -127,11 +127,11 @@ function encode(str) {
 }
 
 function isIdentifierChar(chr) {
-  return /^[\w_$]$/.test(chr)
+  return /^[a-zA-Z_$_$]$/.test(chr)
 }
 
 function isIdentifier(str) {
-  return /[a-zA-Z_$]/.test(str[0]) && (str.length === 1 || /^[\w_$]+$/.test(str.slice(1)))
+  return isIdentifierChar(str[0]) && (str.length === 1 || /^[\w_$]+$/.test(str.slice(1)))
 }
 
 function isStringQuotation(chr) {
@@ -243,33 +243,40 @@ export function tokenize(code) {
         continue
       }
       const start = i++
+      let foundClose = false
       
-      const isInline = () => i < code.length && code[i] !== '\n'
+      const isNotEof = () => i < code.length && code[i] !== '\n'
       // string quotation
       if (isQuotationChar) {
-        for (; isInline(); i++) {
+        for (; isNotEof(); i++) {
           if (isStringQuotation(code[i])) {
+            foundClose = true
             break
           }
         }
       } else {
         // regex
-        for (; isInline(); i++) {
+        for (; isNotEof(); i++) {
           if (code[i] === '/' && code[i - 1] !== '\\') {
+            foundClose = true
             // append regex flags
-            while (start !== i && /^[a-z]$/.test(code[i + 1]) && isInline()) {
+            while (start !== i && /^[a-z]$/.test(code[i + 1]) && isNotEof()) {
               i++
             };
             break
           }
         }
       }
-      if (start !== i) {
+      if (start !== i && foundClose) {
+        // If current line is fully closed with string quotes or regex slashes,
+        // add them to tokens
         current = code.slice(start, i + 1)
         append(T_STRING)
       } else {
+        // If it doesn't match any of the above, just leave it as operator and move on
         current = curr
         append()
+        i = start + 1
       }
     } else if (isCommentStart(c_n)) {
       const start = i

--- a/test/ast.test.js
+++ b/test/ast.test.js
@@ -155,6 +155,51 @@ describe('string & regex', () => {
     ])
   })
 
+  it('multi line regex tests', () => {
+    const code1 = 
+      `/reg/.test('str')[]\n` +
+      `/reg/.test('str')`
+
+    // '[]' consider as a end of the expression
+    expect(getNonSpacesTokensTypes(tokenize(code1))).toEqual([
+      'string',
+      'sign',
+      'identifier',
+      'sign',
+      'string',
+      'sign',
+      'sign',
+      'sign',
+      'break',
+      'string',
+      'sign',
+      'identifier',
+      'sign',
+      'string',
+      'sign',
+    ])
+
+    const code2 = 
+      `/reg/.test('str')()\n` +
+      `/reg/.test('str')`
+
+    // what before '()' still considers as an expression
+    expect(getNonSpacesTokensTypes(tokenize(code2))).toEqual([
+      'string',
+      'sign',
+      'identifier',
+      'sign',
+      'string',
+      'sign',
+      'sign',
+      'sign',
+      'break',
+      'sign',
+      'identifier',
+      'string',
+    ])
+  })
+
   it('import string', () => {
     const code = `import mod from "../../mod"`
     const tokens = tokenize(code)

--- a/test/ast.test.js
+++ b/test/ast.test.js
@@ -161,22 +161,21 @@ describe('string & regex', () => {
       `/reg/.test('str')`
 
     // '[]' consider as a end of the expression
-    expect(getNonSpacesTokensTypes(tokenize(code1))).toEqual([
-      'string',
-      'sign',
-      'identifier',
-      'sign',
-      'string',
-      'sign',
-      'sign',
-      'sign',
-      'break',
-      'string',
-      'sign',
-      'identifier',
-      'sign',
-      'string',
-      'sign',
+    expect(getNonSpacesTokens(tokenize(code1))).toEqual([
+      "/reg/",
+      ".",
+      "test",
+      "(",
+      "'str'",
+      ")",
+      "[",
+      "]",
+      "/reg/", // regex
+      ".",
+      "test",
+      "(",
+      "'str'",
+      ")",
     ])
 
     const code2 = 
@@ -184,23 +183,23 @@ describe('string & regex', () => {
       `/reg/.test('str')`
 
     // what before '()' still considers as an expression
-    expect(getNonSpacesTokensTypes(tokenize(code2))).toEqual([
-      'string',
-      'sign',
-      'identifier',
-      'sign',
-      'string',
-      'sign',
-      'sign',
-      'sign',
-      'break',
-      'sign',
-      'identifier',
-      'sign',
-      'identifier',
-      'sign',
-      'string',
-      'sign',
+    expect(getNonSpacesTokens(tokenize(code2))).toEqual([
+      "/reg/",
+      ".",
+      "test",
+      "(",
+      "'str'",
+      ")",
+      "(",
+      ")",
+      "/",   // operator
+      "reg", // identifier
+      "/",   // operator
+      ".",
+      "test",
+      "(",
+      "'str'",
+      ")",
     ])
   })
 

--- a/test/ast.test.js
+++ b/test/ast.test.js
@@ -196,7 +196,11 @@ describe('string & regex', () => {
       'break',
       'sign',
       'identifier',
+      'sign',
+      'identifier',
+      'sign',
       'string',
+      'sign',
     ])
   })
 


### PR DESCRIPTION
These should be considered as 2 valid expressions

<img width="282" alt="image" src="https://user-images.githubusercontent.com/4800338/159186376-9cbb868b-6741-4e08-b021-618bb6eff697.png">

If there's `()` as end, should still be considered as expression

<img width="240" alt="image" src="https://user-images.githubusercontent.com/4800338/159187158-c3c2fa04-084c-442b-9f77-eb613e876ce2.png">
