### PR TITLE
fix: handle in char class

### DIFF
--- a/packages/sugar-high/lib/index.js
+++ b/packages/sugar-high/lib/index.js
@@ -715,9 +715,16 @@ function tokenize(code, options) {
 
       let foundClose = false
 
+      // `/` is literal inside regex character classes, e.g. `[/]`.
+      let inCharClass = false
+
       // traverse to find closing regex slash
       for (; !isEol(); i++) {
-        if (code[i] === '/' && code[i - 1] !== '\\') {
+        const ch = code[i]
+        const escaped = code[i - 1] === '\\'
+        if (!escaped && ch === '[') inCharClass = true
+        if (!escaped && ch === ']') inCharClass = false
+        if (ch === '/' && !inCharClass && !escaped) {
           foundClose = true
           // end of regex, append regex flags
           while (start !== i && /^[a-z]$/.test(code[i + 1]) && !isEol()) {

--- a/packages/sugar-high/test/ast.test.ts
+++ b/packages/sugar-high/test/ast.test.ts
@@ -694,6 +694,13 @@ describe('regex', () => {
     `)
   })
 
+  it('contains slash character classes', () => {
+    const code = `const matchBoundary = (s) => /^[/][\\w-]+[/]$/u.test(s)`
+    expect(getTokensAsString(tokenize(code))).toContain(
+      "/^[/][\\w-]+[/]$/u => string"
+    )
+  })
+
   it('regex plus operators', () => {
     const code = `/^\\/[0-5]\\/$/ + /^\\/\w+\\/$/gi`
     const tokens = tokenize(code)


### PR DESCRIPTION
`[/]` in regex should still be captured as regex