### PR TITLE
Jsx nested

### DIFF
--- a/docs/pages/index.js
+++ b/docs/pages/index.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { tokenize } from 'sugar-high'
+import { highlight, tokenize, types } from 'sugar-high'
 import { Editor } from 'codice'
 
 const fullExample = `
@@ -79,6 +79,8 @@ const _iu = /* evaluate */ (19) / 234 + 56 / 7;
 
 
 const devExample = `
+<div>Hello <Name /> with {data}</div>
+
 `.trim()
 
 const example = process.env.NODE_ENV === 'development' && devExample
@@ -95,14 +97,7 @@ export default function Page() {
     if (process.env.NODE_ENV !== 'production') {
       console.log(
         tokenize(code)
-          .map(t => t[1])
-      )
-    }
-
-    if (process.env.NODE_ENV !== 'production') {
-      console.log(
-        tokenize(code)
-          .map(t => t[1])
+          .map(t => [t[1], types[t[0]]])
       )
     }
   }
@@ -211,7 +206,7 @@ export default function Page() {
           </div>
         }
       </div>
-      <Editor className="editor" defaultValue={example} onChange={update} />
+      <Editor className="editor" highlight={highlight} value={example} onChange={update} />
       <div className="flex">
       </div>
     </div>

--- a/docs/pages/index.js
+++ b/docs/pages/index.js
@@ -91,7 +91,9 @@ const _iu = /* evaluate */ (19) / 234 + 56 / 7;
 
 
 const devExample = `
-<div>Hello <Name /> with {data}</div>
+x = <div>this </div>
+y = <div>thi</div>
+z = <div>this</div>
 `.trim()
 
 const example = process.env.NODE_ENV === 'development' && devExample

--- a/docs/pages/index.js
+++ b/docs/pages/index.js
@@ -2,18 +2,6 @@ import { useEffect, useState } from 'react'
 import { highlight, tokenize, types } from 'sugar-high'
 import { Editor } from 'codice'
 
-function LocalStorage() {
-  const key = '$$__sugar_highlight_code__'
-  function set(code) {
-    localStorage.setItem(key, code)
-  }
-  function get() {
-    return localStorage.getItem(key)
-  }
-
-  return { set, get }
-}
-
 const fullExample = `
 // npm i -S sugar-high
 
@@ -91,9 +79,6 @@ const _iu = /* evaluate */ (19) / 234 + 56 / 7;
 
 
 const devExample = `
-x = <div>this </div>
-y = <div>thi</div>
-z = <div>this</div>
 `.trim()
 
 const example = process.env.NODE_ENV === 'development' && devExample
