### PR TITLE
Add token class maps and mark hook

### DIFF
--- a/.changeset/tidy-tokens-glow.md
+++ b/.changeset/tidy-tokens-glow.md
@@ -1,0 +1,8 @@
+---
+'sugar-high': minor
+'@sugar-high/react': minor
+'@sugar-high/remark': minor
+---
+
+Add token class maps with `cx` and a mutable `mark(token)` hook across the core, React, and Remark
+APIs.

--- a/.changeset/tidy-tokens-glow.md
+++ b/.changeset/tidy-tokens-glow.md
@@ -1,8 +1,0 @@
----
-'sugar-high': minor
-'@sugar-high/react': minor
-'@sugar-high/remark': minor
----
-
-Add token class maps with `cx` and a mutable `mark(token)` hook across the core, React, and Remark
-APIs.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -26,7 +26,7 @@ import { Editor } from '@sugar-high/react'
 ```tsx
 import { Code } from '@sugar-high/react/code'
 
-<Code lang="python" title="main.py" lineNumbers>
+<Code lang="python" title="main.py" lineNumbers cx={{ keyword: 'font-bold' }}>
   {'def hello():\n    return "world"'}
 </Code>
 ```

--- a/packages/react/src/code/code.tsx
+++ b/packages/react/src/code/code.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { tokenize, generate, type LanguageName } from 'sugar-high'
+import { tokenize, generate, type HighlightOptions, type LanguageName } from 'sugar-high'
 import { css, HEADER_CSS } from './css'
 import { lang as canonicalLang } from 'sugar-high/lang'
 import { useMemo } from 'react'
