### PR TITLE
feat: highlight quoted object keys as property

### DIFF
--- a/packages/sugar-high/README.md
+++ b/packages/sugar-high/README.md
@@ -42,6 +42,8 @@ For more language presets and syntax color themes, see **[sugar-high.vercel.app]
 
 Each line is wrapped in `sh__line`. Set **CSS custom properties** `--sh-*` on an ancestor (for example `:root`) to pick colors—inspect the output or the example below for the variable names you need.
 
+Quoted object keys (`{ "key": "value" }` in JSON or JS/TS) are highlighted as `property`—the same token as member access (`obj.foo`) and JSX attribute names—so keys and string values get distinct colors (`--sh-property` vs `--sh-string`).
+
 Example theme:
 
 ```css

--- a/packages/sugar-high/lib/index.js
+++ b/packages/sugar-high/lib/index.js
@@ -302,6 +302,24 @@ function isRegexStart(str) {
 }
 
 /**
+ * After a closing string quote at `index`, checks whether the next
+ * non-whitespace character is `:` (optionally preceded by a `?` for
+ * TS optional members like `{ "key"?: string }`).
+ * @param {string} code
+ * @param {number} index
+ * @returns {boolean}
+ */
+function isObjectKeyColonAhead(code, index) {
+  let i = index + 1
+  while (i < code.length && /\s/.test(code[i])) i++
+  if (code[i] === '?') {
+    i++
+    while (i < code.length && /\s/.test(code[i])) i++
+  }
+  return code[i] === ':'
+}
+
+/**
  * @param {string} code
  * @param {{
  *   keywords?: Set<string>
@@ -364,6 +382,10 @@ function tokenize(code, options) {
 
   /** @type {string | null} */
   let __strQuote = null
+  /** Index in `tokens` of the pending string's opening quote. */
+  let __strTokenStart = 0
+  /** Value of the last non-space token right before the pending string opened. */
+  let __strOpenPrevToken = ''
   let __regexQuoteStart = false
   let __strTemplateExprStack = 0
   let __strTemplateQuoteStack = 0
@@ -479,15 +501,31 @@ function tokenize(code, options) {
     // Inside jsx literals or template literals, string quotation is still part of it.
     if (isSingleQuotes(curr) && !inJsxLiterals() && !inStrTemplateLiterals()) {
       append()
+      let isStrClose = false
       if (prev !== `\\`) {
         if (__strQuote && curr === __strQuote) {
           __strQuote = null
+          isStrClose = true
         } else if (!__strQuote) {
           __strQuote = curr
+          __strTokenStart = tokens.length
+          __strOpenPrevToken = last[1]
         }
       }
 
       append(T_STRING, curr)
+      // Quoted object keys (`{"a": 1}`, `{ 'a': 1 }`): a string that opened
+      // right after `{` or `,` and is followed by `:` is a key, not a value.
+      // The prev-token guard keeps `case "x":` and `cond ? "a" : "b"` as strings.
+      if (
+        isStrClose &&
+        (__strOpenPrevToken === '{' || __strOpenPrevToken === ',') &&
+        isObjectKeyColonAhead(code, i)
+      ) {
+        for (let t = __strTokenStart; t < tokens.length; t++) {
+          tokens[t][0] = T_PROPERTY
+        }
+      }
       continue
     }
 

--- a/packages/sugar-high/test/ast.test.ts
+++ b/packages/sugar-high/test/ast.test.ts
@@ -990,6 +990,194 @@ describe('strings', () => {
   })
 })
 
+describe('object keys', () => {
+  it('quoted json keys are properties, values stay strings', () => {
+    const code = `{"name": "Alice", "age": 30}`
+    expect(getTokensAsString(tokenize(code))).toMatchInlineSnapshot(`
+      [
+        "{ => sign",
+        "" => property",
+        "name => property",
+        "" => property",
+        ": => sign",
+        "" => string",
+        "Alice => string",
+        "" => string",
+        ", => sign",
+        "" => property",
+        "age => property",
+        "" => property",
+        ": => sign",
+        "30 => class",
+        "} => sign",
+      ]
+    `)
+  })
+
+  it('multiline json with nested objects', () => {
+    const code = `{
+  "a": 1,
+  "b": { "c": true }
+}`
+    expect(getTokensAsString(tokenize(code))).toMatchInlineSnapshot(`
+      [
+        "{ => sign",
+        "" => property",
+        "a => property",
+        "" => property",
+        ": => sign",
+        "1 => class",
+        ", => sign",
+        "" => property",
+        "b => property",
+        "" => property",
+        ": => sign",
+        "{ => sign",
+        "" => property",
+        "c => property",
+        "" => property",
+        ": => sign",
+        "true => keyword",
+        "} => sign",
+        "} => sign",
+      ]
+    `)
+  })
+
+  it('single quoted keys in js object literals', () => {
+    const code = `const o = { foo: 1, 'bar': 2 }`
+    expect(getTokensAsString(tokenize(code))).toMatchInlineSnapshot(`
+      [
+        "const => keyword",
+        "o => identifier",
+        "= => sign",
+        "{ => sign",
+        "foo => identifier",
+        ": => sign",
+        "1 => class",
+        ", => sign",
+        "' => property",
+        "bar => property",
+        "' => property",
+        ": => sign",
+        "2 => class",
+        "} => sign",
+      ]
+    `)
+  })
+
+  it('string value containing a colon stays a string', () => {
+    const code = `{"a": "b:c"}`
+    expect(getTokensAsString(tokenize(code))).toMatchInlineSnapshot(`
+      [
+        "{ => sign",
+        "" => property",
+        "a => property",
+        "" => property",
+        ": => sign",
+        "" => string",
+        "b:c => string",
+        "" => string",
+        "} => sign",
+      ]
+    `)
+  })
+
+  it('escaped quote inside a key', () => {
+    const code = `{"a\\"b": 1}`
+    expect(getTokensAsString(tokenize(code))).toMatchInlineSnapshot(`
+      [
+        "{ => sign",
+        "" => property",
+        "a\\ => property",
+        "" => property",
+        "b => property",
+        "" => property",
+        ": => sign",
+        "1 => class",
+        "} => sign",
+      ]
+    `)
+  })
+
+  it('ts optional member keys', () => {
+    const code = `interface Opts { "a"?: string }`
+    expect(getTokensAsString(tokenize(code))).toMatchInlineSnapshot(`
+      [
+        "interface => keyword",
+        "Opts => class",
+        "{ => sign",
+        "" => property",
+        "a => property",
+        "" => property",
+        "? => sign",
+        ": => sign",
+        "string => keyword",
+        "} => sign",
+      ]
+    `)
+  })
+
+  it('case labels are not keys', () => {
+    const code = `switch (x) { case "a": break }`
+    expect(getTokensAsString(tokenize(code))).toMatchInlineSnapshot(`
+      [
+        "switch => keyword",
+        "( => sign",
+        "x => identifier",
+        ") => sign",
+        "{ => sign",
+        "case => keyword",
+        "" => string",
+        "a => string",
+        "" => string",
+        ": => sign",
+        "break => keyword",
+        "} => sign",
+      ]
+    `)
+  })
+
+  it('ternary branches are not keys', () => {
+    const code = `f(x, flag ? "a" : "b")`
+    expect(getTokensAsString(tokenize(code))).toMatchInlineSnapshot(`
+      [
+        "f => identifier",
+        "( => sign",
+        "x => identifier",
+        ", => sign",
+        "flag => identifier",
+        "? => sign",
+        "" => string",
+        "a => string",
+        "" => string",
+        ": => sign",
+        "" => string",
+        "b => string",
+        "" => string",
+        ") => sign",
+      ]
+    `)
+  })
+
+  it('array elements are not keys', () => {
+    const code = `["a", "b"]`
+    expect(getTokensAsString(tokenize(code))).toMatchInlineSnapshot(`
+      [
+        "[ => sign",
+        "" => string",
+        "a => string",
+        "" => string",
+        ", => sign",
+        "" => string",
+        "b => string",
+        "" => string",
+        "] => sign",
+      ]
+    `)
+  })
+})
+
 describe('class', () => {
   it('determine class name', () => {
     const code = `class Bar extends Array {}`


### PR DESCRIPTION
Fixes #161

| Type | Before | After |
| --- | --- | --- |
| JSON | <img width="717" height="296" alt="Screenshot 2026-07-08 at 11 47 11 AM" src="https://github.com/user-attachments/assets/4934b639-24e5-404f-8dec-26d95391dee3" /> | <img width="718" height="287" alt="Screenshot 2026-07-08 at 11 46 28 AM" src="https://github.com/user-attachments/assets/b0dd6a90-e8d0-4c18-b16d-90ff86cf3af6" /> | 
| JS/TS | <img width="722" height="296" alt="Screenshot 2026-07-08 at 11 48 26 AM" src="https://github.com/user-attachments/assets/944dd89c-d5a7-49bd-96f6-fd65b56badcb" /> | <img width="724" height="287" alt="Screenshot 2026-07-08 at 11 48 41 AM" src="https://github.com/user-attachments/assets/04256331-7b3c-4858-b2ea-bd3b9be617bf" /> |

## Problem

Quoted object keys tokenize identically to string values (both `string`), so keys and values are indistinguishable when highlighting JSON — the most useful visual cue when scanning large JSON blobs:

```js
tokenize('{"name": "Alice"}')
// "name" and "Alice" both => string (green-on-green with typical themes)
```

## Approach

Retype a quoted string as `property` when **both**:

1. the token before the opening quote is `{` or `,`, and
2. the first non-whitespace character after the closing quote is `:` (allowing one optional `?` for TS optional members like `{ "key"?: string }`).

Condition 1 rules out the JavaScript false positives — `case "x":` (preceded by the `case` keyword) and ternaries `cond ? "a" : "b"` (preceded by `?`/`:`) keep their `string` type. Single-quoted JS keys (`{ 'a': 1 }`) work too, and unquoted keys are unchanged (`identifier`).

Keys reuse the existing `property` token — the same type as member access (`obj.foo`) and JSX attribute names — so there's no new token id (no renumbering), no new `--sh-*` variable, and existing themes color keys immediately via `--sh-property`.

Implementation is localized to the quote open/close branch of `tokenize()`: record the token index and preceding token when a string opens, look ahead past whitespace when it closes, and retype the quote/content tokens if both conditions hold.

## Result

```js
tokenize('{"name": "Alice", "age": 30}')
// "name", "age"  => property
// "Alice"        => string
// 30             => class
```

## Tests

New `object keys` describe in `test/ast.test.ts` covering: JSON keys vs values, nested/multiline JSON, single-quoted JS keys, values containing `:`, escaped quotes inside keys, TS `"a"?:`, and the negative cases (`case "a":`, ternary branches, array elements). All 72 tests pass with **zero changes to existing snapshots**, so the behavior is purely additive for everything previously covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)