### PR TITLE
Add fetch to the list of keywords

### DIFF
--- a/packages/sugar-high/lib/index.js
+++ b/packages/sugar-high/lib/index.js
@@ -43,6 +43,7 @@ const Keywords_Js = new Set([
   'export',
   'from',
   'static',
+  'fetch',
 ])
 
 const Signs = new Set([


### PR DESCRIPTION
Add `fetch` to the list of keywords for a better syntax highlighting 