@@ -104,15 +89,7 @@ const example = process.env.NODE_ENV === 'development' && devExample
 export default function Page() {
   const [isLineNumberEnabled, setLineNumberEnabled] = useState(true)
   const [isDev, setIsDev] = useState(false)
-  const [storage] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const s = LocalStorage()
-      return s
-    }
-  })
-  const [code, setCode] = useState(
-    () => (typeof window !== 'undefined' && storage.get()) || example
-  )
+  const [code, setCode] = useState(() => example)
 
   function debug(code) {
     if (process.env.NODE_ENV !== 'production') {
@@ -125,13 +102,11 @@ export default function Page() {
 
   function update(_code) {
     debug(_code)
-    storage.set(_code)
     setCode(_code)
   }
 
   useEffect(() => {
-    const _code = storage.get() || example
-    update(_code)
+    update(code)
   }, [])
 
   return (

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -174,19 +174,16 @@ export function tokenize(code) {
   // jsx.expr for entering {expression}
   // jsx.end for entering close tag
   // jsx.stack for marking the nested layers of tags
-  /** @type {{tag: boolean; close?: boolean; child: boolean; expr: boolean; end: boolean, stack: number }} */
-  const jsx = {
-    tag: false,
-    // close: false,
-    child: false,
-    expr: false,
-    end: false,
-    stack: 0
-  }
   let __jsxEnter = false
+  let __jsxTag = false
+  let __jsxChild = false
+  let __jsxExpr = false
 
-  const inJsxTag = () => jsx.tag || jsx.end
-  const inJsxLiterals = () => !inJsxTag() && jsx.child && !jsx.expr && jsx.stack > 0
+  // only match paired (open + close) tags, not self-closing tags
+  let __jsxStack = 0
+
+  const inJsxTag = () => __jsxTag && !__jsxChild
+  const inJsxLiterals = () => !__jsxTag && __jsxChild && !__jsxExpr && __jsxStack > 0
 
   /**
    *
@@ -194,8 +191,11 @@ export function tokenize(code) {
    * @returns {number}
    */
   function classify(token) {
+    if (['with'].some(s => token.includes(s))) {
+      console.log('token', token, 'child', __jsxChild, 'stack', __jsxStack, 'enter', __jsxEnter, 'expr', __jsxExpr)
+    }
     const isJsxLiterals = inJsxLiterals()
-    if (jsx.stack && keywords.has(token)) {
+    if (keywords.has(token)) {
       return last[1] === '.' ? T_IDENTIFIER : T_KEYWORD
     } else if (token === '\n') {
       return T_BREAK
@@ -232,59 +232,81 @@ export function tokenize(code) {
     const c_n = curr + next // current and next
 
 
-    if (jsx.tag) {
-      const isOpenElementEnd = curr === '>'
-      const isSelfCloseSign = p_c === '/>'
-      // if (!jsx.child) {
-      //   console.log('set child', jsx.end, isOpenElementEnd, isSelfCloseSign)
-      // }
-
-      // if (curr === '/') {
-      //   console.log('set jsx.tag(1)', jsx.tag, curr, p_c, prev, jsx.end)
-      // }
-
-      if (isOpenElementEnd) {
-        jsx.tag = false
-      }
-
-      if (isSelfCloseSign) {
-        jsx.end = false
-        jsx.tag = false
-        current = '/>'
-        jsx.stack--
+    if (__jsxChild) {
+      if (curr === '{') {
+        append()
+        __jsxExpr = true
+        current = curr
         append()
         continue
       }
     }
 
-    // enter children
-    if (__jsxEnter && prev === '>' && (code[i - 2] + prev) !== '/>') {
-      __jsxEnter = false
-      console.log('enter children', jsx, curr)
-      if (!jsx.child) jsx.child = true
-      jsx.stack++
-    }
-    // if it's not in a jsx tag declaration or a string, close child if next is jsx close tag
-    if (!jsx.tag && (curr === '<' && isIdentifierChar(next) || c_n === '</')) {
-      jsx.tag = true
-      const isCloseTag = c_n === '</'
-      if (isCloseTag) {
-      } else {
-        __jsxEnter = true
+    if (__jsxEnter) {
+      if (!__jsxTag && curr === '<') {
+        append()
+        __jsxTag = true
+        current = curr
+        if (next === '/') {
+          current = c_n
+          i++
+        }
+        append()
+        continue
       }
-      console.log('set tag to true', curr)
+      if (__jsxTag) {
+        // >: open tag close sign
+        if (curr === '>' && prev !== '/') {
+          append()
+          __jsxTag = false
+          if (!__jsxChild) __jsxChild = true
+          __jsxStack++
+          current = curr
+          append()
+          continue
+        }
 
-      console.log('set jsx.tag(2)', jsx.tag)
+        // >: tag self close sign or close tag sign
+        if (c_n === '/>' || c_n === '</') {
+          append()
+          if (c_n === '/>') {
+            __jsxTag = false
+          }
+          if (c_n === '</') {
+            __jsxStack--
+          }
+          __jsxEnter = __jsxStack > 0
+          current = c_n
+          i++
+          append()
+          continue
+        }
 
-      // leave children
-      if (isCloseTag && jsx.child) {
-        jsx.child = jsx.stack > 0
-        jsx.stack--
+        // <: open tag sign
+        if (curr === '<') {
+          append()
+          current = curr
+          if (next === '/') {
+            current = c_n
+            i++
+          }
+          append()
+          continue
+        }
+      }
+    }
+
+    // if it's not in a jsx tag declaration or a string, close child if next is jsx close tag
+    if (!__jsxTag && (curr === '<' && isIdentifierChar(next) || c_n === '</')) {
+      __jsxTag = true
+
+      if (curr === '<' && next !== '/') {
+        __jsxEnter = true
       }
     }
 
     const isQuotationChar = isStringQuotation(curr)
-    const isRegexChar = !jsx.tag && isRegexStart(c_n)
+    const isRegexChar = !__jsxEnter && isRegexStart(c_n)
     const isJsxLiterals = inJsxLiterals()
     if (isQuotationChar || isRegexChar) {
       append()
@@ -365,7 +387,7 @@ export function tokenize(code) {
       ) {
         current += curr
         if (next === '<') {
-          append();
+          append()
         }
       } else {
         append()
@@ -373,23 +395,23 @@ export function tokenize(code) {
         append()
       }
     } else {
-      // console.log('isJsxLiterals', isJsxLiterals, curr, jsx.stack)
       if (
         // it's jsx literals and is not a jsx bracket
         (isJsxLiterals && !jsxBrackets.has(curr)) ||
         // same type char as previous one in current token
-        (isWord(curr) === isWord(current[current.length - 1]) && !signs.has(curr) || jsx.stack > 1)
+        (isWord(curr) === isWord(current[current.length - 1]) && !signs.has(curr) || __jsxStack > 0)
       ) {
-        current += curr
-        if (next === '<') {
-          append();
+        if (__jsxExpr && curr === '}') {
+          append()
+          __jsxExpr = false
+          current = curr
+          append()
+        } else {
+          current += curr
         }
       } else {
-        // console.log('jsx.stack', current, curr, jsx.stack, isJsxLiterals)
         if (p_c === '</') {
           current = p_c
-          // current += curr
-          // i++
         }
         append()
 
@@ -398,20 +420,12 @@ export function tokenize(code) {
 
         }
         if ((c_n === '</' || c_n === '/>')) {
-
-          // current = c_n
-          // append()
-          // i++
+          current = c_n
+          append()
+          i++
         }
         else if (jsxBrackets.has(curr)) append()
       }
-    }
-
-    if (jsx.child && curr === '{') {
-      jsx.expr = true
-    }
-    if (jsx.child && jsx.expr && curr === '}') {
-      jsx.expr = false
     }
   }
 

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -173,11 +173,20 @@ export function tokenize(code) {
   // jsx.child for entering children
   // jsx.expr for entering {expression}
   // jsx.end for entering close tag
-  /** @type {{ tag: boolean; close: boolean; child: boolean; expr: boolean; end: boolean }} */
-  const jsx = { tag: false, close: false, child: false, expr: false, end: false }
+  // jsx.stack for marking the nested layers of tags
+  /** @type {{tag: boolean; close?: boolean; child: boolean; expr: boolean; end: boolean, stack: number }} */
+  const jsx = {
+    tag: false,
+    // close: false,
+    child: false,
+    expr: false,
+    end: false,
+    stack: 0
+  }
+  let __jsxEnter = false
 
-  const inJsxTag = () => jsx.tag || jsx.close
-  const inJsxLiterals = () => !inJsxTag() && jsx.child && !jsx.expr
+  const inJsxTag = () => jsx.tag || jsx.end
+  const inJsxLiterals = () => !inJsxTag() && jsx.child && !jsx.expr && jsx.stack > 0
 
   /**
    *
@@ -185,7 +194,8 @@ export function tokenize(code) {
    * @returns {number}
    */
   function classify(token) {
-    if (keywords.has(token)) {
+    const isJsxLiterals = inJsxLiterals()
+    if (jsx.stack && keywords.has(token)) {
       return last[1] === '.' ? T_IDENTIFIER : T_KEYWORD
     } else if (token === '\n') {
       return T_BREAK
@@ -193,7 +203,7 @@ export function tokenize(code) {
       return T_SPACE
     } else if (token.split('').every(ch => signs.has(ch))) {
       return T_SIGN
-    } else if (inJsxLiterals()) {
+    } else if (isJsxLiterals) {
       return T_JSX_LITERALS
     } else if (isCls(token)) {
       return inJsxTag() ? T_IDENTIFIER : T_CLS_NUMBER
@@ -220,35 +230,62 @@ export function tokenize(code) {
     const next = code[i + 1]
     const p_c = prev + curr // previous and current
     const c_n = curr + next // current and next
-    const isJsxLiterals = inJsxLiterals()
 
-    if (jsx.close && (last[1] === '>' || last[1] === '/>')) {
-      jsx.close = false
-    }
-
-    if (!jsx.tag && (c_n === '</' || c_n === '/>')) {
-      jsx.end = true
-    }
 
     if (jsx.tag) {
       const isOpenElementEnd = curr === '>'
-      const isCloseElementEnd = p_c === '/>'
-      jsx.child = !jsx.end && (isOpenElementEnd && !isCloseElementEnd)
+      const isSelfCloseSign = p_c === '/>'
+      // if (!jsx.child) {
+      //   console.log('set child', jsx.end, isOpenElementEnd, isSelfCloseSign)
+      // }
 
-      jsx.tag = !(isOpenElementEnd || isCloseElementEnd)
-      jsx.close = isOpenElementEnd || isCloseElementEnd
-      if (jsx.end && (isCloseElementEnd || isOpenElementEnd)) {
-        jsx.end = false
+      // if (curr === '/') {
+      //   console.log('set jsx.tag(1)', jsx.tag, curr, p_c, prev, jsx.end)
+      // }
+
+      if (isOpenElementEnd) {
+        jsx.tag = false
       }
+
+      if (isSelfCloseSign) {
+        jsx.end = false
+        jsx.tag = false
+        current = '/>'
+        jsx.stack--
+        append()
+        continue
+      }
+    }
+
+    // enter children
+    if (__jsxEnter && prev === '>' && (code[i - 2] + prev) !== '/>') {
+      __jsxEnter = false
+      console.log('enter children', jsx, curr)
+      if (!jsx.child) jsx.child = true
+      jsx.stack++
     }
     // if it's not in a jsx tag declaration or a string, close child if next is jsx close tag
     if (!jsx.tag && (curr === '<' && isIdentifierChar(next) || c_n === '</')) {
       jsx.tag = true
-      jsx.child = false
+      const isCloseTag = c_n === '</'
+      if (isCloseTag) {
+      } else {
+        __jsxEnter = true
+      }
+      console.log('set tag to true', curr)
+
+      console.log('set jsx.tag(2)', jsx.tag)
+
+      // leave children
+      if (isCloseTag && jsx.child) {
+        jsx.child = jsx.stack > 0
+        jsx.stack--
+      }
     }
 
     const isQuotationChar = isStringQuotation(curr)
     const isRegexChar = !jsx.tag && isRegexStart(c_n)
+    const isJsxLiterals = inJsxLiterals()
     if (isQuotationChar || isRegexChar) {
       append()
       const [lastType, lastToken] = last
@@ -336,24 +373,35 @@ export function tokenize(code) {
         append()
       }
     } else {
+      // console.log('isJsxLiterals', isJsxLiterals, curr, jsx.stack)
       if (
         // it's jsx literals and is not a jsx bracket
         (isJsxLiterals && !jsxBrackets.has(curr)) ||
         // same type char as previous one in current token
-        isWord(curr) === isWord(current[current.length - 1]) &&
-        !signs.has(curr)
+        (isWord(curr) === isWord(current[current.length - 1]) && !signs.has(curr) || jsx.stack > 1)
       ) {
         current += curr
         if (next === '<') {
-          append(T_JSX_LITERALS);
+          append();
         }
       } else {
-        append(c_n === '</' ? T_JSX_LITERALS : undefined)
-        current = curr
-        if (c_n === '</' || c_n === '/>') {
-          current = c_n
-          append()
-          i++
+        // console.log('jsx.stack', current, curr, jsx.stack, isJsxLiterals)
+        if (p_c === '</') {
+          current = p_c
+          // current += curr
+          // i++
+        }
+        append()
+
+        if (p_c !== '</') {
+          current = curr
+
+        }
+        if ((c_n === '</' || c_n === '/>')) {
+
+          // current = c_n
+          // append()
+          // i++
         }
         else if (jsxBrackets.has(curr)) append()
       }

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -168,12 +168,6 @@ export function tokenize(code) {
   /** @type {Array<[number, string]>} */
   const tokens = []
 
-  // jsx.tag for entering open or closed tags
-  // jsx.close for is the closing sign of open or close tags
-  // jsx.child for entering children
-  // jsx.expr for entering {expression}
-  // jsx.end for entering close tag
-  // jsx.stack for marking the nested layers of tags
   let __jsxEnter = false
   /**
    * @type {0 | 1 | 2}
@@ -182,14 +176,13 @@ export function tokenize(code) {
    * 2 for closing jsx tag
    **/
   let __jsxTag = 0
-  let __jsxChild = false
   let __jsxExpr = false
 
   // only match paired (open + close) tags, not self-closing tags
   let __jsxStack = 0
-
-  const inJsxTag = () => __jsxTag && !__jsxChild
-  const inJsxLiterals = () => !__jsxTag && __jsxChild && !__jsxExpr && __jsxStack > 0
+  const __jsxChild = () => __jsxEnter && !__jsxExpr && !__jsxTag
+  const inJsxTag = () => __jsxTag && !__jsxChild()
+  const inJsxLiterals = () => !__jsxTag && __jsxChild() && !__jsxExpr && __jsxStack > 0
 
   /**
    *
@@ -198,9 +191,6 @@ export function tokenize(code) {
    */
   function classify(token) {
     const isJsxLiterals = inJsxLiterals()
-    if (['this'].some(s => token.includes(s))) {
-      console.log('token', token, 'child', __jsxChild, 'stack', __jsxStack, 'enter', __jsxEnter, 'expr', __jsxExpr, 'isJsxLiterals', isJsxLiterals)
-    }
     if (isJsxLiterals) {
       return T_JSX_LITERALS
     } else if (keywords.has(token)) {
@@ -238,12 +228,12 @@ export function tokenize(code) {
     const c_n = curr + next // current and next
 
 
-    if (__jsxChild) {
+    if (__jsxChild()) {
       if (curr === '{') {
         append()
-        __jsxExpr = true
         current = curr
-        append()
+        append(T_SIGN)
+        __jsxExpr = true
         continue
       }
     }
@@ -259,7 +249,7 @@ export function tokenize(code) {
           current = c_n
           i++
         }
-        append()
+        append(T_SIGN)
         continue
       }
       if (__jsxTag) {
@@ -268,14 +258,13 @@ export function tokenize(code) {
           append()
           if (__jsxTag === 1) {
             __jsxTag = 0
-            if (!__jsxChild) __jsxChild = true
             __jsxStack++
           } else {
             __jsxTag = 0
-            __jsxChild = false
+            __jsxEnter = false
           }
           current = curr
-          append()
+          append(T_SIGN)
           continue
         }
 
@@ -288,10 +277,9 @@ export function tokenize(code) {
           if (c_n === '</') {
             __jsxStack--
           }
-          __jsxChild = __jsxStack > 0
           current = c_n
           i++
-          append()
+          append(T_SIGN)
           continue
         }
 
@@ -299,7 +287,7 @@ export function tokenize(code) {
         if (curr === '<') {
           append()
           current = curr
-          append()
+          append(T_SIGN)
           continue
         }
       }
@@ -404,20 +392,18 @@ export function tokenize(code) {
         append()
       }
     } else {
-      if (
+      if (__jsxExpr && curr === '}') {
+        append()
+        current = curr
+        append()
+        __jsxExpr = false
+      } else if (
         // it's jsx literals and is not a jsx bracket
         (isJsxLiterals && !jsxBrackets.has(curr)) ||
         // same type char as previous one in current token
-        (isWord(curr) === isWord(current[current.length - 1]) && !signs.has(curr) || __jsxStack > 0)
+        ((isWord(curr) === isWord(current[current.length - 1]) || __jsxChild()) && !signs.has(curr))
       ) {
-        if (__jsxExpr && curr === '}') {
-          append()
-          __jsxExpr = false
-          current = curr
-          append()
-        } else {
-          current += curr
-        }
+        current += curr
       } else {
         if (p_c === '</') {
           current = p_c

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -175,7 +175,13 @@ export function tokenize(code) {
   // jsx.end for entering close tag
   // jsx.stack for marking the nested layers of tags
   let __jsxEnter = false
-  let __jsxTag = false
+  /**
+   * @type {0 | 1 | 2}
+   * 0 for not in jsx
+   * 1 for open jsx tag
+   * 2 for closing jsx tag
+   **/
+  let __jsxTag = 0
   let __jsxChild = false
   let __jsxExpr = false
 
@@ -191,11 +197,13 @@ export function tokenize(code) {
    * @returns {number}
    */
   function classify(token) {
-    if (['with'].some(s => token.includes(s))) {
-      console.log('token', token, 'child', __jsxChild, 'stack', __jsxStack, 'enter', __jsxEnter, 'expr', __jsxExpr)
-    }
     const isJsxLiterals = inJsxLiterals()
-    if (keywords.has(token)) {
+    if (['this'].some(s => token.includes(s))) {
+      console.log('token', token, 'child', __jsxChild, 'stack', __jsxStack, 'enter', __jsxEnter, 'expr', __jsxExpr, 'isJsxLiterals', isJsxLiterals)
+    }
+    if (isJsxLiterals) {
+      return T_JSX_LITERALS
+    } else if (keywords.has(token)) {
       return last[1] === '.' ? T_IDENTIFIER : T_KEYWORD
     } else if (token === '\n') {
       return T_BREAK
@@ -203,8 +211,6 @@ export function tokenize(code) {
       return T_SPACE
     } else if (token.split('').every(ch => signs.has(ch))) {
       return T_SIGN
-    } else if (isJsxLiterals) {
-      return T_JSX_LITERALS
     } else if (isCls(token)) {
       return inJsxTag() ? T_IDENTIFIER : T_CLS_NUMBER
     } else {
@@ -243,11 +249,13 @@ export function tokenize(code) {
     }
 
     if (__jsxEnter) {
+      // <: open tag sign
       if (!__jsxTag && curr === '<') {
         append()
-        __jsxTag = true
+        __jsxTag = 1
         current = curr
         if (next === '/') {
+          __jsxTag = 2
           current = c_n
           i++
         }
@@ -255,12 +263,17 @@ export function tokenize(code) {
         continue
       }
       if (__jsxTag) {
-        // >: open tag close sign
+        // >: open tag close sign or closing tag closing sign
         if (curr === '>' && prev !== '/') {
           append()
-          __jsxTag = false
-          if (!__jsxChild) __jsxChild = true
-          __jsxStack++
+          if (__jsxTag === 1) {
+            __jsxTag = 0
+            if (!__jsxChild) __jsxChild = true
+            __jsxStack++
+          } else {
+            __jsxTag = 0
+            __jsxChild = false
+          }
           current = curr
           append()
           continue
@@ -270,12 +283,12 @@ export function tokenize(code) {
         if (c_n === '/>' || c_n === '</') {
           append()
           if (c_n === '/>') {
-            __jsxTag = false
+            __jsxTag = 0
           }
           if (c_n === '</') {
             __jsxStack--
           }
-          __jsxEnter = __jsxStack > 0
+          __jsxChild = __jsxStack > 0
           current = c_n
           i++
           append()
@@ -286,10 +299,6 @@ export function tokenize(code) {
         if (curr === '<') {
           append()
           current = curr
-          if (next === '/') {
-            current = c_n
-            i++
-          }
           append()
           continue
         }
@@ -298,7 +307,7 @@ export function tokenize(code) {
 
     // if it's not in a jsx tag declaration or a string, close child if next is jsx close tag
     if (!__jsxTag && (curr === '<' && isIdentifierChar(next) || c_n === '</')) {
-      __jsxTag = true
+      __jsxTag = next === '/' ? 2 : 1
 
       if (curr === '<' && next !== '/') {
         __jsxEnter = true

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "next build docs"
   },
   "devDependencies": {
-    "codice": "^0.0.3",
+    "codice": "latest",
     "next": "12.1.6-canary.6",
     "react": "18.0.0",
     "react-dom": "18.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "next build docs"
   },
   "devDependencies": {
-    "codice": "file:../codice",
+    "codice": "^0.0.9",
     "next": "12.1.6-canary.6",
     "react": "18.0.0",
     "react-dom": "18.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "next build docs"
   },
   "devDependencies": {
-    "codice": "latest",
+    "codice": "file:../codice",
     "next": "12.1.6-canary.6",
     "react": "18.0.0",
     "react-dom": "18.0.0",

--- a/test/ast.test.js
+++ b/test/ast.test.js
@@ -170,6 +170,7 @@ describe('jsx', () => {
     ])
     expect(extractTokensTypes(tokens)).toEqual([
       'sign', 'identifier', 'sign', 'jsxliterals', 'sign', 'identifier', 'sign', 'jsxliterals', 'sign', 'identifier',
+      'sign', 'sign', 'identifier', 'sign'
     ])
   })
 })

--- a/test/ast.test.js
+++ b/test/ast.test.js
@@ -162,6 +162,16 @@ describe('jsx', () => {
     const jsxTextChildrenToken = tokens.find(tk => mergeSpaces(tk[1]) === 'Hello World')
     expect(getTypeName(jsxTextChildrenToken)).toBe('jsxliterals')
   });
+
+  it('parse keyword in jsx children literals as jsx literals', () => {
+    const tokens = tokenize(`<div>Hello <Name /> with {data}</div>`)
+    expect(extractTokenValues(tokens)).toEqual([
+      '<', 'div', '>', 'Hello', '<', 'Name', '/>', 'with', '{', 'data', '}', '</', 'div', '>',
+    ])
+    expect(extractTokensTypes(tokens)).toEqual([
+      'sign', 'identifier', 'sign', 'jsxliterals', 'sign', 'identifier', 'sign', 'jsxliterals', 'sign', 'identifier',
+    ])
+  })
 })
 
 describe('comments', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -107,8 +107,10 @@ check-error@^1.0.2:
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
   integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
-"codice@file:../codice":
-  version "0.0.8"
+codice@^0.0.9:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/codice/-/codice-0.0.9.tgz#356d55e3fcb3c4c958697f5dab4f6dfbff398e08"
+  integrity sha512-Zfgipzkr/B51E8p83kRFLhsWdLRwobSqv4Ud5y/KxWmsFnSqYiqm5T9s/DHUBAx7zNuuZi+uY1YYtkkaYar7Hw==
 
 deep-eql@^3.0.1:
   version "3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,70 +2,70 @@
 # yarn lockfile v1
 
 
-"@next/env@12.1.6-canary.13":
-  version "12.1.6-canary.13"
-  resolved "https://registry.yarnpkg.com/@next/env/-/env-12.1.6-canary.13.tgz#ca207c7e49af769ed109e595e3cefbe64b5bed55"
-  integrity sha512-6lztQdiscjQKnG7t1d53R2dZIpQs8ICmlKobPC3invR/m+03mazGBcJJKoNQlvCOh7LSVq2cG5GxQwW4KXAwag==
+"@next/env@12.1.6-canary.6":
+  version "12.1.6-canary.6"
+  resolved "https://registry.yarnpkg.com/@next/env/-/env-12.1.6-canary.6.tgz#1e66ea0ce6e84e05379ac9a5206de8001e749a56"
+  integrity sha512-wZCixZXLJGXLoKElD7byRQpC2t2VGi7ZCsfyrJoUVXV+ax3OHc3/E0JaGhoGhcDGACM2EelMvHcyJaotg52Jow==
 
-"@next/swc-android-arm-eabi@12.1.6-canary.13":
-  version "12.1.6-canary.13"
-  resolved "https://registry.yarnpkg.com/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.1.6-canary.13.tgz#954a74d5bac36a2802a419b00b152aeda2a19233"
-  integrity sha512-dRI3rxG70fuDHU2zbvxSFGJAlgRWlcRDEBiAc8BS9x5qUEDOsSD8iUya/sc7u96pRPZbcXkuqwg0WTGDAjeSbQ==
+"@next/swc-android-arm-eabi@12.1.6-canary.6":
+  version "12.1.6-canary.6"
+  resolved "https://registry.yarnpkg.com/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.1.6-canary.6.tgz#217bc3201530d223a543fb8a589ae21d68276ab7"
+  integrity sha512-t99Ybdzw8fIp9LAE6aa2KfwM47UveNEFusfvXFlcjm8CW0MPQ4Plhuc833Jn2erHH+fQO3uZbJgpaGeCXv29sQ==
 
-"@next/swc-android-arm64@12.1.6-canary.13":
-  version "12.1.6-canary.13"
-  resolved "https://registry.yarnpkg.com/@next/swc-android-arm64/-/swc-android-arm64-12.1.6-canary.13.tgz#df81745aac1eedf6d938272176fee033b6522714"
-  integrity sha512-TIZhv5tGKHr4lGxolzV9WNj3uhLHHYS1bbcl6t4Htbc+yYEzZanF+wI7f8AXctxrk8fjDfrUhg2Ql3+THZM4Ag==
+"@next/swc-android-arm64@12.1.6-canary.6":
+  version "12.1.6-canary.6"
+  resolved "https://registry.yarnpkg.com/@next/swc-android-arm64/-/swc-android-arm64-12.1.6-canary.6.tgz#1521dce6e2451009fc32cf0c497d7ebbc7e1d37c"
+  integrity sha512-C6h4dack99uSLlwN93RA1xSpJpD+g8ssTdlUIHrXoRxNX8gId61q2a5Pj1FVyJ92skFHneifwNNrEh4bs5lBBQ==
 
-"@next/swc-darwin-arm64@12.1.6-canary.13":
-  version "12.1.6-canary.13"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.6-canary.13.tgz#1062345c275ede42b57687a906ba65edc77d7bb9"
-  integrity sha512-c4Zy8+2lO1skCyIenQGIp5wzLqg9zlZC+rea5ThMBkIK6qrMJMPLwPZjZ9ZHg5WwpePqIb++ZSyk+t5sCGZu/A==
+"@next/swc-darwin-arm64@12.1.6-canary.6":
+  version "12.1.6-canary.6"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.6-canary.6.tgz#27d2d59fad0e1e4a428c4b3e7aa24d12165d9c13"
+  integrity sha512-aeISTmbhZsve8aB2SvOomq1rVJn44uPgNyFYa6KqEeTXHPk8CaRCqa+77/hFbTdoq2hq9iZRlDUwT1h5TZF+zg==
 
-"@next/swc-darwin-x64@12.1.6-canary.13":
-  version "12.1.6-canary.13"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.6-canary.13.tgz#8c8c29ce0d29d761c43d9c975b302a26d52c1bbb"
-  integrity sha512-Oc8j5kox8r+9DJE90k7/DjjVpEB0KqMMsn8NESAyJV1GTyYWr7LkzF57tJVrk3EqR2rHlVLmoTq+WBTw4FXAzg==
+"@next/swc-darwin-x64@12.1.6-canary.6":
+  version "12.1.6-canary.6"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.6-canary.6.tgz#d88fc1d6b50a186f380ca81cd85a24313a9c68e0"
+  integrity sha512-QbKrt4DC9fOfaCj8RLGpwb3tev1kiy+hR/NWoFdHykNWbcIGoxVWxwWL4gXTMefhSO4aJTIHoV2DY4s+G87vew==
 
-"@next/swc-linux-arm-gnueabihf@12.1.6-canary.13":
-  version "12.1.6-canary.13"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.6-canary.13.tgz#bc78b0099f7f20ac2ab476b6f23763cf67b8c1ef"
-  integrity sha512-xW6o9aTcIfxA1XU/mZ0ncZfC7hgmCMgDhqdwiENUSBocjJEquoFJnV7+oiSpsbtHDZAh1dXYrcfzIjYUZUIGMw==
+"@next/swc-linux-arm-gnueabihf@12.1.6-canary.6":
+  version "12.1.6-canary.6"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.6-canary.6.tgz#27050fa44b4c19d45c29df9e71fd901b014d5b62"
+  integrity sha512-CBYBMj8kfVrwR4/x91AQaY9BfSYFKXPsa6JjHCraqeRT4U03Yp+T2wVNDrbb5l3gV/yezswFuzuLAvhYe5qOaQ==
 
-"@next/swc-linux-arm64-gnu@12.1.6-canary.13":
-  version "12.1.6-canary.13"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.6-canary.13.tgz#7498bd4c83eb32d2ee4d89efded09b71940961d2"
-  integrity sha512-J0/2wlYIhIayMZ35DSuY2oC99aU7rKB8j4reJeILqFwGZI/HepGTLBKfkN/V19lFJVoPlG7IDSlaJcge0VuGTA==
+"@next/swc-linux-arm64-gnu@12.1.6-canary.6":
+  version "12.1.6-canary.6"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.6-canary.6.tgz#22de8c62657bd3744f4afbbe3319bac71991d28c"
+  integrity sha512-NwayGutn9gviEBWILBg3Lu6SBosOSCO44HSODJhcQ/L4Wq1pahdH9Gf4Rsw74VX97NN8qDSQ+UwN1dtq9F/3zg==
 
-"@next/swc-linux-arm64-musl@12.1.6-canary.13":
-  version "12.1.6-canary.13"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.6-canary.13.tgz#ff617a10f652fa606b916969e29859141af982fc"
-  integrity sha512-yR6v3TeU1PIgcIXGd0sOWMENppZVbJaN/O/OP9piZcbrgQJ83r6yofTdyQGUMBimlgacpBtR1IVMwYt6K7GC1Q==
+"@next/swc-linux-arm64-musl@12.1.6-canary.6":
+  version "12.1.6-canary.6"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.6-canary.6.tgz#2a98d2e622e5f1f78e691701249da13a7e00a554"
+  integrity sha512-FYFaoGVxwGbIGDvAzxV92hsutBX/XEu4ZV/Rj9MvP3MGsrorRoJdzwsxqAmcthebk+UMWDcCWwXfDbuiYsU+xQ==
 
-"@next/swc-linux-x64-gnu@12.1.6-canary.13":
-  version "12.1.6-canary.13"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.6-canary.13.tgz#caae99a3b15ed29ac89a761572d4f3be8f916f0f"
-  integrity sha512-6OnOvug79XUCd7MHbvhqmw8ExWHbrGzP3Qlk/1BwZLSsYoRTsyNR+jhqJsiX7zCHCO4UuHvRiBxTXK3klkBzSw==
+"@next/swc-linux-x64-gnu@12.1.6-canary.6":
+  version "12.1.6-canary.6"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.6-canary.6.tgz#c9d323cd9ee9b424a1b696d44f03b82f5b577476"
+  integrity sha512-+7veyDwX1kSFUvmHgaCPi91Kg7PHramTpNWfPSvbcD3yVDUO1Oai0gGSChmj8suWVSIPf5nV4LumfzyN4JPKUg==
 
-"@next/swc-linux-x64-musl@12.1.6-canary.13":
-  version "12.1.6-canary.13"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.6-canary.13.tgz#4b9974ec4bffbbce531e2ca7f2656531dae5aa1b"
-  integrity sha512-oZidDXFRnmBSY3Czu3CIz3E68O+fhOVTn/7d5W9pdKToW1V5Xhl8K6wshhBPlZ5HoAYHQUkPjyCj4DovSZ90Ww==
+"@next/swc-linux-x64-musl@12.1.6-canary.6":
+  version "12.1.6-canary.6"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.6-canary.6.tgz#3344a66da6f80b401aec6ba047514a7e74108dd9"
+  integrity sha512-oop2UvXeFgSOntfp7azGpmYopQ4d62U5yHmYEp8QKAWNDFI8tki9HJZ0Sz+eFHxJuhgBDyRcqWYX32fcOcDG5g==
 
-"@next/swc-win32-arm64-msvc@12.1.6-canary.13":
-  version "12.1.6-canary.13"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.6-canary.13.tgz#76e7800615613b1e3fabe48b3f03e53bdd259ec8"
-  integrity sha512-n2I8q3SRXeTYt5saIozU6lrEgkWEUbXRK1Mw4uKGm5be7EgPellSzrlhq9UQIAv/UjJTOJc/g2PBHoyEwxhoOA==
+"@next/swc-win32-arm64-msvc@12.1.6-canary.6":
+  version "12.1.6-canary.6"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.6-canary.6.tgz#36460f85c546067e85da71aef7e5ce5f97b7a4ed"
+  integrity sha512-OaqtXtVaugjrCojr1OahG3H7vm3PfDobiddIelvCGX2MbQ5S8VXYv9fEZyOH6FcvAwUWrg0RhH7la+q6bVll4Q==
 
-"@next/swc-win32-ia32-msvc@12.1.6-canary.13":
-  version "12.1.6-canary.13"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.6-canary.13.tgz#cb767aa522d8c7c831a76448d71f5ded8b9e7b4e"
-  integrity sha512-0vhCykqENJgxaTY2attFseoL52mmXlE/SkzjWGCS6uCYorfm+krSTU/WO/bQjIRKqr8xGlVIi89cNipFxoExDQ==
+"@next/swc-win32-ia32-msvc@12.1.6-canary.6":
+  version "12.1.6-canary.6"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.6-canary.6.tgz#b6f3728fdddbc2cf3ae51f6f2f2ee193b332c730"
+  integrity sha512-mVkCIbkLHJuKw//uMrvJzTM3y8mDFZK7ShFece48GpmiU21YZ6Cofyx8c6gtrTUV/nbyStiW8tSQjf/tW9TIJQ==
 
-"@next/swc-win32-x64-msvc@12.1.6-canary.13":
-  version "12.1.6-canary.13"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.6-canary.13.tgz#a6689ea4ac1974d6f42321478a0bd9fe365e0cdf"
-  integrity sha512-GgmJU3m1vkwBaj04UnFxXAE3IC10y9T5z8mtExVCEwzuK4zVQbUNcu6rqDSbxj8zDdxW3sLHmgR5H8rUbQ7dMg==
+"@next/swc-win32-x64-msvc@12.1.6-canary.6":
+  version "12.1.6-canary.6"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.6-canary.6.tgz#972f6a3b8a1cfbce3d50ca029a89ae3db0cd17bb"
+  integrity sha512-QlsNgb5J7ply7y4K8vmUhhCWlxcVXbtYD3a+juLhyhsZ6Yba1YV0rE+O/xfsfUtRLicXgR8qvUR8E1dMwKaCHQ==
 
 "@types/chai-subset@^1.3.3":
   version "1.3.3"
@@ -107,10 +107,8 @@ check-error@^1.0.2:
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
   integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
-codice@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/codice/-/codice-0.0.1.tgz#52939af6b31d8a7a8ab573aab1af416cace7718a"
-  integrity sha512-mglz9m+JK72zZa72L3QRETLakQDVNyH2KtCUQFAAt6uvf3bgqsJTfRYS5+cEXob8p2SH+FrObzPJksp1aTcwDA==
+"codice@file:../codice":
+  version "0.0.8"
 
 deep-eql@^3.0.1:
   version "3.0.1"
@@ -303,28 +301,28 @@ nanoid@^3.1.30, nanoid@^3.3.1:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
   integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
 
-next@12.1.6-canary.13:
-  version "12.1.6-canary.13"
-  resolved "https://registry.yarnpkg.com/next/-/next-12.1.6-canary.13.tgz#42b73be5c26d67685033d8142f67227348de5e22"
-  integrity sha512-jFAptkvBn03rY/FbUmuSC7b1yFYcaV/j3t3KaEp1vqz7EyDpd6YYZQnQ8FMy2JehU8ZPxhQBNhKmpJ8iyDxkig==
+next@12.1.6-canary.6:
+  version "12.1.6-canary.6"
+  resolved "https://registry.yarnpkg.com/next/-/next-12.1.6-canary.6.tgz#3a35be7eac9e9a7959398b4ae20403f3782fea57"
+  integrity sha512-FhC4/bI8lz/4jYqKC5/gw8mnMc0EvsHAPkP9RRtnci9CINT4l+GxVOWWkGoWxkTBa6t3enTBwqOw4ahk1Mc0cg==
   dependencies:
-    "@next/env" "12.1.6-canary.13"
+    "@next/env" "12.1.6-canary.6"
     caniuse-lite "^1.0.30001332"
     postcss "8.4.5"
     styled-jsx "5.0.1"
   optionalDependencies:
-    "@next/swc-android-arm-eabi" "12.1.6-canary.13"
-    "@next/swc-android-arm64" "12.1.6-canary.13"
-    "@next/swc-darwin-arm64" "12.1.6-canary.13"
-    "@next/swc-darwin-x64" "12.1.6-canary.13"
-    "@next/swc-linux-arm-gnueabihf" "12.1.6-canary.13"
-    "@next/swc-linux-arm64-gnu" "12.1.6-canary.13"
-    "@next/swc-linux-arm64-musl" "12.1.6-canary.13"
-    "@next/swc-linux-x64-gnu" "12.1.6-canary.13"
-    "@next/swc-linux-x64-musl" "12.1.6-canary.13"
-    "@next/swc-win32-arm64-msvc" "12.1.6-canary.13"
-    "@next/swc-win32-ia32-msvc" "12.1.6-canary.13"
-    "@next/swc-win32-x64-msvc" "12.1.6-canary.13"
+    "@next/swc-android-arm-eabi" "12.1.6-canary.6"
+    "@next/swc-android-arm64" "12.1.6-canary.6"
+    "@next/swc-darwin-arm64" "12.1.6-canary.6"
+    "@next/swc-darwin-x64" "12.1.6-canary.6"
+    "@next/swc-linux-arm-gnueabihf" "12.1.6-canary.6"
+    "@next/swc-linux-arm64-gnu" "12.1.6-canary.6"
+    "@next/swc-linux-arm64-musl" "12.1.6-canary.6"
+    "@next/swc-linux-x64-gnu" "12.1.6-canary.6"
+    "@next/swc-linux-x64-musl" "12.1.6-canary.6"
+    "@next/swc-win32-arm64-msvc" "12.1.6-canary.6"
+    "@next/swc-win32-ia32-msvc" "12.1.6-canary.6"
+    "@next/swc-win32-x64-msvc" "12.1.6-canary.6"
 
 path-parse@^1.0.7:
   version "1.0.7"


### PR DESCRIPTION
Fixes #45 

Rewrite jsx parsing logic: divide jsx into serveral parts

For example
```jsx
<div>text {data}</div>
```

* `__jsxEnter` represents the whole jsx tag
* `__jsxTag` represents the tag position, it's not inside jsx tag, or it's inside a open or closing tag
* `__jsxExpr` represents inside expression
* `__jsxChild()` is calculated by others: inside jsx, but not inside tag or expression, then it's jsx children literals

### Chores 

* bump editor version
* scrolling editor
* bump next