@@ -17,11 +17,15 @@ function generateHighlightedLines(
   lineNumbers: boolean,
   title: string | undefined,
   extension: string | undefined,
-  language: LanguageName | undefined
+  language: LanguageName | undefined,
+  cx: HighlightOptions['cx'],
+  mark: HighlightOptions['mark']
 ) {
   const ext = extension || getExtension(title)
   const resolvedLang = language || canonicalLang(ext)
-  const options = resolvedLang ? { lang: resolvedLang } : undefined
+  const options: HighlightOptions | undefined = resolvedLang || cx || mark
+    ? { ...(resolvedLang ? { lang: resolvedLang } : {}), cx, mark }
+    : undefined
   const childrenLines = generate(tokenize(codeText, options), options)
 
   // each line will contain class name 'sh__line',
@@ -158,6 +162,8 @@ export function Code({
   asMarkup = false,
   extension,
   lang,
+  cx,
+  mark,
   ...props
 }: {
   children: string
@@ -173,12 +179,14 @@ export function Code({
   asMarkup?: boolean
   extension?: string
   lang?: LanguageName
+  cx?: HighlightOptions['cx']
+  mark?: HighlightOptions['mark']
 } & React.HTMLAttributes<HTMLDivElement>) {
   const lineElements = useMemo(() =>
     asMarkup
       ? code
-      : generateHighlightedLines(code, highlightLines, lineNumbers, title, extension, lang),
-    [code, highlightLines, lineNumbers, title, extension, lang, asMarkup]
+      : generateHighlightedLines(code, highlightLines, lineNumbers, title, extension, lang, cx, mark),
+    [code, highlightLines, lineNumbers, title, extension, lang, cx, mark, asMarkup]
   )
 
   return (

--- a/packages/react/src/editor/editor.tsx
+++ b/packages/react/src/editor/editor.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState, forwardRef } from 'react'
 import { CodeHeader, getExtension, Code } from '../code/code'
 import { ScopedStyle } from '../style'
 import { css } from './css'
-import type { LanguageName } from 'sugar-high'
+import type { HighlightOptions, LanguageName } from 'sugar-high'
 
 export const Editor = forwardRef(function Editor(
   {
@@ -15,6 +15,8 @@ export const Editor = forwardRef(function Editor(
     lineNumbersWidth,
     extension,
     lang,
+    cx,
+    mark,
     padding,
     onChange = () => {},
     fontSize,
@@ -31,6 +33,8 @@ export const Editor = forwardRef(function Editor(
     padding?: string
     extension?: string
     lang?: LanguageName
+    cx?: HighlightOptions['cx']
+    mark?: HighlightOptions['mark']
     onChangeTitle?: (title: string) => void
     onChange?: (code: string) => void
     textareaRef?: React.Ref<HTMLTextAreaElement>
@@ -79,6 +83,8 @@ export const Editor = forwardRef(function Editor(
           title={null}
           extension={extension || getExtension(title)}
           lang={lang}
+          cx={cx}
+          mark={mark}
           controls={false}
           lineNumbers={lineNumbers}
           lineNumbersWidth={lineNumbersWidth}

--- a/packages/react/src/language.test.tsx
+++ b/packages/react/src/language.test.tsx
@@ -20,4 +20,11 @@ describe('language selection', () => {
     const html = renderToString(<Editor lang="rust" value="fn main() {}" />)
     expect(html).toContain('sh__token--keyword')
   })
+
+  it('marks tokens with custom classes', () => {
+    const html = renderToString(
+      <Code lang="javascript" cx={{ keyword: 'font-bold' }}>{'const value = true'}</Code>
+    )
+    expect(html).toContain('sh__token--keyword font-bold')
+  })
 })

--- a/packages/remark/README.md
+++ b/packages/remark/README.md
@@ -33,7 +33,7 @@ Using [remark](https://github.com/remarkjs/remark):
 const { highlight } = require('@sugar-high/remark');
 
 await remark()
-  .use(highlight)
+  .use(highlight, { cx: { keyword: 'font-bold' } })
   .use(require('remark-html'))
   .process(file, (err, file) => console.log(String(file)));
 ```

--- a/packages/remark/src/index.ts
+++ b/packages/remark/src/index.ts
@@ -3,7 +3,7 @@ import { lang as canonicalizeLang } from 'sugar-high/lang'
 import { map as unistMap } from 'unist-util-map'
 import rangeParser from 'parse-numeric-range'
 
-function cx(...args: any[]): string {
+function join(...args: any[]): string {
   return args.filter(Boolean).join(' ')
 }
 
@@ -68,7 +68,12 @@ const h = (type, attrs, children) => {
   }
 }
 
-const highlight = () => (tree) => {
+type RemarkSugarHighOptions = {
+  cx?: HighlightOptions['cx']
+  mark?: HighlightOptions['mark']
+}
+
+const highlight = ({ cx, mark }: RemarkSugarHighOptions = {}) => (tree) => {
   return unistMap(tree, (node) => {
     const { type, tagName } = node
     if (tagName !== 'code' && type !== 'code') return node
@@ -89,8 +94,8 @@ const highlight = () => (tree) => {
 
     const canonicalLang = canonicalizeLang(lang)
     const outputLang = canonicalLang || lang
-    const options: HighlightOptions | undefined = canonicalLang
-      ? { lang: canonicalLang }
+    const options: HighlightOptions | undefined = canonicalLang || cx || mark
+      ? { ...(canonicalLang ? { lang: canonicalLang } : {}), cx, mark }
       : undefined
 
     const codeText =
@@ -119,7 +124,8 @@ const highlight = () => (tree) => {
         if (token.properties && typeof token.properties.style === 'object') {
           let styleString = ''
           for (const [key, value] of Object.entries(token.properties.style)) {
-            styleString += `${key}:${value};`
+            const property = key.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`)
+            styleString += `${property}:${value};`
           }
           if (styleString) {
             token.properties.style = styleString
@@ -139,7 +145,7 @@ const highlight = () => (tree) => {
       )
 
       // add class to line
-      line.properties.className = cx(
+      line.properties.className = join(
         line.properties.className,
         highLightClassName
       )

--- a/packages/sugar-high/README.md
+++ b/packages/sugar-high/README.md
@@ -96,6 +96,36 @@ lang('.yml')  // 'yaml'
 
 For more language presets and syntax color themes, see **[sugar-high.vercel.app](https://sugar-high.vercel.app/)**.
 
+### Mark tokens
+
+Use `cx` to append classes by token type. This works with utility classes, CSS Modules, and global
+styles while preserving Sugar High's semantic token classes.
+
+```js
+const html = highlight(source, {
+  lang: 'typescript',
+  cx: {
+    keyword: 'font-bold',
+    comment: 'italic opacity-60',
+  },
+})
+```
+
+For conditional styling or custom attributes, mutate each generated token with `mark`:
+
+```js
+highlight(source, {
+  mark(token) {
+    if (token.type === 'comment' && token.value.includes('TODO')) {
+      token.className += ' text-orange-500'
+      token.properties['data-todo'] = true
+    }
+  },
+})
+```
+
+`cx` is applied before `mark`, so the callback receives the composed class name.
+
 ## Styling
 
 Each line is wrapped in `sh__line`. Set **CSS custom properties** `--sh-*` on an ancestor (for example `:root`) to pick colors—inspect the output or the example below for the variable names you need.

--- a/packages/sugar-high/lib/core.d.ts
+++ b/packages/sugar-high/lib/core.d.ts
@@ -1,3 +1,24 @@
+export type TokenType =
+  | 'identifier'
+  | 'keyword'
+  | 'string'
+  | 'class'
+  | 'property'
+  | 'entity'
+  | 'jsxliterals'
+  | 'sign'
+  | 'comment'
+  | 'break'
+  | 'space'
+
+export type MarkToken = {
+  type: TokenType
+  value: string
+  className: string
+  style: Record<string, string | number>
+  properties: Record<string, string | number | boolean>
+}
+
 export type HighlightOptions = {
   keywords?: Set<string>
   /**
@@ -26,11 +47,15 @@ export type HighlightOptions = {
   /** Replace the general lexer for a complex language family. */
   tokenize?: (code: string, options: HighlightOptions) => Array<[number, string]>
   lineClassName?: (line: string, index: number) => string | null | undefined
+  /** Additional classes keyed by token type. */
+  cx?: Partial<Record<TokenType, string>>
+  /** Mutate a token before it is rendered. */
+  mark?: (token: MarkToken) => void
 }
 
 export function highlight(code: string, options?: HighlightOptions): string
 export function tokenize(code: string, options?: HighlightOptions): Array<[number, string]>
-export function generate(tokens: Array<[number, string]>, options?: Pick<HighlightOptions, 'lineClassName'>): Array<any>
+export function generate(tokens: Array<[number, string]>, options?: Pick<HighlightOptions, 'lineClassName' | 'cx' | 'mark'>): Array<any>
 export const SugarHigh: {
   TokenTypes: {
     [key: number]: string

--- a/packages/sugar-high/lib/core.js
+++ b/packages/sugar-high/lib/core.js
@@ -150,4 +150,17 @@ export { generate, highlight, SugarHigh, tokenize }
  * @property {boolean} [templateStrings]
  * @property {(line: string, index: number) => string | null | undefined} [lineClassName]
  * @property {(code: string, options: HighlightOptions) => Array<[number, string]>} [tokenize]
+ * @property {Partial<Record<TokenType, string>>} [cx]
+ * @property {(token: MarkToken) => void} [mark]
+ */
+
+/**
+ * @typedef {'identifier' | 'keyword' | 'string' | 'class' | 'property' | 'entity' | 'jsxliterals' | 'sign' | 'comment' | 'break' | 'space'} TokenType
+ * @typedef {{
+ *   type: TokenType
+ *   value: string
+ *   className: string
+ *   style: Record<string, string | number>
+ *   properties: Record<string, string | number | boolean>
+ * }} MarkToken
  */

--- a/packages/sugar-high/lib/index.d.ts
+++ b/packages/sugar-high/lib/index.d.ts
@@ -1,5 +1,7 @@
 import type { HighlightOptions as CoreHighlightOptions } from './core.js'
 
+export type { MarkToken, TokenType } from './core.js'
+
 export type LanguageName =
   | 'javascript'
   | 'typescript'

--- a/packages/sugar-high/lib/shared.js
+++ b/packages/sugar-high/lib/shared.js
@@ -13,11 +13,17 @@ const SugarHigh = /** @type {const} */ ({
 
 /**
  * @param {Array<[number, string]>} tokens
- * @param {{ lineClassName?: (line: string, index: number) => string | null | undefined } | undefined} options
+ * @param {{
+ *   lineClassName?: (line: string, index: number) => string | null | undefined
+ *   cx?: Partial<Record<import('./core.js').TokenType, string>>
+ *   mark?: (token: import('./core.js').MarkToken) => void
+ * } | undefined} options
  */
 function generate(tokens, options) {
   const lines = []
   const lineClassName = typeof options?.lineClassName === 'function' ? options.lineClassName : null
+  const cx = options?.cx
+  const mark = options?.mark
   let lineIndex = 0
   /** @type {Array<[number, string]>} */
   const lineTokens = []
@@ -33,13 +39,23 @@ function generate(tokens, options) {
       tagName: 'span',
       children: tokens.map(([type, value]) => {
         const tokenType = TokenTypes[type]
+        const extraClassName = cx?.[tokenType]
+        const token = {
+          type: tokenType,
+          value,
+          className: `sh__token--${tokenType}${extraClassName ? ` ${extraClassName}` : ''}`,
+          style: { color: `var(--sh-${tokenType})` },
+          properties: {},
+        }
+        mark?.(token)
         return {
           type: 'element',
           tagName: 'span',
-          children: [{ type: 'text', value }],
+          children: [{ type: 'text', value: token.value }],
           properties: {
-            className: `sh__token--${tokenType}`,
-            style: { color: `var(--sh-${tokenType})` },
+            ...token.properties,
+            className: token.className,
+            style: token.style,
           },
         }
       }),
@@ -90,8 +106,12 @@ function toHtml(lines) {
   return lines.map(line => {
     const children = line.children.map(token => {
       const style = Object.entries(token.properties.style)
-        .map(([key, value]) => `${key}:${value}`).join(';')
-      return `<${token.tagName} class="${token.properties.className}" style="${style}">${encode(token.children[0].value)}</${token.tagName}>`
+        .map(([key, value]) => `${key.replace(/[A-Z]/g, match => `-${match.toLowerCase()}`)}:${value}`).join(';')
+      const properties = Object.entries(token.properties)
+        .filter(([key, value]) => /^[\w:-]+$/.test(key) && key !== 'className' && key !== 'style' && value !== false && value != null)
+        .map(([key, value]) => value === true ? key : `${key}="${encode(String(value))}"`).join(' ')
+      const attributes = `class="${encode(token.properties.className)}" style="${encode(style)}"${properties ? ` ${properties}` : ''}`
+      return `<${token.tagName} ${attributes}>${encode(token.children[0].value)}</${token.tagName}>`
     }).join('')
     return `<${line.tagName} class="${line.properties.className}">${children}</${line.tagName}>`
   }).join('\n')

--- a/packages/sugar-high/test/ast.test.ts
+++ b/packages/sugar-high/test/ast.test.ts
@@ -1054,6 +1054,37 @@ describe('newline handling', () => {
     expect(html).toContain('class="sh__line sh__line--marked"')
   })
 
+  it('should append token classes with cx before marking tokens', () => {
+    const html = highlight('const value = true', {
+      cx: { keyword: 'font-bold' },
+      mark(token) {
+        if (token.type === 'keyword') {
+          expect(token.className).toContain('font-bold')
+          token.className += ' uppercase'
+        }
+      },
+    })
+
+    expect(html).toContain('class="sh__token--keyword font-bold uppercase"')
+  })
+
+  it('should let mark mutate token content, styles, and properties', () => {
+    const html = highlight('// TODO', {
+      mark(token) {
+        if (token.type === 'comment') {
+          token.value = 'marked <todo>'
+          token.style.fontWeight = 700
+          token.properties['data-todo'] = true
+          token.properties.title = 'Review "this"'
+        }
+      },
+    })
+
+    expect(html).toContain('style="color:var(--sh-comment);font-weight:700"')
+    expect(html).toContain('data-todo title="Review &quot;this&quot;"')
+    expect(html).toContain('marked &lt;todo&gt;')
+  })
+
   it('should preserve empty lines in HTML output', () => {
     const codeWithEmptyLines = `function test() {
   console.log('first');


### PR DESCRIPTION
## Summary

Add two levels of token customization across the core, React, and Remark APIs:

- `cx` appends classes by semantic token type, making Tailwind and CSS Modules straightforward.
- `mark(token)` is a mutable, token-level escape hatch for conditional classes, styles, attributes, and content.
- `cx` is applied before `mark`, so the hook receives the composed class name.

```ts
highlight(code, {
  lang: "typescript",
  cx: {
    keyword: "font-bold",
    comment: "italic opacity-60",
  },
  mark(token) {
    if (token.type === "comment" && token.value.includes("TODO")) {
      token.className += " text-orange-500"
      token.properties["data-todo"] = true
    }
  },
})
```

`mark(token)` returns `void`; mutations are reflected in HTML output and the React and Remark renderers.