### PR TITLE
fix: jsx child parse wrong when there is no '\n' before '<'

### DIFF
--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -317,6 +317,9 @@ export function tokenize(code) {
         !signs.has(curr)
       ) {
         current += curr
+        if (next === '<') {
+          append();
+        }
       } else {
         append()
         current = curr

--- a/test/ast.test.js
+++ b/test/ast.test.js
@@ -104,6 +104,20 @@ describe('jsx', () => {
   })
 })
 
+describe('jsx nest', () => {
+  it('parse jsx compositions', () => {
+    const tokens = tokenize(`
+      <Component>This is content</Component>
+    `)
+    expect(getNonSpacesTokens(tokens)).toEqual([
+      "<", "Component", ">", "This is content", "</", "Component", ">",
+    ])
+    
+    const jsChildrenTextToken = tokens.find(tk => mergeSpaces(tk[1]) === 'This is content')
+    expect(getTypeName(jsChildrenTextToken)).toBe('jsxliterals')
+  })
+})
+
 describe('comments', () => {
   it('basic inline comments', () => {
     const code = `+ // This is a inline comment / <- a slash`


### PR DESCRIPTION
Fixes #28

Decide next is '<' when update the current value.