### PR TITLE
feat: support property and entity type

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,18 +35,24 @@ Then make your own theme with customized colors by token type and put in global 
  * keyword
  * string
  * Class, number and null
+ * property
+ * entity
+ * jsx literals
  * sign
  * comment
- * jsxliterals
+ * break
+ * space
  */
 :root {
   --sh-class: #2d5e9d;
   --sh-identifier: #354150;
   --sh-sign: #8996a3;
+  --sh-property: #0550ae;
+  --sh-entity: #249a97;
+  --sh-jsxliterals: #6266d1;
   --sh-string: #00a99a;
   --sh-keyword: #f47067;
   --sh-comment: #a19595;
-  --sh-jsxliterals: #6266d1;
 }
 ```
 
@@ -67,6 +73,16 @@ pre code {
   margin-right: 24px;
   text-align: right;
   color: #a4a4a4;
+}
+```
+
+### Line Highlight
+
+Use `.sh__line:nth-child(<line number>)` to highlight specific line.
+
+```css
+.sh__line:nth-child(5) {
+  background: #f5f5f5;
 }
 ```
 

--- a/docs/app/carousel.js
+++ b/docs/app/carousel.js
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react'
 import { Editor } from 'codice'
 import { highlight } from 'sugar-high'
 
-const EXAMPLE_PAIRS =[]; [
+const EXAMPLE_PAIRS = [
   [
     'install.js',
     `\

--- a/docs/app/carousel.js
+++ b/docs/app/carousel.js
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react'
 import { Editor } from 'codice'
 import { highlight } from 'sugar-high'
 
-const EXAMPLE_PAIRS = [
+const EXAMPLE_PAIRS =[]; [
   [
     'install.js',
     `\

--- a/docs/app/live-editor.js
+++ b/docs/app/live-editor.js
@@ -9,6 +9,7 @@ const defaultColorPlateColors = {
   identifier: '#354150',
   sign: '#8996a3',
   entity: '#249a97',
+  property: '#0550ae',
   jsxliterals: '#bf7db6',
   string: '#00a99a',
   keyword: '#f47067',
@@ -122,6 +123,7 @@ export default function LiveEditor() {
           --sh-identifier: ${colorPlateColors.identifier};
           --sh-sign: ${colorPlateColors.sign};
           --sh-entity: ${colorPlateColors.entity};
+          --sh-property: ${colorPlateColors.property};
           --sh-string: ${colorPlateColors.string};
           --sh-keyword: ${colorPlateColors.keyword};
           --sh-comment: ${colorPlateColors.comment};

--- a/docs/app/live-editor.js
+++ b/docs/app/live-editor.js
@@ -30,10 +30,16 @@ const customizableColors = Object.entries(SugarHigh.TokenTypes)
 .filter(([, tokenTypeName]) => tokenTypeName !== 'break' && tokenTypeName !== 'space')
   .sort((a, b) => a - b)
 
-const DEFAULT_LIVE_CODE =
-`export default function App() {
-  return <p>hello world</p>
-}`
+const DEFAULT_LIVE_CODE = `\
+export default function App() {
+  return (
+    <>
+      <div ref={refs.setReference} />
+      <div ref={refs.setFloating} style={floatingStyles} />
+    </>
+  )
+}
+`
 
 function useTextTypingAnimation(targetText, delay, onReady) {
   const [text, setText] = useState('')

--- a/docs/app/live-editor.js
+++ b/docs/app/live-editor.js
@@ -36,10 +36,11 @@ const DEFAULT_LIVE_CODE = `\
 export default function App() {
   return (
     <>
-      <div>
-        <span>text</span>
-      </div>
-      <div ref={refs.setFloating} style={styles} />
+      <h1>
+        Hello
+        <span className="small"> world</span>
+      </h1>
+      <div style={styles.bar} />
     </>
   )
 }
@@ -47,18 +48,25 @@ export default function App() {
 `
 
 function useTextTypingAnimation(targetText, delay, onReady) {
+  
   const [text, setText] = useState('')
   const [isTyping, setIsTyping] = useState(true)
   const animationDuration = delay / targetText.length
   let timeoutId = useRef(null)
   
   useEffect(() => {
-    if (isTyping) {
-      if (text.length < targetText.length && !timeoutId.current) {
+    if (isTyping && targetText.length) {
+      if (text.length < targetText.length) {
+        const nextText = targetText.substring(0, text.length + 1)
+        if (timeoutId.current) {
+          clearTimeout(timeoutId.current)
+          timeoutId.current = null
+        }
         timeoutId.current = setTimeout(() => {
-          setText(targetText.substring(0, text.length + 1))
+          setText(nextText)
         }, animationDuration)
-      } else if (text.length < targetText.length) {
+
+      } else if (text.length === targetText.length) {
         setIsTyping(false)
         onReady()
       }
@@ -69,7 +77,7 @@ function useTextTypingAnimation(targetText, delay, onReady) {
         timeoutId.current = null
       }
     }
-  }, [targetText, text])
+  }, [targetText, text, timeoutId.current])
 
   return { text, isTyping, setText }
 }
@@ -144,8 +152,8 @@ export default function LiveEditor() {
           value={liveCode}
           onChange={(newCode) => {
             setLiveCode(newCode)
-            !isTyping && setDefaultLiveCode(newCode)
             debouncedTokenize(newCode)
+            if (!isTyping) setDefaultLiveCode(newCode)
           }}
         />
 

--- a/docs/app/live-editor.js
+++ b/docs/app/live-editor.js
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 import { highlight, tokenize, SugarHigh } from 'sugar-high'
 import { Editor } from 'codice'
 
@@ -8,10 +8,11 @@ const defaultColorPlateColors = {
   class: '#8d85ff',
   identifier: '#354150',
   sign: '#8996a3',
+  entity: '#249a97',
+  jsxliterals: '#bf7db6',
   string: '#00a99a',
   keyword: '#f47067',
   comment: '#a19595',
-  jsxliterals: '#bf7db6',
   break: '#ffffff',
   space: '#ffffff',
 }
@@ -34,37 +35,36 @@ const DEFAULT_LIVE_CODE = `\
 export default function App() {
   return (
     <>
-      <div ref={refs.setReference} />
+      <div>
+        <span>text</span>
+      </div>
       <div ref={refs.setFloating} style={floatingStyles} />
     </>
   )
 }
+
 `
 
 function useTextTypingAnimation(targetText, delay, onReady) {
   const [text, setText] = useState('')
   const [isTyping, setIsTyping] = useState(true)
+  
+  const typeText = useCallback((index) => {
+    if (text.length === targetText.length) {
+      setIsTyping(false)
+      onReady()
+      return
+    }
 
+    setText(targetText.substring(0, index + 1))
+    setTimeout(() => typeText(index + 1), delay / targetText.length)
+  }, [targetText, text])
+  
   useEffect(() => {
-    let timeoutId
-
-    const typeText = (index) => {
-      if (index === targetText.length) {
-        setIsTyping(false)
-        onReady()
-        return
-      }
-
-      setText(targetText.substring(0, index + 1))
-      timeoutId = setTimeout(() => typeText(index + 1), delay / targetText.length)
+    if (!text.length) {
+      typeText(0)
     }
-
-    typeText(0)
-
-    return () => {
-      clearTimeout(timeoutId)
-    }
-  }, [targetText, delay])
+  }, [targetText, text])
 
   return { text, isTyping, setText }
 }
@@ -121,6 +121,7 @@ export default function LiveEditor() {
           --sh-class: ${colorPlateColors.class};
           --sh-identifier: ${colorPlateColors.identifier};
           --sh-sign: ${colorPlateColors.sign};
+          --sh-entity: ${colorPlateColors.entity};
           --sh-string: ${colorPlateColors.string};
           --sh-keyword: ${colorPlateColors.keyword};
           --sh-comment: ${colorPlateColors.comment};

--- a/docs/app/live-editor.js
+++ b/docs/app/live-editor.js
@@ -8,8 +8,8 @@ const defaultColorPlateColors = {
   class: '#8d85ff',
   identifier: '#354150',
   sign: '#8996a3',
-  entity: '#249a97',
-  property: '#0550ae',
+  entity: '#6eafad',
+  property: '#4e8fdf',
   jsxliterals: '#bf7db6',
   string: '#00a99a',
   keyword: '#f47067',
@@ -29,7 +29,7 @@ function debounce(func, timeout = 200){
 }
 
 const customizableColors = Object.entries(SugarHigh.TokenTypes)
-.filter(([, tokenTypeName]) => tokenTypeName !== 'break' && tokenTypeName !== 'space')
+  .filter(([, tokenTypeName]) => tokenTypeName !== 'break' && tokenTypeName !== 'space')
   .sort((a, b) => a - b)
 
 const DEFAULT_LIVE_CODE = `\
@@ -49,21 +49,25 @@ export default function App() {
 function useTextTypingAnimation(targetText, delay, onReady) {
   const [text, setText] = useState('')
   const [isTyping, setIsTyping] = useState(true)
-  
-  const typeText = useCallback((index) => {
-    if (text.length === targetText.length) {
-      setIsTyping(false)
-      onReady()
-      return
-    }
-
-    setText(targetText.substring(0, index + 1))
-    setTimeout(() => typeText(index + 1), delay / targetText.length)
-  }, [targetText, text])
+  const animationDuration = delay / targetText.length
+  let timeoutId = useRef(null)
   
   useEffect(() => {
-    if (!text.length) {
-      typeText(0)
+    if (isTyping) {
+      if (text.length < targetText.length && !timeoutId.current) {
+        timeoutId.current = setTimeout(() => {
+          setText(targetText.substring(0, text.length + 1))
+        }, animationDuration)
+      } else if (text.length < targetText.length) {
+        setIsTyping(false)
+        onReady()
+      }
+    }
+    return () => {
+      if (timeoutId.current) {
+        clearTimeout(timeoutId.current)
+        timeoutId.current = null
+      }
     }
   }, [targetText, text])
 
@@ -122,8 +126,8 @@ export default function LiveEditor() {
           --sh-class: ${colorPlateColors.class};
           --sh-identifier: ${colorPlateColors.identifier};
           --sh-sign: ${colorPlateColors.sign};
-          --sh-entity: ${colorPlateColors.entity};
           --sh-property: ${colorPlateColors.property};
+          --sh-entity: ${colorPlateColors.entity};
           --sh-string: ${colorPlateColors.string};
           --sh-keyword: ${colorPlateColors.keyword};
           --sh-comment: ${colorPlateColors.comment};
@@ -174,10 +178,10 @@ export default function LiveEditor() {
       {isDebug &&
         <div className='editor-tokens'>
           <pre>
-            {liveCodeTokens.map(([tokenType, token], i) => {
+            {liveCodeTokens.map(([tokenType, token], index) => {
               const tokenTypeName = SugarHigh.TokenTypes[tokenType]
               return (
-                <div key={i}>{tokenTypeName}{' '.repeat(12 - tokenTypeName.length)} {token}</div>
+                <div key={index}>{tokenTypeName}{' '.repeat(12 - tokenTypeName.length)} {token}</div>
               )
             })}
           </pre>

--- a/docs/app/live-editor.js
+++ b/docs/app/live-editor.js
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { highlight, tokenize, SugarHigh } from 'sugar-high'
 import { Editor } from 'codice'
 
@@ -39,7 +39,7 @@ export default function App() {
       <div>
         <span>text</span>
       </div>
-      <div ref={refs.setFloating} style={floatingStyles} />
+      <div ref={refs.setFloating} style={styles} />
     </>
   )
 }

--- a/docs/app/styles.css
+++ b/docs/app/styles.css
@@ -161,6 +161,7 @@ textarea {
   --sh-identifier: #354150;
   --sh-sign: #8996a3;
   --sh-entity: #249a97;
+  --sh-property: #0550ae;
   --sh-string: #00a99a;
   --sh-keyword: #f47067;
   --sh-comment: #a19595;

--- a/docs/app/styles.css
+++ b/docs/app/styles.css
@@ -162,10 +162,10 @@ textarea {
   --sh-sign: #8996a3;
   --sh-property: #0550ae;
   --sh-entity: #249a97;
+  --sh-jsxliterals: #6266d1;
   --sh-string: #00a99a;
   --sh-keyword: #f47067;
   --sh-comment: #a19595;
-  --sh-jsxliterals: #6266d1;
   --editor-background-color: transparent;
 
   position: relative;

--- a/docs/app/styles.css
+++ b/docs/app/styles.css
@@ -160,6 +160,7 @@ textarea {
   --sh-class: #2d5e9d;
   --sh-identifier: #354150;
   --sh-sign: #8996a3;
+  --sh-entity: #249a97;
   --sh-string: #00a99a;
   --sh-keyword: #f47067;
   --sh-comment: #a19595;

--- a/docs/app/styles.css
+++ b/docs/app/styles.css
@@ -160,8 +160,8 @@ textarea {
   --sh-class: #2d5e9d;
   --sh-identifier: #354150;
   --sh-sign: #8996a3;
-  --sh-entity: #249a97;
   --sh-property: #0550ae;
+  --sh-entity: #249a97;
   --sh-string: #00a99a;
   --sh-keyword: #f47067;
   --sh-comment: #a19595;
@@ -187,7 +187,7 @@ code {
 }
 .codice-editor code {
   padding-left: 48px;
-  min-height: 360px;
+  min-height: 400px;
   width: 100%;
 }
 
@@ -262,25 +262,7 @@ pre code .sh__line::before {
   color: #333;
 }
 
-.live-editor-section .live-editor__color__item__indicator--class {
-  background-color: currentColor;
-}
-.live-editor-section .live-editor__color__item__indicator--identifier {
-  background-color: currentColor;
-}
-.live-editor-section .live-editor__color__item__indicator--sign {
-  background-color: currentColor;
-}
-.live-editor-section .live-editor__color__item__indicator--string {
-  background-color: currentColor;
-}
-.live-editor-section .live-editor__color__item__indicator--keyword {
-  background-color: currentColor;
-}
-.live-editor-section .live-editor__color__item__indicator--comment {
-  background-color: currentColor;
-}
-.live-editor-section .live-editor__color__item__indicator--jsxliterals {
+.live-editor-section .live-editor__color__item__indicator {
   background-color: currentColor;
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -246,10 +246,8 @@ function tokenize(code) {
     }
     // Then determine if they're jsx literals
     const isJsxLiterals = inJsxLiterals()
-    if (isJsxLiterals) {
-      return T_JSX_LITERALS
+    if (isJsxLiterals) return T_JSX_LITERALS
 
-    }
     // Determine strings first before other types
     if (inStringQuotes()) {
       return T_STRING
@@ -264,10 +262,12 @@ function tokenize(code) {
     } else if (isCls(token)) {
       return inJsxTag() ? T_IDENTIFIER : T_CLS_NUMBER
     } else {
-
-      return isIdentifier(token) &&
-        !inStrTemplateLiterals() &&
-        (!isSingleQuotes(__strQuote)) ? T_IDENTIFIER : T_STRING
+      if (isIdentifier(token)) {
+        const isLastDot = last[1] === '.'
+        if (!inStrTemplateLiterals() && (!isSingleQuotes(__strQuote)) && !isLastDot) return T_IDENTIFIER
+        if (isLastDot) return T_PROPERTY
+      }
+      return T_STRING
     }
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -76,17 +76,19 @@ const signs = new Set([
   ...jsxBrackets,
 ])
 
-const types = [
+const types = /** @type {const} */ ([
   'identifier',
   'keyword',
   'string',
   'class',
+  'property',
+  'jsxtag',
+  'jsxliterals',
   'sign',
   'comment',
   'break',
   'space',
-  'jsxliterals'
-]
+])
 
 /**
  *
@@ -94,11 +96,13 @@ const types = [
  * 1 - keyword
  * 2 - string
  * 3 - Class, number and null
- * 4 - sign
- * 5 - comment
- * 6 - break
- * 7 - space
- * 8 - jsx literals
+ * 4 - property
+ * 5 - entity
+ * 6 - jsx literals
+ * 7 - sign
+ * 8 - comment
+ * 9 - break
+ * 10 - space
  *
  */
 const [
@@ -106,12 +110,14 @@ const [
   T_KEYWORD,
   T_STRING,
   T_CLS_NUMBER,
+  T_PROPERTY,
+  T_ENTITY,
+  T_JSX_LITERALS,
   T_SIGN,
   T_COMMENT,
   T_BREAK,
   T_SPACE,
-  T_JSX_LITERALS,
-] = types.map((_, i) => i)
+] = /** @types {const} */ [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
 function isSpaces(str) {
   return /^[^\S\r\n]+$/g.test(str)
@@ -594,7 +600,7 @@ function highlight(code) {
 }
 
 // namespace
-const SugarHigh = {
+const SugarHigh = /** @type {const} */ {
   TokenTypes: types,
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -424,9 +424,12 @@ function tokenize(code) {
         }
 
         // jsx property 
-        if (next === '=' && isIdentifier(current)) {
-          current += curr
-          append(T_PROPERTY)
+        if (next === '=') {
+          const prop = current ? (current + curr) : curr
+          if (isIdentifier(prop)) {
+            current = prop
+            append(T_PROPERTY)
+          }
           continue
         }
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -264,9 +264,9 @@ function tokenize(code) {
       return inJsxTag() ? T_IDENTIFIER : T_CLS_NUMBER
     } else {
       if (isIdentifier(token)) {
-        const isLastDot = last[1] === '.' && isIdentifier(last[0])
-        if (!inStrTemplateLiterals() && (!isSingleQuotes(__strQuote)) && !isLastDot) return T_IDENTIFIER
-        if (isLastDot) return T_PROPERTY
+        const isLastPropDot = lastTwo[1][1] === '.' && isIdentifier(lastTwo[0][1])
+        if (!inStrTemplateLiterals() && (!isSingleQuotes(__strQuote)) && !isLastPropDot) return T_IDENTIFIER
+        if (isLastPropDot) return T_PROPERTY
       }
       return T_STRING
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -191,8 +191,8 @@ function isRegexStart(str) {
 function tokenize(code) {
   let current = ''
   let type = -1
-  /** @type {[number | null, string | null]} */
-  let last = [null, null]
+  /** @type {([number, string])[]} */
+  const lastTwo = [[-1, ''], [-1, '']]
   /** @type {Array<[number, string]>} */
   const tokens = []
 
@@ -230,6 +230,7 @@ function tokenize(code) {
    * @returns {number}
    */
   function classify(token) {
+    const last = lastTwo[1]
     const isLineBreak = token === '\n'
     // First checking if they're attributes values
     if (inJsxTag()) {
@@ -263,7 +264,7 @@ function tokenize(code) {
       return inJsxTag() ? T_IDENTIFIER : T_CLS_NUMBER
     } else {
       if (isIdentifier(token)) {
-        const isLastDot = last[1] === '.'
+        const isLastDot = last[1] === '.' && isIdentifier(last[0])
         if (!inStrTemplateLiterals() && (!isSingleQuotes(__strQuote)) && !isLastDot) return T_IDENTIFIER
         if (isLastDot) return T_PROPERTY
       }
@@ -280,7 +281,8 @@ function tokenize(code) {
       /** @type [number, string]  */
       const pair = [type, current]
       if (type !== T_SPACE && type !== T_BREAK) {
-        last = pair
+        if (lastTwo.length === 2) lastTwo.shift()
+        lastTwo.push(pair)
       }
 
       tokens.push(pair)
@@ -449,7 +451,7 @@ function tokenize(code) {
       current += curr
     } else if (isRegexChar) {
       append()
-      const [lastType, lastToken] = last
+      const [lastType, lastToken] = lastTwo[1]
       // Special cases that are not considered as regex:
       // * (expr1) / expr2: `)` before `/` operator is still in expression
       // * <non comment start>/ expr: non comment start before `/` is not regex

--- a/lib/index.js
+++ b/lib/index.js
@@ -76,35 +76,35 @@ const signs = new Set([
   ...jsxBrackets,
 ])
 
+
+/**
+ *
+ * 0  - identifier
+ * 1  - keyword
+ * 2  - string
+ * 3  - Class, number and null
+ * 4  - property
+ * 5  - entity
+ * 6  - jsx literals
+ * 7  - sign
+ * 8  - comment
+ * 9  - break
+ * 10 - space
+ *
+ */
 const types = /** @type {const} */ ([
   'identifier',
   'keyword',
   'string',
   'class',
   'property',
-  'jsxtag',
+  'entity',
   'jsxliterals',
   'sign',
   'comment',
   'break',
   'space',
 ])
-
-/**
- *
- * 0 - identifier
- * 1 - keyword
- * 2 - string
- * 3 - Class, number and null
- * 4 - property
- * 5 - entity
- * 6 - jsx literals
- * 7 - sign
- * 8 - comment
- * 9 - break
- * 10 - space
- *
- */
 const [
   T_IDENTIFIER,
   T_KEYWORD,
@@ -117,7 +117,7 @@ const [
   T_COMMENT,
   T_BREAK,
   T_SPACE,
-] = /** @types {const} */ [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+] = /** @types {const} */ types.map((_, i) => i)
 
 function isSpaces(str) {
   return /^[^\S\r\n]+$/g.test(str)
@@ -211,7 +211,9 @@ function tokenize(code) {
   // only match paired (open + close) tags, not self-closing tags
   let __jsxStack = 0
   const __jsxChild = () => __jsxEnter && !__jsxExpr && !__jsxTag
+  // < __content__ >
   const inJsxTag = () => __jsxTag && !__jsxChild()
+  // {'__content__'}
   const inJsxLiterals = () => !__jsxTag && __jsxChild() && !__jsxExpr && __jsxStack > 0
 
   /** @type {string | null} */
@@ -230,8 +232,17 @@ function tokenize(code) {
   function classify(token) {
     const isLineBreak = token === '\n'
     // First checking if they're attributes values
-    if (inJsxTag() && inStringQuotes()) {
-      return T_STRING
+    if (inJsxTag()) {
+      if (inStringQuotes()) {
+        return T_STRING
+      }
+
+      const [, lastToken] = last
+      if (isIdentifier(token)) {
+        // classify jsx open tag
+        if ((lastToken === '<' || lastToken === '</')) 
+          return T_ENTITY
+      }
     }
     // Then determine if they're jsx literals
     const isJsxLiterals = inJsxLiterals()
@@ -271,6 +282,11 @@ function tokenize(code) {
       if (type !== T_SPACE && type !== T_BREAK) {
         last = pair
       }
+
+      // const endTokenPair = tokens[tokens.length - 1] || null
+      // if (endTokenPair && endTokenPair[0] !== T_SPACE && endTokenPair[0] !== T_BREAK) {
+      //   lastTokenPair = endTokenPair
+      // }
       tokens.push(pair)
     }
     current = ''
@@ -407,6 +423,13 @@ function tokenize(code) {
           append(T_SIGN)
           continue
         }
+
+        // jsx property 
+        // if (next === '=' && isIdentifier(current)) {
+
+        //   append(T_PROPERTY)
+        //   continue
+        // }
       }
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -283,10 +283,6 @@ function tokenize(code) {
         last = pair
       }
 
-      // const endTokenPair = tokens[tokens.length - 1] || null
-      // if (endTokenPair && endTokenPair[0] !== T_SPACE && endTokenPair[0] !== T_BREAK) {
-      //   lastTokenPair = endTokenPair
-      // }
       tokens.push(pair)
     }
     current = ''
@@ -425,11 +421,11 @@ function tokenize(code) {
         }
 
         // jsx property 
-        // if (next === '=' && isIdentifier(current)) {
-
-        //   append(T_PROPERTY)
-        //   continue
-        // }
+        if (next === '=' && isIdentifier(current)) {
+          current += curr
+          append(T_PROPERTY)
+          continue
+        }
       }
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -225,6 +225,7 @@ function tokenize(code) {
   const inStringQuotes = () => __strQuote !== null
   const inStrTemplateLiterals = () => (__strTemplateQuoteStack > __strTemplateExprStack)
   const inStrTemplateExpr = () => __strTemplateQuoteStack > 0 && (__strTemplateQuoteStack === __strTemplateExprStack)
+  const inStringContent = () => inStringQuotes() || inStrTemplateLiterals()
 
   /**
    *
@@ -267,7 +268,7 @@ function tokenize(code) {
       if (isIdentifier(token)) {
         const isLastPropDot = last[1] === '.' && isIdentifier(beforeLast[1])
 
-        if (!inStrTemplateLiterals() && !isSingleQuotes(__strQuote) && !isLastPropDot) return T_IDENTIFIER
+        if (!inStringContent() && !isLastPropDot) return T_IDENTIFIER
         if (isLastPropDot) return T_PROPERTY
       }
       return T_STRING
@@ -423,7 +424,16 @@ function tokenize(code) {
           continue
         }
 
-        // jsx property 
+        // jsx property
+        // `-` in data-prop
+        if (next === '-'  && !inStringContent() && !inJsxLiterals()) {
+          if (current) {
+            append(T_PROPERTY, current + curr + next)
+            i += 1
+            continue
+          }
+        }
+        // `=` in property=<value>
         if (next === '=') {
           const prop = current ? (current + curr) : curr
           if (isIdentifier(prop)) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -191,8 +191,10 @@ function isRegexStart(str) {
 function tokenize(code) {
   let current = ''
   let type = -1
-  /** @type {([number, string])[]} */
-  const lastTwo = [[-1, ''], [-1, '']]
+  /** @type {[number, string]} */
+  let last = [-1, '']
+  /** @type {[number, string]} */
+  let beforeLast = [-2, '']
   /** @type {Array<[number, string]>} */
   const tokens = []
 
@@ -230,7 +232,6 @@ function tokenize(code) {
    * @returns {number}
    */
   function classify(token) {
-    const last = lastTwo[1]
     const isLineBreak = token === '\n'
     // First checking if they're attributes values
     if (inJsxTag()) {
@@ -264,8 +265,9 @@ function tokenize(code) {
       return inJsxTag() ? T_IDENTIFIER : T_CLS_NUMBER
     } else {
       if (isIdentifier(token)) {
-        const isLastPropDot = lastTwo[1][1] === '.' && isIdentifier(lastTwo[0][1])
-        if (!inStrTemplateLiterals() && (!isSingleQuotes(__strQuote)) && !isLastPropDot) return T_IDENTIFIER
+        const isLastPropDot = last[1] === '.' && isIdentifier(beforeLast[1])
+
+        if (!inStrTemplateLiterals() && !isSingleQuotes(__strQuote) && !isLastPropDot) return T_IDENTIFIER
         if (isLastPropDot) return T_PROPERTY
       }
       return T_STRING
@@ -281,8 +283,8 @@ function tokenize(code) {
       /** @type [number, string]  */
       const pair = [type, current]
       if (type !== T_SPACE && type !== T_BREAK) {
-        if (lastTwo.length === 2) lastTwo.shift()
-        lastTwo.push(pair)
+        beforeLast = last
+        last = pair
       }
 
       tokens.push(pair)
@@ -451,7 +453,8 @@ function tokenize(code) {
       current += curr
     } else if (isRegexChar) {
       append()
-      const [lastType, lastToken] = lastTwo[1]
+      const [lastType, lastToken] = last
+      console.log('last token', lastToken, last)
       // Special cases that are not considered as regex:
       // * (expr1) / expr2: `)` before `/` operator is still in expression
       // * <non comment start>/ expr: non comment start before `/` is not regex

--- a/lib/index.js
+++ b/lib/index.js
@@ -286,7 +286,6 @@ function tokenize(code) {
         beforeLast = last
         last = pair
       }
-
       tokens.push(pair)
     }
     current = ''
@@ -454,13 +453,12 @@ function tokenize(code) {
     } else if (isRegexChar) {
       append()
       const [lastType, lastToken] = last
-      console.log('last token', lastToken, last)
       // Special cases that are not considered as regex:
       // * (expr1) / expr2: `)` before `/` operator is still in expression
       // * <non comment start>/ expr: non comment start before `/` is not regex
       if (
         isRegexChar &&
-        lastType &&
+        lastType !== -1 &&
         !(
           (lastType === T_SIGN && ')' !== lastToken) ||
           lastType === T_COMMENT

--- a/test/ast.test.js
+++ b/test/ast.test.js
@@ -99,7 +99,7 @@ describe('jsx', () => {
     expect(extractTokenValues(tokens)).toEqual([
       "// jsx", "const", "element", "=", "(", "<", ">", "<", "Food", "season", "=", "{", "{", "sault",
       ":", "<", "p", "a", "=", "{", "[", "{", "}", "]", "}", "/>", "}", "}", ">", "</", "Food", ">", "{",
-      "/* jsx comment */", "}", "<", "h1", "className", "=", '"', 'title', '"', "data", "-", "title", "=", '"', 'true', '"',
+      "/* jsx comment */", "}", "<", "h1", "className", "=", '"', 'title', '"', "data-", "title", "=", '"', 'true', '"',
       ">", "Read more", "{", "'", "'", "}", "<", "Link", "href", "=", '"', '/posts/first-post', '"', ">", "<", "a", ">",
       "this page! -", "{", "Date", ".", "now", "(", ")", "}", "</", "a", ">", "</", "Link", ">", "</", "h1", ">",
       "</", ">", ")",
@@ -112,7 +112,7 @@ describe('jsx', () => {
       ["{", "sign"], ["[", "sign"], ["{", "sign"], ["}", "sign"], ["]", "sign"], ["}", "sign"], ["/>", "sign"],
       ["}", "sign"], ["}", "sign"], [">", "sign"], ["</", "sign"], ["Food", "entity"], [">", "sign"], ["{", "sign"],
       ["/* jsx comment */", "comment"], ["}", "sign"], ["<", "sign"], ["h1", "entity"], ["className", "property"],
-      ["=", "sign"], ["\"", "string"], ["title", "string"], ["\"", "string"], ["data", "identifier"], ["-", "sign"],
+      ["=", "sign"], ["\"", "string"], ["title", "string"], ["\"", "string"], ["data-", "property"],
       ["title", "property"], ["=", "sign"], ["\"", "string"], ["true", "string"], ["\"", "string"], [">", "sign"],
       ["", "jsxliterals"], ["Read more", "jsxliterals"], ["{", "sign"], ["'", "string"], ["", "string"], ["'", "string"],
       ["}", "sign"], ["", "jsxliterals"], ["", "jsxliterals"], ["<", "sign"], ["Link", "entity"], ["href", "property"],
@@ -211,11 +211,10 @@ describe('jsx', () => {
     const code = '<h1 data-title="true" />'
     const tokens = tokenize(code)
     expect(extractTokenValues(tokens)).toEqual([
-      '<', 'h1', 'data', '-', 'title', '=', '"', 'true', '"', '/>',
+      '<', 'h1', 'data-', 'title', '=', '"', 'true', '"', '/>',
     ])
     expect(extractTokenArray(tokens)).toEqual([
-      // FIXME: data-property -> property
-      ["<", "sign"], ["h1", "entity"], ["data", "identifier"], ["-", "sign"], ["title", "property"], ["=", "sign"],
+      ["<", "sign"], ["h1", "entity"], ["data-", "property"], ["title", "property"], ["=", "sign"],
       ["\"", "string"], ["true", "string"], ["\"", "string"], ["/>", "sign"]
     ])
 

--- a/test/ast.test.js
+++ b/test/ast.test.js
@@ -106,20 +106,22 @@ describe('jsx', () => {
     ])
     expect(extractTokenArray(tokens)).toEqual([
       ["// jsx", "comment"], ["const", "keyword"], ["element", "identifier"], ["=", "sign"], ["(", "sign"], ["<", "sign"],
-      [">", "sign"], ["<", "sign"], ["Food", "identifier"], ["season", "identifier"], ["=", "sign"], ["{", "sign"],
-      ["{", "sign"], ["sault", "identifier"], [":", "sign"], ["<", "sign"], ["p", "identifier"], ["a", "identifier"],
+      [">", "sign"], ["<", "sign"], ["Food", "entity"], ["season", "property"], ["=", "sign"], ["{", "sign"],
+      ["{", "sign"], ["sault", "identifier"], [":", "sign"], ["<", "sign"], ["p", "entity"], 
+      // FIXME: a is a property
+      ["a", "identifier"],
       ["=", "sign"], ["{", "sign"], ["[", "sign"], ["{", "sign"], ["}", "sign"], ["]", "sign"], ["}", "sign"], ["/>", "sign"],
-      ["}", "sign"], ["}", "sign"], [">", "sign"], ["</", "sign"], ["Food", "identifier"], [">", "sign"], ["{", "sign"],
-      ["/* jsx comment */", "comment"], ["}", "sign"], ["<", "sign"], ["h1", "identifier"], ["className", "identifier"],
+      ["}", "sign"], ["}", "sign"], [">", "sign"], ["</", "sign"], ["Food", "entity"], [">", "sign"], ["{", "sign"],
+      ["/* jsx comment */", "comment"], ["}", "sign"], ["<", "sign"], ["h1", "entity"], ["className", "property"],
       ["=", "sign"], ["\"", "string"], ["title", "string"], ["\"", "string"], ["data", "identifier"], ["-", "sign"],
-      ["title", "identifier"], ["=", "sign"], ["\"", "string"], ["true", "string"], ["\"", "string"], [">", "sign"],
+      ["title", "property"], ["=", "sign"], ["\"", "string"], ["true", "string"], ["\"", "string"], [">", "sign"],
       ["", "jsxliterals"], ["Read more", "jsxliterals"], ["{", "sign"], ["'", "string"], ["", "string"], ["'", "string"],
-      ["}", "sign"], ["", "jsxliterals"], ["", "jsxliterals"], ["<", "sign"], ["Link", "identifier"], ["href", "identifier"],
+      ["}", "sign"], ["", "jsxliterals"], ["", "jsxliterals"], ["<", "sign"], ["Link", "entity"], ["href", "property"],
       ["=", "sign"], ["\"", "string"], ["/posts/first-post", "string"], ["\"", "string"], [">", "sign"], ["", "jsxliterals"],
-      ["", "jsxliterals"], ["<", "sign"], ["a", "identifier"], [">", "sign"], ["this page! -", "jsxliterals"], ["{", "sign"],
-      ["Date", "class"], [".", "sign"], ["now", "identifier"], ["(", "sign"], [")", "sign"], ["}", "sign"], ["</", "sign"],
-      ["a", "identifier"], [">", "sign"], ["</", "sign"], ["Link", "identifier"], [">", "sign"], ["</", "sign"],
-      ["h1", "identifier"], [">", "sign"], ["</", "sign"], [">", "sign"], [")", "sign"]
+      ["", "jsxliterals"], ["<", "sign"], ["a", "entity"], [">", "sign"], ["this page! -", "jsxliterals"], ["{", "sign"],
+      ["Date", "class"], [".", "sign"], ["now", "property"], ["(", "sign"], [")", "sign"], ["}", "sign"], ["</", "sign"],
+      ["a", "entity"], [">", "sign"], ["</", "sign"], ["Link", "entity"], [">", "sign"], ["</", "sign"],
+      ["h1", "entity"], [">", "sign"], ["</", "sign"], [">", "sign"], [")", "sign"]
     ])
   })
 
@@ -129,8 +131,8 @@ describe('jsx', () => {
       '<', 'Foo', '>', 'This is content', '</', 'Foo', '>',
     ])
     expect(extractTokenArray(tokens)).toEqual([
-      ["<", "sign"], ["Foo", "identifier"], [">", "sign"], ["This is content", "jsxliterals"], ["</", "sign"],
-      ["Foo", "identifier"], [">", "sign"]
+      ["<", "sign"], ["Foo", "entity"], [">", "sign"], ["This is content", "jsxliterals"], ["</", "sign"],
+      ["Foo", "entity"], [">", "sign"]
     ])
   })
 
@@ -140,8 +142,8 @@ describe('jsx', () => {
       '<', 'Foo', '>', '{', 'Class', '+', 'variable', '}', '</', 'Foo', '>',
     ])
     expect(extractTokenArray(tokens)).toEqual([
-      ["<", "sign"], ["Foo", "identifier"], [">", "sign"], ["{", "sign"], ["Class", "class"], ["+", "sign"],
-      ["variable", "identifier"], ["}", "sign"], ["</", "sign"], ["Foo", "identifier"], [">", "sign"]
+      ["<", "sign"], ["Foo", "entity"], [">", "sign"], ["{", "sign"], ["Class", "class"], ["+", "sign"],
+      ["variable", "identifier"], ["}", "sign"], ["</", "sign"], ["Foo", "entity"], [">", "sign"]
     ])
   })
 
@@ -157,12 +159,12 @@ describe('jsx', () => {
       'z', '=', '<', 'div', '>', 'this', '</', 'div', '>',
     ])
     expect(extractTokenArray(tokens)).toEqual([
-      ["x", "identifier"], ["=", "sign"], ["<", "sign"], ["div", "identifier"], [">", "sign"], ["this", "jsxliterals"],
-      ["</", "sign"], ["div", "identifier"], [">", "sign"],
-      ["y", "identifier"], ["=", "sign"], ["<", "sign"], ["div", "identifier"], [">", "sign"], ["thi", "jsxliterals"],
-      ["</", "sign"], ["div", "identifier"], [">", "sign"],
-      ["z", "identifier"], ["=", "sign"], ["<", "sign"], ["div", "identifier"], [">", "sign"], ["this", "jsxliterals"],
-      ["</", "sign"], ["div", "identifier"], [">", "sign"],
+      ["x", "identifier"], ["=", "sign"], ["<", "sign"], ["div", "entity"], [">", "sign"], ["this", "jsxliterals"],
+      ["</", "sign"], ["div", "entity"], [">", "sign"],
+      ["y", "identifier"], ["=", "sign"], ["<", "sign"], ["div", "entity"], [">", "sign"], ["thi", "jsxliterals"],
+      ["</", "sign"], ["div", "entity"], [">", "sign"],
+      ["z", "identifier"], ["=", "sign"], ["<", "sign"], ["div", "entity"], [">", "sign"], ["this", "jsxliterals"],
+      ["</", "sign"], ["div", "entity"], [">", "sign"],
     ])
   })
 
@@ -176,8 +178,8 @@ describe('jsx', () => {
     ])
     expect(extractTokenArray(tokens)).toEqual([
       ["// jsx", "comment"], ["const", "keyword"], ["element", "identifier"], ["=", "sign"], ["(", "sign"], ["<", "sign"],
-      ["div", "identifier"], [">", "sign"], ["Hello World", "jsxliterals"], ["<", "sign"], ["Food", "identifier"],
-      ["/>", "sign"], ["</", "sign"], ["div", "identifier"], [">", "sign"], [")", "sign"]
+      ["div", "entity"], [">", "sign"], ["Hello World", "jsxliterals"], ["<", "sign"], ["Food", "entity"],
+      ["/>", "sign"], ["</", "sign"], ["div", "entity"], [">", "sign"], [")", "sign"]
     ])
   })
 
@@ -187,9 +189,9 @@ describe('jsx', () => {
       '<', 'div', '>', 'Hello', '<', 'Name', '/>', 'with', '{', 'data', '}', '</', 'div', '>',
     ])
     expect(extractTokenArray(tokens)).toEqual([
-      ["<", "sign"], ["div", "identifier"], [">", "sign"], ["Hello", "jsxliterals"], ["<", "sign"], ["Name", "identifier"],
+      ["<", "sign"], ["div", "entity"], [">", "sign"], ["Hello", "jsxliterals"], ["<", "sign"], ["Name", "entity"],
       ["/>", "sign"], ["with", "jsxliterals"], ["{", "sign"], ["data", "identifier"], ["}", "sign"], ["</", "sign"],
-      ["div", "identifier"], [">", "sign"]
+      ["div", "entity"], [">", "sign"]
     ])
   })
 
@@ -200,9 +202,9 @@ describe('jsx', () => {
       '<', 'button', 'onClick', '=', '{', '(', ')', '=', '>', '{', '}', '}', '>', 'click', '</', 'button', '>',
     ])
     expect(extractTokenArray(tokens)).toEqual([
-      ["<", "sign"], ["button", "identifier"], ["onClick", "identifier"], ["=", "sign"], ["{", "sign"], ["(", "sign"],
+      ["<", "sign"], ["button", "entity"], ["onClick", "property"], ["=", "sign"], ["{", "sign"], ["(", "sign"],
       [")", "sign"], ["=", "sign"], [">", "sign"], ["{", "sign"], ["}", "sign"], ["}", "sign"], [">", "sign"],
-      ["click", "jsxliterals"], ["</", "sign"], ["button", "identifier"], [">", "sign"]
+      ["click", "jsxliterals"], ["</", "sign"], ["button", "entity"], [">", "sign"]
     ])
   })
 
@@ -213,7 +215,8 @@ describe('jsx', () => {
       '<', 'h1', 'data', '-', 'title', '=', '"', 'true', '"', '/>',
     ])
     expect(extractTokenArray(tokens)).toEqual([
-      ["<", "sign"], ["h1", "identifier"], ["data", "identifier"], ["-", "sign"], ["title", "identifier"], ["=", "sign"],
+      // FIXME: data-property -> property
+      ["<", "sign"], ["h1", "entity"], ["data", "identifier"], ["-", "sign"], ["title", "property"], ["=", "sign"],
       ["\"", "string"], ["true", "string"], ["\"", "string"], ["/>", "sign"]
     ])
 
@@ -235,7 +238,7 @@ describe('jsx', () => {
       '<', 'p', '>', 'Let\'s get started!', '</', 'p', '>',
     ])
     expect(extractTokenArray(tokens)).toEqual([
-      ["<", "sign"], ["p", "identifier"], [">", "sign"], ["Let's get started!", "jsxliterals"], ["</", "sign"], ["p", "identifier"],
+      ["<", "sign"], ["p", "entity"], [">", "sign"], ["Let's get started!", "jsxliterals"], ["</", "sign"], ["p", "entity"],
       [">", "sign"]
     ])
   })
@@ -254,10 +257,10 @@ describe('jsx', () => {
       '<', 'p', '>', 'Text 2', '</', 'p', '>', '</', '>',
     ])
     expect(extractTokenArray(tokens)).toEqual([
-      ["<", "sign"], [">", "sign"], ["<", "sign"], ["div", "identifier"], [">", "sign"], ["", "jsxliterals"],
-      ["", "jsxliterals"], ["<", "sign"], ["p", "identifier"], [">", "sign"], ["Text 1", "jsxliterals"], ["</", "sign"],
-      ["p", "identifier"], [">", "sign"], ["</", "sign"], ["div", "identifier"], [">", "sign"], ["<", "sign"],
-      ["p", "identifier"], [">", "sign"], ["Text 2", "jsxliterals"], ["</", "sign"], ["p", "identifier"], [">", "sign"],
+      ["<", "sign"], [">", "sign"], ["<", "sign"], ["div", "entity"], [">", "sign"], ["", "jsxliterals"],
+      ["", "jsxliterals"], ["<", "sign"], ["p", "entity"], [">", "sign"], ["Text 1", "jsxliterals"], ["</", "sign"],
+      ["p", "entity"], [">", "sign"], ["</", "sign"], ["div", "entity"], [">", "sign"], ["<", "sign"],
+      ["p", "entity"], [">", "sign"], ["Text 2", "jsxliterals"], ["</", "sign"], ["p", "entity"], [">", "sign"],
       ["</", "sign"], [">", "sign"]
     ])
   })
@@ -271,7 +274,7 @@ describe('jsx', () => {
     const tokens = tokenize(code)
     expect(extractTokenArray(tokens)).toEqual([
       ['<', 'sign'],
-      ['a', 'identifier'],
+      ['a', 'entity'],
       ['k', 'identifier'],
       ['=', 'sign'],
       ['{', 'sign'],

--- a/test/ast.test.js
+++ b/test/ast.test.js
@@ -226,8 +226,8 @@ describe('jsx', () => {
       '<', 'svg', 'color', '=', '"', 'null', '"', 'height', '=', '"', '24', '"', '/>',
     ])
     expect(extractTokenArray(tokens2)).toEqual([
-      ["<", "sign"], ["svg", "identifier"], ["color", "identifier"], ["=", "sign"], ["\"", "string"], ["null", "string"],
-      ["\"", "string"], ["height", "identifier"], ["=", "sign"], ["\"", "string"], ["24", "string"], ["\"", "string"], ["/>", "sign"]
+      ["<", "sign"], ["svg", "entity"], ["color", "property"], ["=", "sign"], ["\"", "string"], ["null", "string"],
+      ["\"", "string"], ["height", "property"], ["=", "sign"], ["\"", "string"], ["24", "string"], ["\"", "string"], ["/>", "sign"]
     ])
   })
 
@@ -364,7 +364,8 @@ describe('regex', () => {
 
   it('multi line regex tests', () => {
     const code1 =
-      `/reg/.test('str')[]\n` +
+      `/reg/.test('str')\n` +
+      `[]\n` +
       `/reg/.test('str')`
 
     // '[]' consider as a end of the expression

--- a/test/ast.test.js
+++ b/test/ast.test.js
@@ -107,10 +107,9 @@ describe('jsx', () => {
     expect(extractTokenArray(tokens)).toEqual([
       ["// jsx", "comment"], ["const", "keyword"], ["element", "identifier"], ["=", "sign"], ["(", "sign"], ["<", "sign"],
       [">", "sign"], ["<", "sign"], ["Food", "entity"], ["season", "property"], ["=", "sign"], ["{", "sign"],
-      ["{", "sign"], ["sault", "identifier"], [":", "sign"], ["<", "sign"], ["p", "entity"], 
-      // FIXME: a is a property
-      ["a", "identifier"],
-      ["=", "sign"], ["{", "sign"], ["[", "sign"], ["{", "sign"], ["}", "sign"], ["]", "sign"], ["}", "sign"], ["/>", "sign"],
+      ["{", "sign"], ["sault", "identifier"], [":", "sign"], 
+      ["<", "sign"], ["p", "entity"], ["a", "property"], ["=", "sign"], 
+      ["{", "sign"], ["[", "sign"], ["{", "sign"], ["}", "sign"], ["]", "sign"], ["}", "sign"], ["/>", "sign"],
       ["}", "sign"], ["}", "sign"], [">", "sign"], ["</", "sign"], ["Food", "entity"], [">", "sign"], ["{", "sign"],
       ["/* jsx comment */", "comment"], ["}", "sign"], ["<", "sign"], ["h1", "entity"], ["className", "property"],
       ["=", "sign"], ["\"", "string"], ["title", "string"], ["\"", "string"], ["data", "identifier"], ["-", "sign"],
@@ -275,7 +274,7 @@ describe('jsx', () => {
     expect(extractTokenArray(tokens)).toEqual([
       ['<', 'sign'],
       ['a', 'entity'],
-      ['k', 'identifier'],
+      ['k', 'property'],
       ['=', 'sign'],
       ['{', 'sign'],
       ['v', 'identifier'],
@@ -288,6 +287,22 @@ describe('jsx', () => {
       [')', 'sign'],
       ['{', 'sign'],
       ['}', 'sign'],
+    ])
+  })
+
+  it('should handle object spread correctly', () => {
+    const code = `<Component {...props} />`
+    const tokens = tokenize(code)
+    expect(extractTokenArray(tokens)).toEqual([
+      ['<', 'sign'],
+      ['Component', 'entity'],
+      ['{', 'sign'],
+      ['.', 'sign'],
+      ['.', 'sign'],
+      ['.', 'sign'],
+      ['props', 'identifier'],
+      ['}', 'sign'],
+      ['/>', 'sign'],
     ])
   })
 })


### PR DESCRIPTION
Resolves #94 

* Add `property` type that will be highlighted for `.<id>` and jsx property keys
* Add `entity` type that will be highlighted for jsx tag

Tests coverage
- [x] handle spread separately `{...x}`
- [x] `data-prop` 