### PR TITLE
fix: Inconsistent jsx literals

### DIFF
--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -327,6 +327,9 @@ export function tokenize(code) {
         )
       ) {
         current += curr
+        if (next === '<') {
+          append();
+        }
       } else {
         append()
         current = curr

--- a/test/ast.test.js
+++ b/test/ast.test.js
@@ -148,6 +148,20 @@ describe('jsx', () => {
       'identifier', 'sign', 'sign', 'identifier', 'sign', 'jsxliterals', 'sign', 'identifier', 'sign', 'break',
     ])
   })
+
+  it('parse fold jsx', () => {
+    const tokens = tokenize(`// jsx
+    const element = (
+      <div>Hello World <Food /><div/>
+    )`);
+
+    expect(extractTokenValues(tokens)).toEqual([
+      "// jsx", "const", "element", "=", "(", "<", "div", ">", "Hello World", "<", "Food", "/>", "<", "div", "/>", ")"
+    ])
+
+    const jsxTextChildrenToken = tokens.find(tk => mergeSpaces(tk[1]) === 'Hello World')
+    expect(getTypeName(jsxTextChildrenToken)).toBe('jsxliterals')
+  });
 })
 
 describe('comments', () => {


### PR DESCRIPTION
Call append when curr is space and next is '<'

Fixes: #44 