### PR TITLE
fix: jsx children detection

### DIFF
--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -172,8 +172,9 @@ export function tokenize(code) {
   // jsx.close for is the closing sign of open or close tags
   // jsx.child for entering children
   // jsx.expr for entering {expression}
-  /** @type {{ tag: boolean; close: boolean; child: boolean; expr: boolean }} */
-  const jsx = { tag: false, close: false, child: false, expr: false }
+  // jsx.end for entering close tag
+  /** @type {{ tag: boolean; close: boolean; child: boolean; expr: boolean; end: boolean }} */
+  const jsx = { tag: false, close: false, child: false, expr: false, end: false }
 
   const inJsxTag = () => jsx.tag || jsx.close
   const inJsxLiterals = () => !inJsxTag() && jsx.child && !jsx.expr
@@ -192,12 +193,12 @@ export function tokenize(code) {
       return T_SPACE
     } else if (token.split('').every(ch => signs.has(ch))) {
       return T_SIGN
+    } else if (inJsxLiterals()) {
+      return T_JSX_LITERALS
     } else if (isCls(token)) {
-      return inJsxLiterals() ? T_JSX_LITERALS : inJsxTag() ? T_IDENTIFIER : T_CLS_NUMBER
+      return inJsxTag() ? T_IDENTIFIER : T_CLS_NUMBER
     } else {
-      return inJsxLiterals()
-        ? T_JSX_LITERALS
-        : isIdentifier(token) ? T_IDENTIFIER : T_STRING
+      return isIdentifier(token) ? T_IDENTIFIER : T_STRING
     }
   }
 
@@ -224,12 +225,21 @@ export function tokenize(code) {
     if (jsx.close && (last[1] === '>' || last[1] === '/>')) {
       jsx.close = false
     }
+
+    if (!jsx.tag && (c_n === '</' || c_n === '/>')) {
+      jsx.end = true
+    }
+
     if (jsx.tag) {
       const isOpenElementEnd = curr === '>'
       const isCloseElementEnd = p_c === '/>'
-      jsx.child = !isCloseElementEnd
+      jsx.child = !jsx.end && (isOpenElementEnd && !isCloseElementEnd)
+
       jsx.tag = !(isOpenElementEnd || isCloseElementEnd)
       jsx.close = isOpenElementEnd || isCloseElementEnd
+      if (jsx.end && (isCloseElementEnd || isOpenElementEnd)) {
+        jsx.end = false
+      }
     }
     // if it's not in a jsx tag declaration or a string, close child if next is jsx close tag
     if (!jsx.tag && (curr === '<' && isIdentifierChar(next) || c_n === '</')) {
@@ -324,16 +334,18 @@ export function tokenize(code) {
       }
     } else {
       if (
+        // it's jsx literals and is not a jsx bracket
         (isJsxLiterals && !jsxBrackets.has(curr)) ||
+        // same type char as previous one in current token
         isWord(curr) === isWord(current[current.length - 1]) &&
         !signs.has(curr)
       ) {
         current += curr
         if (next === '<') {
-          append();
+          append(T_JSX_LITERALS);
         }
       } else {
-        append()
+        append(c_n === '</' ? T_JSX_LITERALS : undefined)
         current = curr
         if (c_n === '</' || c_n === '/>') {
           current = c_n

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "codice": "^0.0.3",
-    "next": "^12.1.6-canary.6",
+    "next": "12.1.6-canary.6",
     "react": "18.0.0",
     "react-dom": "18.0.0",
     "sugar-high": "link:./",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "codice": "^0.0.3",
-    "next": "12.1.6-canary.6",
+    "next": "^12.1.6-canary.6",
     "react": "18.0.0",
     "react-dom": "18.0.0",
     "sugar-high": "link:./",

--- a/test/ast.test.js
+++ b/test/ast.test.js
@@ -121,6 +121,24 @@ describe('jsx', () => {
       'sign', 'identifier', 'sign', 'sign', 'class', 'sign', 'identifier', 'sign', 'sign', 'identifier', 'sign',
     ])
   })
+
+  it('parse multi jsx definitions', () => {
+    const tokens = tokenize(
+      `x = <div>this </div>
+        y = <div>thi</div>
+        z = <div>this</div>
+      `)
+    expect(extractTokenValues(tokens)).toEqual([
+      'x', '=', '<', 'div', '>', 'this', '</', 'div', '>',
+      'y', '=', '<', 'div', '>', 'thi', '</', 'div', '>',
+      'z', '=', '<', 'div', '>', 'this', '</', 'div', '>',
+    ])
+    expect(extractTokensTypes(tokens)).toEqual([
+      'identifier', 'sign', 'sign', 'identifier', 'sign', 'jsxliterals', 'sign', 'identifier', 'sign', 'break',
+      'identifier', 'sign', 'sign', 'identifier', 'sign', 'jsxliterals', 'sign', 'identifier', 'sign', 'break',
+      'identifier', 'sign', 'sign', 'identifier', 'sign', 'jsxliterals', 'sign', 'identifier', 'sign', 'break',
+    ])
+  })
 })
 
 describe('comments', () => {


### PR DESCRIPTION
Fixes: #38 

* set `jsx.child` to `false` when enters close tag or self close tag
* set jsx literals type when append the token, instead of auto inferring