### PR TITLE
feat: accept keywords set

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,3 +1,7 @@
-export function highlight(code: string): string
+type HighlightOptions = {
+  keywords?: Set<string>
+}
+
+export function highlight(code: string, options?: HighlightOptions): string
 export function tokenize(code: string): Array<[number, string]>
 export function generate(tokens: Array<[number, string]>): Array<any>

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 // @ts-check
 
-const jsxBrackets = new Set(['<', '>', '{', '}', '[', ']'])
-const keywords = new Set([
+const JSXBrackets = new Set(['<', '>', '{', '}', '[', ']'])
+const Keywords_javascript = new Set([
   'for',
   'do',
   'while',
@@ -45,7 +45,7 @@ const keywords = new Set([
   'static',
 ])
 
-const signs = new Set([
+const Signs = new Set([
   '+',
   '-',
   '*',
@@ -73,7 +73,7 @@ const signs = new Set([
   '#',
   '@',
   '\\',
-  ...jsxBrackets,
+  ...JSXBrackets,
 ])
 
 
@@ -92,7 +92,7 @@ const signs = new Set([
  * 10 - space
  *
  */
-const types = /** @type {const} */ ([
+const TokenTypes = /** @type {const} */ ([
   'identifier',
   'keyword',
   'string',
@@ -117,14 +117,14 @@ const [
   T_COMMENT,
   T_BREAK,
   T_SPACE,
-] = /** @types {const} */ types.map((_, i) => i)
+] = /** @types {const} */ TokenTypes.map((_, i) => i)
 
 function isSpaces(str) {
   return /^[^\S\r\n]+$/g.test(str)
 }
 
 function isSign(ch) {
-  return signs.has(ch)
+  return Signs.has(ch)
 }
 
 function encode(str) {
@@ -186,9 +186,11 @@ function isRegexStart(str) {
 
 /**
  * @param {string} code
+ * @param {{ keywords: Set<string> }} options
  * @return {Array<[number, string]>}
  */
-function tokenize(code) {
+function tokenize(code, options) {
+  const { keywords } = options
   let current = ''
   let type = -1
   /** @type {[number, string]} */
@@ -284,7 +286,7 @@ function tokenize(code) {
    */
   const append = (type_, token_) => {
     if (type_ || token_) {
-      const nType = types[type_]
+      const nType = TokenTypes[type_]
     }
     if (token_) {
       current = token_
@@ -571,9 +573,9 @@ function tokenize(code) {
         __jsxExpr = false
       } else if (
         // it's jsx literals and is not a jsx bracket
-        (isJsxLiterals && !jsxBrackets.has(curr)) ||
+        (isJsxLiterals && !JSXBrackets.has(curr)) ||
         // same type char as previous one in current token
-        ((isWord(curr) === isWord(current[current.length - 1]) || __jsxChild()) && !signs.has(curr))
+        ((isWord(curr) === isWord(current[current.length - 1]) || __jsxChild()) && !Signs.has(curr))
       ) {
         current += curr
       } else {
@@ -591,7 +593,7 @@ function tokenize(code) {
           append()
           i++
         }
-        else if (jsxBrackets.has(curr)) append()
+        else if (JSXBrackets.has(curr)) append()
       }
     }
   }
@@ -638,8 +640,8 @@ function generate(tokens) {
               value: value, // to encode
             }],
             properties: {
-              className: `sh__token--${types[type]}`,
-              style: `color: var(--sh-${types[type]})`,
+              className: `sh__token--${TokenTypes[type]}`,
+              style: `color: var(--sh-${TokenTypes[type]})`,
             },
           }
         ))
@@ -700,10 +702,14 @@ function toHtml(lines) {
 /**
  *
  * @param {string} code
+ * @param {{ keywords: Set<string> } | undefined} options
  * @returns {string}
  */
-function highlight(code) {
-  const tokens = tokenize(code)
+function highlight(code, options) {
+  options = options || {}
+  options.keywords = options.keywords || Keywords_javascript
+
+  const tokens = tokenize(code, options)
   const lines = generate(tokens)
   const output = toHtml(lines)
   return output
@@ -711,8 +717,8 @@ function highlight(code) {
 
 // namespace
 const SugarHigh = /** @type {const} */ {
-  TokenTypes: types,
-  TokenMap: new Map(types.map((type, i) => [type, i])),
+  TokenTypes,
+  TokenMap: new Map(TokenTypes.map((type, i) => [type, i])),
 }
 
 export {

--- a/lib/index.js
+++ b/lib/index.js
@@ -190,7 +190,9 @@ function isRegexStart(str) {
  * @return {Array<[number, string]>}
  */
 function tokenize(code, options) {
-  const { keywords } = options
+  options = options || {}
+  const keywords = options.keywords || Keywords_javascript
+
   let current = ''
   let type = -1
   /** @type {[number, string]} */
@@ -706,9 +708,6 @@ function toHtml(lines) {
  * @returns {string}
  */
 function highlight(code, options) {
-  options = options || {}
-  options.keywords = options.keywords || Keywords_javascript
-
   const tokens = tokenize(code, options)
   const lines = generate(tokens)
   const output = toHtml(lines)

--- a/test/ast.test.js
+++ b/test/ast.test.js
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import { tokenize } from '../lib'
-import { extractTokenArray, extractTokenValues } from './testing-utils'
+import { 
+  extractTokenArray, 
+  extractTokenValues,
+  getTokenValues,
+  getTokenArray,
+} from './testing-utils'
 
 describe('function calls', () => {
   it('dot catch should not be determined as keyword', () => {

--- a/test/ast.test.js
+++ b/test/ast.test.js
@@ -1,37 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { tokenize, SugarHigh } from '../lib'
-
-function getTypeName(token) {
-  return SugarHigh.TokenTypes[token[0]]
-}
-
-function getTokenValues(tokens) {
-  return tokens.map((tk) => tk[1])
-}
-
-function mergeSpaces(str) {
-  return str.trim().replace(/^[\s]{2,}$/g, ' ')
-}
-
-function filterSpaces(arr) {
-  return arr
-    .map(t => mergeSpaces(t))
-    .filter(Boolean)
-}
-
-function extractTokenValues(tokens) {
-  return filterSpaces(getTokenValues(tokens))
-}
-
-function getTokenArray(tokens) {
-  return tokens.map((tk) => [tk[1], getTypeName(tk)]);
-}
-
-function extractTokenArray(tokens) {
-  return tokens
-    .map((tk) => [mergeSpaces(tk[1]), getTypeName(tk)])
-    .filter(([_, type]) => type !== 'space' && type !== 'break')
-}
+import { tokenize } from '../lib'
+import { extractTokenArray, extractTokenValues } from './testing-utils'
 
 describe('function calls', () => {
   it('dot catch should not be determined as keyword', () => {

--- a/test/testing-utils.js
+++ b/test/testing-utils.js
@@ -40,5 +40,7 @@ function getTokensPairs(tokens) {
 export {
   extractTokenArray,
   extractTokenValues,
+  getTokenValues,
   getTokensPairs,
+  getTokenArray,
 }

--- a/test/testing-utils.js
+++ b/test/testing-utils.js
@@ -1,0 +1,44 @@
+import { SugarHigh } from '..'
+
+function getTypeName(token) {
+  return SugarHigh.TokenTypes[token[0]]
+}
+
+function getTokenValues(tokens) {
+  return tokens.map((tk) => tk[1])
+}
+
+function mergeSpaces(str) {
+  return str.trim().replace(/^[\s]{2,}$/g, ' ')
+}
+
+function filterSpaces(arr) {
+  return arr
+    .map(t => mergeSpaces(t))
+    .filter(Boolean)
+}
+
+function extractTokenValues(tokens) {
+  return filterSpaces(getTokenValues(tokens))
+}
+
+function getTokenArray(tokens) {
+  return tokens.map((tk) => [tk[1], getTypeName(tk)]);
+}
+
+function extractTokenArray(tokens) {
+  return tokens
+    .map((tk) => [mergeSpaces(tk[1]), getTypeName(tk)])
+    .filter(([_, type]) => type !== 'space' && type !== 'break')
+}
+
+function getTokensPairs(tokens) {
+  const extracted = extractTokenArray(tokens)
+  return extracted.map(([value, type]) => `${value} => ${type}`)
+}
+
+export {
+  extractTokenArray,
+  extractTokenValues,
+  getTokensPairs,
+}

--- a/test/tokenize.test.js
+++ b/test/tokenize.test.js
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { tokenize } from '../lib/'
+import { getTokensPairs } from './testing-utils'
+
+describe('tokenize - customized keywords', () => {
+  it('should tokenize the input string with the given keywords', () => {
+    const input = 'def f(): return 1'
+    const keywords = ['def', 'return']
+    const actual = getTokensPairs(tokenize(input, keywords))
+    expect(actual).toMatchInlineSnapshot(`
+      [
+        "def => identifier",
+        "f => identifier",
+        "( => sign",
+        ") => sign",
+        ": => sign",
+        "return => keyword",
+        "1 => class",
+      ]
+    `)
+  })
+})


### PR DESCRIPTION
Add new option `options.keywords` to `highlight()` API that can pass down a set of keywords to the language, which could use for highlighting on different languages