### PR TITLE
Redesign React and Remark product pages

### DIFF
--- a/apps/docs/app/components/install-banner.css
+++ b/apps/docs/app/components/install-banner.css
@@ -5,7 +5,6 @@
   justify-content: center;
   max-width: 100vw;
   margin: 0;
-  padding: 24px 0 0;
   background: transparent;
   touch-action: pan-y;
 }
@@ -132,94 +131,6 @@
   overflow-x: auto;
 }
 
-.install-banner__sample-grid {
-  --install-banner-card-edge-spread: min(96px, 14vw);
-  --install-banner-card-inner-spread: min(32px, 5vw);
-  width: 100%;
-  max-width: 720px;
-  height: 320px;
-  position: relative;
-  margin: 52px 0 78px;
-  overflow: visible;
-  overflow-y: visible;
-}
-
-.install-banner__code.install-banner__code--sample {
-  --install-banner-card-shift: 0px;
-  --install-banner-card-rotate: 0deg;
-  position: absolute;
-  bottom: 0;
-  left: 50%;
-  width: min(430px, calc(100% - 40px));
-  min-height: 176px;
-  border: 1px solid rgb(255 255 255 / 10%);
-  border-radius: 6px;
-  background-color: rgb(56 56 56 / 88%);
-  box-shadow:
-    0 -1px 0 rgb(255 255 255 / 8%),
-    0 12px 28px rgb(0 0 0 / 16%);
-  backdrop-filter: blur(2px);
-  transform: translateX(-50%) translateX(var(--install-banner-card-shift, 0))
-    translateY(var(--install-banner-card-lift, 0))
-    rotate(var(--install-banner-card-rotate, 0deg));
-  transform-origin: 50% 100%;
-  transition:
-    background-color 0.3s ease,
-    border-color 0.3s ease,
-    box-shadow 0.22s ease,
-    color 0.3s ease,
-    transform 0.56s cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.install-banner__sample-grid--spread .install-banner__code--sample {
-  --install-banner-card-shift: var(--install-banner-card-final-shift, 0px);
-  --install-banner-card-rotate: var(--install-banner-card-final-rotate, 0deg);
-}
-
-.install-banner__sample-grid .install-banner__code--sample:hover,
-.install-banner__sample-grid .install-banner__code--sample:focus-within {
-  box-shadow:
-    0 -1px 0 rgb(255 255 255 / 10%),
-    0 22px 42px rgb(0 0 0 / 22%);
-}
-
-.install-banner__sample-grid .install-banner__code--sample:nth-child(1) {
-  --install-banner-card-final-shift: calc(var(--install-banner-card-edge-spread) * -1);
-  --install-banner-card-final-rotate: -13deg;
-  z-index: 1;
-}
-
-.install-banner__sample-grid .install-banner__code--sample:nth-child(2) {
-  --install-banner-card-final-shift: calc(var(--install-banner-card-inner-spread) * -1);
-  --install-banner-card-final-rotate: -4deg;
-  z-index: 2;
-}
-
-.install-banner__sample-grid .install-banner__code--sample:nth-child(3) {
-  --install-banner-card-final-shift: var(--install-banner-card-inner-spread);
-  --install-banner-card-final-rotate: 5deg;
-  z-index: 3;
-}
-
-.install-banner__sample-grid .install-banner__code--sample:nth-child(4) {
-  --install-banner-card-final-shift: var(--install-banner-card-edge-spread);
-  --install-banner-card-final-rotate: 14deg;
-  z-index: 4;
-}
-
-.install-banner__sample-grid .install-banner__code--sample.install-banner__code--sample-active {
-  --install-banner-card-lift: -26px;
-  z-index: 10;
-  box-shadow:
-    0 -1px 0 rgb(255 255 255 / 12%),
-    0 28px 52px rgb(0 0 0 / 26%);
-}
-
-.install-banner__sample-grid .install-banner__code--sample.install-banner__code--sample-active:hover,
-.install-banner__sample-grid .install-banner__code--sample.install-banner__code--sample-active:focus-within {
-  --install-banner-card-lift: -26px;
-}
-
 .install-banner__code .sh__line--diff-add {
   background-color: color-mix(in srgb, #2da44e 18%, transparent);
 }
@@ -255,27 +166,6 @@
 
 .install-banner[data-install-theme='light'] .install-banner__code .sh__line--highlighted {
   background-color: rgb(73 152 255 / 12%);
-}
-
-.install-banner[data-install-theme='light'] .install-banner__code.install-banner__code--sample {
-  background-color: rgb(246 246 246 / 88%);
-  border-color: rgb(53 65 80 / 10%);
-  box-shadow:
-    0 -1px 0 rgb(255 255 255 / 72%),
-    0 12px 28px rgb(53 65 80 / 12%);
-}
-
-.install-banner[data-install-theme='light'] .install-banner__sample-grid .install-banner__code--sample:hover,
-.install-banner[data-install-theme='light'] .install-banner__sample-grid .install-banner__code--sample:focus-within {
-  box-shadow:
-    0 -1px 0 rgb(255 255 255 / 82%),
-    0 22px 42px rgb(53 65 80 / 18%);
-}
-
-.install-banner[data-install-theme='light'] .install-banner__sample-grid .install-banner__code--sample.install-banner__code--sample-active {
-  box-shadow:
-    0 -1px 0 rgb(255 255 255 / 88%),
-    0 28px 52px rgb(53 65 80 / 22%);
 }
 
 .install-banner__block {
@@ -344,33 +234,4 @@
     height: 30px;
   }
 
-  .install-banner__sample-grid {
-    --install-banner-card-edge-spread: 0px;
-    --install-banner-card-inner-spread: 0px;
-    height: 340px;
-    margin-top: 52px;
-    margin-bottom: 104px;
-    max-width: 100%;
-    overflow: visible;
-    overflow-y: visible;
-  }
-
-  .install-banner__code.install-banner__code--sample {
-    width: min(390px, calc(100% - 24px));
-    --install-banner-card-final-rotate: 0deg;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .install-banner__code.install-banner__code--sample {
-    transition-duration: 0.01ms;
-  }
-
-  .install-banner__sample-grid .install-banner__code--sample:hover,
-  .install-banner__sample-grid .install-banner__code--sample:focus-within,
-  .install-banner__sample-grid .install-banner__code--sample.install-banner__code--sample-active,
-  .install-banner__sample-grid .install-banner__code--sample.install-banner__code--sample-active:hover,
-  .install-banner__sample-grid .install-banner__code--sample.install-banner__code--sample-active:focus-within {
-    --install-banner-card-lift: -8px;
-  }
 }

--- a/apps/docs/app/components/install-banner.tsx
+++ b/apps/docs/app/components/install-banner.tsx
@@ -2,13 +2,12 @@
 
 import {
   useContext,
-  useEffect,
   useMemo,
-  useRef,
   useState,
   type CSSProperties,
   type KeyboardEvent,
   type PointerEvent,
+  type ReactNode,
 } from 'react'
 import { CopyButton } from './copy-button'
 import { Code } from '@sugar-high/react'
@@ -35,57 +34,12 @@ const presetByTitleExample = `\
 import { highlight } from 'sugar-high'
 import { lang } from 'sugar-high/lang'
 
-const ext = (title) => title.split('.').pop()
+highlight('const ready = true') // JavaScript is the default
+highlight('print("hi")', { lang: 'python' }) // canonical name
+highlight('name: sugar-high', { lang: lang('yml') }) // yml → yaml`
 
-highlight('.card { color: red; }', { lang: lang(ext('theme.css')) })
-highlight('def hi():\\n    print("ok")', { lang: lang(ext('main.py')) })`
-
-const cPresetSample = `\
-#include <stdint.h> /* fixed-width ints */
-#define MIX(x,y) (((x) & 0xffu) ^ ((y) >> 8) | (0xab00u)) // bit ops
-typedef struct { uint16_t a; uint32_t b; } hdr_t; // packed header fields
-static inline uint32_t rot(uint32_t x, int n) { return (x << n) | (x >> (32 - n)); } // rotate
-`
-
-const javaPresetSample = `\
-// FQCN-heavy lines: generics, streams, method refs (no extra imports)
-java.util.List<java.util.Map<String, Integer>> rows = java.util.List.of(java.util.Map.of("a", 1), java.util.Map.of("b", 2));
-java.util.stream.Stream.of("x", "y").map(String::toUpperCase).filter(s -> !s.isEmpty()).forEach(System.out::println);
-`
-
-const pythonPresetSample = `\
-from __future__ import annotations  # postponed annotations
-from itertools import chain, groupby  # stdlib
-RE = r"(?x) ^\\s* (?P<name> [A-Za-z_]\\w* ) \\s* = \\s* (?P<val> .+ ) $ "  # verbose regex
-def windows(xs: list[int], n: int) -> list[list[int]]: return [xs[i : i + n] for i in range(0, len(xs), n)]  # slices
-`
-
-const goPresetSample = `\
-package main
-import "encoding/json"; import "fmt"; import "strings" // one line, three imports
-type Row struct { ID string \`json:"id"\`; Tags []string \`json:"tags,omitempty"\` } // struct tags
-func (r Row) Label() string { return fmt.Sprintf("%s [%s]", r.ID, strings.Join(r.Tags, ",")) } // Sprintf + Join
-var _ json.Marshaler = (*Row)(nil) // interface satisfaction
-`
-
-const diffPresetSample = `\
-  export const theme = {
--   accent: '#f47067',
-+   accent: '#2876db',
-    surface: '#ffffff',
-  }
-`
-
-export default function InstallBanner() {
+export default function InstallBanner({ children }: { children?: ReactNode }) {
   const [bannerTheme, setBannerTheme] = useState<'light' | 'dark'>('light')
-  const [activeLanguageSampleIndex, setActiveLanguageSampleIndex] =
-    useState<number | null>(null)
-  const [hasSpreadLanguageSamples, setHasSpreadLanguageSamples] =
-    useState(false)
-  const lastLanguageSampleHoverPoint = useRef<{ x: number; y: number } | null>(
-    null
-  )
-  const languageSampleGridRef = useRef<HTMLDivElement | null>(null)
   const syntaxThemeCtx = useContext(SyntaxThemeContext)
   const themeIndex = syntaxThemeCtx?.themeIndex ?? 0
   const plateColors =
@@ -126,16 +80,6 @@ ${formatPlateAsCssVars(darkPlate)}
   const darkCodeShVars = useMemo(() => plateToShVarMap(darkPlate), [darkPlate])
   const codeShVars = bannerTheme === 'light' ? lightCodeShVars : darkCodeShVars
 
-  const languagePresetSamples = useMemo(
-    () => [
-      { title: 'main.c', markup: highlight(cPresetSample, { lang: 'c' }) },
-      { title: 'main.go', markup: highlight(goPresetSample, { lang: 'go' }) },
-      { title: 'App.java', markup: highlight(javaPresetSample, { lang: 'java' }) },
-      { title: 'main.py', markup: highlight(pythonPresetSample, { lang: 'python' }) },
-    ],
-    []
-  )
-
   const presetByTitleMarkup = useMemo(
     () =>
       highlight(presetByTitleExample, {
@@ -153,27 +97,6 @@ ${formatPlateAsCssVars(darkPlate)}
       }),
     []
   )
-
-  const activateLanguageSampleFromPointer = (
-    index: number,
-    event: PointerEvent<HTMLDivElement>
-  ) => {
-    if (event.pointerType === 'touch') return
-
-    const point = { x: event.clientX, y: event.clientY }
-    const previousPoint = lastLanguageSampleHoverPoint.current
-
-    if (
-      previousPoint &&
-      previousPoint.x === point.x &&
-      previousPoint.y === point.y
-    ) {
-      return
-    }
-
-    lastLanguageSampleHoverPoint.current = point
-    setActiveLanguageSampleIndex(index)
-  }
 
   const activateThemeFromPointer = (
     theme: 'light' | 'dark',
@@ -194,37 +117,6 @@ ${formatPlateAsCssVars(darkPlate)}
     }
   }
 
-  useEffect(() => {
-    const grid = languageSampleGridRef.current
-    if (!grid) return
-
-    const prefersReducedMotion = window.matchMedia(
-      '(prefers-reduced-motion: reduce)'
-    )
-
-    if (prefersReducedMotion.matches || !('IntersectionObserver' in window)) {
-      setHasSpreadLanguageSamples(true)
-      return
-    }
-
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (!entry.isIntersecting) return
-
-        setHasSpreadLanguageSamples(true)
-        observer.disconnect()
-      },
-      {
-        rootMargin: '0px 0px -12% 0px',
-        threshold: 0.28,
-      }
-    )
-
-    observer.observe(grid)
-
-    return () => observer.disconnect()
-  }, [])
-
   return (
     <div
       className="install-banner"
@@ -233,7 +125,7 @@ ${formatPlateAsCssVars(darkPlate)}
     >
       <style>
         {`
-        .install-banner [data-codice-header] {
+        .install-banner__code [data-codice-header] {
           display: none;
         }
         `}
@@ -312,8 +204,9 @@ ${formatPlateAsCssVars(darkPlate)}
         <div className="install-banner__block">
           <h2>Languages</h2>
           <p>
-            Pass a canonical language name to <code>highlight</code>, or normalize a filename
-            extension with <code>sugar-high/lang</code>.
+            JavaScript works by default. Pass canonical names directly. <code>lang()</code> turns
+            aliases and extensions such as <code>py</code> and <code>yml</code> into
+            <code>python</code> and <code>yaml</code>.
           </p>
         </div>
         <div
@@ -325,61 +218,13 @@ ${formatPlateAsCssVars(darkPlate)}
           </Code>
           <CopyButton codeSnippet={presetByTitleExample} />
         </div>
-        <div
-          ref={languageSampleGridRef}
-          className={`install-banner__sample-grid${
-            hasSpreadLanguageSamples
-              ? ' install-banner__sample-grid--spread'
-              : ''
-          }`}
-        >
-          {languagePresetSamples.map((sample, index) => (
-            <div
-              key={sample.title}
-              className={`install-banner__code install-banner__code--sample${
-                activeLanguageSampleIndex === index
-                  ? ' install-banner__code--sample-active'
-                  : ''
-              }`}
-              style={codeShVars as CSSProperties}
-              role="button"
-              tabIndex={0}
-              aria-pressed={activeLanguageSampleIndex === index}
-              aria-label={`Bring ${sample.title} example to the front`}
-              onPointerMove={(event) =>
-                activateLanguageSampleFromPointer(index, event)
-              }
-              onPointerDownCapture={() => setActiveLanguageSampleIndex(index)}
-              onFocus={() => setActiveLanguageSampleIndex(index)}
-              onClick={() => setActiveLanguageSampleIndex(index)}
-              onKeyDown={(event) => {
-                if (event.key === 'Enter' || event.key === ' ') {
-                  event.preventDefault()
-                  setActiveLanguageSampleIndex(index)
-                }
-              }}
-            >
-              <Code title={sample.title} asMarkup preformatted>
-                {sample.markup}
-              </Code>
-            </div>
-          ))}
-        </div>
         <div className="install-banner__block">
-          <h2>Diff examples</h2>
+          <h2>Code block &amp; editor</h2>
           <p>
-            Diff and patch files use <code>lang: 'diff'</code> to mark added, removed, hunk, and
-            metadata lines.
+            Use the <Link href="/react">{`<Editor /> & <Code />`}</Link> to present or edit highlighted code.
           </p>
         </div>
-        <div
-          className="install-banner__code"
-          style={codeShVars as CSSProperties}
-        >
-          <Code title="theme.diff" asMarkup preformatted>
-            {highlight(diffPresetSample, { lang: 'diff' })}
-          </Code>
-        </div>
+        {children}
         <div className="install-banner__block">
           <h2>Usage with remark.js</h2>
           <p>

--- a/apps/docs/app/page.tsx
+++ b/apps/docs/app/page.tsx
@@ -17,8 +17,9 @@ export default function Page() {
 
       <SyntaxThemeProvider>
         <Carousel />
-        <LiveEditor />
-        <InstallBanner />
+        <InstallBanner>
+          <LiveEditor />
+        </InstallBanner>
       </SyntaxThemeProvider>
     </>
   )

--- a/apps/docs/app/product-page.css
+++ b/apps/docs/app/product-page.css
@@ -108,20 +108,18 @@
 }
 
 .product-section__head {
-  display: grid;
-  grid-template-columns: minmax(0, 0.7fr) minmax(0, 1.3fr);
-  gap: 36px;
+  display: block;
   margin-bottom: 24px;
-  align-items: start;
 }
 
 .product-section h2 {
-  margin: 0;
+  margin: 0 0 10px;
   font-size: 1.35rem;
   letter-spacing: -0.025em;
 }
 
 .product-section__head p {
+  max-width: 640px;
   margin: 0;
   color: var(--product-muted);
   line-height: 1.7;
@@ -150,7 +148,7 @@
   background: #f6f6f6;
   color: rgba(33, 33, 33, 0.34);
   font-family: var(--font-geist-mono), menlo, monospace;
-  font-size: 11px;
+  font-size: 14px;
 }
 
 .product-card__title {
@@ -166,23 +164,6 @@
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 18px;
-}
-
-.product-note {
-  padding: 22px;
-  border-radius: 10px;
-  background: var(--product-soft);
-}
-
-.product-note h3 {
-  margin-bottom: 8px;
-  font-size: 1rem;
-}
-
-.product-note p {
-  margin: 0;
-  color: var(--product-muted);
-  line-height: 1.6;
 }
 
 .product-code {
@@ -225,13 +206,8 @@
     gap: 12px;
   }
 
-  .product-section__head,
   .product-grid {
     grid-template-columns: 1fr;
-  }
-
-  .product-section__head {
-    gap: 10px;
   }
 
   .product-card__body {

--- a/apps/docs/app/product-page.css
+++ b/apps/docs/app/product-page.css
@@ -138,30 +138,22 @@
 .product-card:has(.react-demo),
 .product-card:has(.react-code-preview),
 .product-card:has(.remark-source) {
-  background: #343434;
+  background: #f6f6f6;
 }
 
 .product-card__bar {
   display: flex;
   align-items: center;
-  gap: 6px;
-  height: 38px;
-  padding: 0 14px;
-  background: var(--product-soft);
+  height: 34px;
+  padding: 0 4px;
+  background: white;
   color: var(--product-muted);
   font-family: var(--font-geist-mono), menlo, monospace;
   font-size: 11px;
 }
 
-.product-card__dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: #cbd3d9;
-}
-
 .product-card__title {
-  margin-left: 6px;
+  margin: 0;
 }
 
 .product-card__body {
@@ -193,23 +185,23 @@
 
 .product-code {
   --codice-code-padding: 18px;
-  --sh-class: #4ec9b0;
-  --sh-identifier: #9cdcfe;
-  --sh-sign: #d4d4d4;
-  --sh-property: #9cdcfe;
-  --sh-entity: #dcdcaa;
-  --sh-jsxliterals: #ff8c42;
-  --sh-string: #ce9178;
-  --sh-keyword: #569cd6;
-  --sh-comment: #6a9955;
+  --sh-class: #2d5e9d;
+  --sh-identifier: #354150;
+  --sh-sign: #8996a3;
+  --sh-property: #0550ae;
+  --sh-entity: #249a97;
+  --sh-jsxliterals: #6266d1;
+  --sh-string: #00a99a;
+  --sh-keyword: #f47067;
+  --sh-comment: #a19595;
   margin: 0;
-  background: #343434;
-  color: #d5d5d5;
+  background: #f6f6f6;
+  color: #354150;
 }
 
 .product-code [data-codice-header] {
-  background: #2b2b2b;
-  color: #aaa;
+  background: white;
+  color: var(--product-muted);
 }
 
 .product-code pre {

--- a/apps/docs/app/product-page.css
+++ b/apps/docs/app/product-page.css
@@ -144,16 +144,18 @@
 .product-card__bar {
   display: flex;
   align-items: center;
+  justify-content: center;
   height: 34px;
-  padding: 0 4px;
-  background: white;
-  color: var(--product-muted);
+  padding: 0 14px;
+  background: #f6f6f6;
+  color: rgba(33, 33, 33, 0.34);
   font-family: var(--font-geist-mono), menlo, monospace;
   font-size: 11px;
 }
 
 .product-card__title {
   margin: 0;
+  line-height: 1;
 }
 
 .product-card__body {
@@ -200,8 +202,8 @@
 }
 
 .product-code [data-codice-header] {
-  background: white;
-  color: var(--product-muted);
+  background: #f6f6f6;
+  color: rgba(33, 33, 33, 0.34);
 }
 
 .product-code pre {

--- a/apps/docs/app/product-page.css
+++ b/apps/docs/app/product-page.css
@@ -1,0 +1,246 @@
+.product-page {
+  --product-ink: #354150;
+  --product-muted: #788592;
+  --product-line: #dfe5e9;
+  --product-soft: #f5f8fa;
+  --product-accent: #f47067;
+  color: var(--product-ink);
+  min-height: 100vh;
+  padding: 20px 16px 80px;
+}
+
+.product-shell {
+  width: min(920px, 100%);
+  margin: 0 auto;
+}
+
+.product-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 44px;
+  margin-bottom: 72px;
+}
+
+.product-nav__brand {
+  color: var(--product-ink);
+  font-weight: 400;
+  text-decoration: none;
+}
+
+.product-nav__links {
+  display: flex;
+  gap: 18px;
+}
+
+.product-nav a {
+  color: var(--product-muted);
+  text-decoration: none;
+}
+
+.product-nav a:hover {
+  color: var(--product-ink);
+}
+
+.product-hero {
+  position: relative;
+  isolation: isolate;
+  max-width: 720px;
+  margin-bottom: 72px;
+}
+
+.product-hero::before {
+  content: '';
+  position: absolute;
+  z-index: -1;
+  width: 270px;
+  height: 270px;
+  top: -95px;
+  left: -100px;
+  border-radius: 50%;
+  background: radial-gradient(circle, color-mix(in srgb, var(--product-accent) 14%, transparent), transparent 70%);
+  pointer-events: none;
+}
+
+.product-eyebrow {
+  margin-bottom: 12px;
+  color: var(--product-accent);
+  font-family: var(--font-geist-mono), menlo, monospace;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.product-hero h1 {
+  margin: 0;
+  font-size: clamp(2.8rem, 8vw, 5rem);
+  line-height: 0.98;
+  letter-spacing: -0.065em;
+}
+
+.product-lede {
+  max-width: 620px;
+  margin: 24px 0 0;
+  color: var(--product-muted);
+  font-size: clamp(1.05rem, 2vw, 1.28rem);
+  line-height: 1.6;
+}
+
+.product-install {
+  display: inline-flex;
+  align-items: center;
+  min-height: 42px;
+  margin-top: 24px;
+  padding: 0 14px;
+  border: 0;
+  border-radius: 8px;
+  background: var(--product-soft);
+  color: var(--product-ink);
+}
+
+.product-install code {
+  font-size: 13px;
+}
+
+.product-section {
+  margin: 72px 0;
+}
+
+.product-section__head {
+  display: grid;
+  grid-template-columns: minmax(0, 0.7fr) minmax(0, 1.3fr);
+  gap: 36px;
+  margin-bottom: 24px;
+  align-items: start;
+}
+
+.product-section h2 {
+  margin: 0;
+  font-size: 1.35rem;
+  letter-spacing: -0.025em;
+}
+
+.product-section__head p {
+  margin: 0;
+  color: var(--product-muted);
+  line-height: 1.7;
+}
+
+.product-card {
+  overflow: hidden;
+  border-radius: 12px;
+  background: white;
+  box-shadow: 0 18px 55px rgba(53, 65, 80, 0.1);
+}
+
+.product-card:has(.product-code),
+.product-card:has(.react-demo),
+.product-card:has(.react-code-preview),
+.product-card:has(.remark-source) {
+  background: #343434;
+}
+
+.product-card__bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 38px;
+  padding: 0 14px;
+  background: var(--product-soft);
+  color: var(--product-muted);
+  font-family: var(--font-geist-mono), menlo, monospace;
+  font-size: 11px;
+}
+
+.product-card__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #cbd3d9;
+}
+
+.product-card__title {
+  margin-left: 6px;
+}
+
+.product-card__body {
+  padding: 20px;
+}
+
+.product-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.product-note {
+  padding: 22px;
+  border-radius: 10px;
+  background: var(--product-soft);
+}
+
+.product-note h3 {
+  margin-bottom: 8px;
+  font-size: 1rem;
+}
+
+.product-note p {
+  margin: 0;
+  color: var(--product-muted);
+  line-height: 1.6;
+}
+
+.product-code {
+  --codice-code-padding: 18px;
+  --sh-class: #4ec9b0;
+  --sh-identifier: #9cdcfe;
+  --sh-sign: #d4d4d4;
+  --sh-property: #9cdcfe;
+  --sh-entity: #dcdcaa;
+  --sh-jsxliterals: #ff8c42;
+  --sh-string: #ce9178;
+  --sh-keyword: #569cd6;
+  --sh-comment: #6a9955;
+  margin: 0;
+  background: #343434;
+  color: #d5d5d5;
+}
+
+.product-code [data-codice-header] {
+  background: #2b2b2b;
+  color: #aaa;
+}
+
+.product-code pre {
+  width: 100%;
+  margin: 0;
+  background: transparent;
+}
+
+.product-code .sh__line {
+  display: block;
+}
+
+@media (max-width: 680px) {
+  .product-nav {
+    margin-bottom: 48px;
+  }
+
+  .product-nav__links {
+    gap: 12px;
+  }
+
+  .product-section__head,
+  .product-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .product-section__head {
+    gap: 10px;
+  }
+
+  .product-card__body {
+    padding: 14px;
+  }
+}

--- a/apps/docs/app/react/page.css
+++ b/apps/docs/app/react/page.css
@@ -1,0 +1,148 @@
+.react-product {
+  --product-accent: #f47067;
+  --codice-caret-color: #354150;
+  --codice-title-color: #6f7b86;
+  --codice-control-color: #a8b1b8;
+  --codice-code-line-number-color: #a4adb5;
+  --codice-code-highlight-color: #fff0ee;
+  --sh-class: #2d5e9d;
+  --sh-identifier: #354150;
+  --sh-sign: #8996a3;
+  --sh-property: #0550ae;
+  --sh-entity: #249a97;
+  --sh-jsxliterals: #6266d1;
+  --sh-string: #00a99a;
+  --sh-keyword: #f47067;
+  --sh-comment: #a19595;
+}
+
+.react-demo__toolbar,
+.react-demo__status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: #788592;
+  font-size: 12px;
+}
+
+.react-demo__toolbar {
+  min-height: 42px;
+  padding: 0 16px;
+  background: #343434;
+  color: #aaa;
+}
+
+.react-demo__toolbar label {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  cursor: pointer;
+}
+
+.react-demo__toolbar input {
+  width: 13px;
+  height: 13px;
+  margin: 0;
+}
+
+.react-demo__editor {
+  --codice-caret-color: #d5efea;
+  --codice-title-color: rgba(221, 221, 221, 0.45);
+  --codice-control-color: #8d8989;
+  --codice-code-line-number-color: #858585;
+  --sh-class: #4ec9b0;
+  --sh-identifier: #9cdcfe;
+  --sh-sign: #d4d4d4;
+  --sh-property: #9cdcfe;
+  --sh-entity: #dcdcaa;
+  --sh-jsxliterals: #ff8c42;
+  --sh-string: #ce9178;
+  --sh-keyword: #569cd6;
+  --sh-comment: #6a9955;
+  min-height: 330px;
+  background: #3d3c3c;
+  color: #d5d5d5;
+}
+
+.react-demo__editor [data-codice-header] {
+  padding-top: 12px;
+}
+
+.react-demo__editor textarea,
+.react-demo__editor pre,
+.react-demo__editor code {
+  min-height: 260px;
+}
+
+.react-demo__status {
+  min-height: 38px;
+  padding: 0 16px;
+  background: #343434;
+  color: #aaa;
+}
+
+.react-code-preview {
+  --codice-code-padding: 18px 18px 22px;
+  --codice-title-color: rgba(221, 221, 221, 0.45);
+  --codice-control-color: #8d8989;
+  --codice-code-line-number-color: #858585;
+  --codice-code-highlight-color: #555;
+  --sh-class: #4ec9b0;
+  --sh-identifier: #9cdcfe;
+  --sh-sign: #d4d4d4;
+  --sh-property: #9cdcfe;
+  --sh-entity: #dcdcaa;
+  --sh-jsxliterals: #ff8c42;
+  --sh-string: #ce9178;
+  --sh-keyword: #569cd6;
+  --sh-comment: #6a9955;
+  background: #343434;
+  color: #d5d5d5;
+}
+
+.react-product .react-demo__editor [data-codice-header],
+.react-product .react-code-preview [data-codice-header] {
+  background: #343434;
+}
+
+.react-product .react-demo__editor [data-codice-title],
+.react-product .react-code-preview [data-codice-title] {
+  color: rgba(221, 221, 221, 0.45);
+}
+
+.react-product .sh__line {
+  display: block;
+}
+
+.react-product [data-highlight] {
+  background: #555;
+}
+
+.react-product .product-card:has(.product-code) .product-card__bar,
+.react-product .product-card:has(.react-demo) .product-card__bar,
+.react-product .product-card:has(.react-code-preview) .product-card__bar {
+  background: #2b2b2b;
+  color: #aaa;
+}
+
+.react-product .product-card:has(.product-code) .product-card__dot,
+.react-product .product-card:has(.react-demo) .product-card__dot,
+.react-product .product-card:has(.react-code-preview) .product-card__dot {
+  background: #666;
+}
+
+@media (max-width: 680px) {
+  .react-demo__editor {
+    min-height: 280px;
+  }
+
+  .react-demo__editor textarea,
+  .react-demo__editor pre,
+  .react-demo__editor code {
+    min-height: 220px;
+  }
+
+  .react-demo__status span:last-child {
+    display: none;
+  }
+}

--- a/apps/docs/app/react/page.css
+++ b/apps/docs/app/react/page.css
@@ -16,7 +16,6 @@
   --sh-comment: #a19595;
 }
 
-.react-demo__toolbar,
 .react-demo__status {
   display: flex;
   align-items: center;
@@ -25,21 +24,14 @@
   font-size: 12px;
 }
 
-.react-demo__toolbar {
-  min-height: 42px;
-  padding: 0 16px;
-  background: #343434;
-  color: #aaa;
-}
-
-.react-demo__toolbar label {
+.react-demo__status label {
   display: flex;
   align-items: center;
   gap: 7px;
   cursor: pointer;
 }
 
-.react-demo__toolbar input {
+.react-demo__status input {
   width: 13px;
   height: 13px;
   margin: 0;
@@ -62,10 +54,6 @@
   min-height: 330px;
   background: #3d3c3c;
   color: #d5d5d5;
-}
-
-.react-demo__editor [data-codice-header] {
-  padding-top: 12px;
 }
 
 .react-demo__editor textarea,
@@ -98,16 +86,6 @@
   --sh-comment: #6a9955;
   background: #343434;
   color: #d5d5d5;
-}
-
-.react-product .react-demo__editor [data-codice-header],
-.react-product .react-code-preview [data-codice-header] {
-  background: #343434;
-}
-
-.react-product .react-demo__editor [data-codice-title],
-.react-product .react-code-preview [data-codice-title] {
-  color: rgba(221, 221, 221, 0.45);
 }
 
 .react-product .sh__line {

--- a/apps/docs/app/react/page.css
+++ b/apps/docs/app/react/page.css
@@ -38,22 +38,11 @@
 }
 
 .react-demo__editor {
-  --codice-caret-color: #d5efea;
-  --codice-title-color: rgba(221, 221, 221, 0.45);
-  --codice-control-color: #8d8989;
-  --codice-code-line-number-color: #858585;
-  --sh-class: #4ec9b0;
-  --sh-identifier: #9cdcfe;
-  --sh-sign: #d4d4d4;
-  --sh-property: #9cdcfe;
-  --sh-entity: #dcdcaa;
-  --sh-jsxliterals: #ff8c42;
-  --sh-string: #ce9178;
-  --sh-keyword: #569cd6;
-  --sh-comment: #6a9955;
+  --codice-caret-color: #354150;
+  --codice-code-line-number-color: #a4a4a4;
   min-height: 330px;
-  background: #3d3c3c;
-  color: #d5d5d5;
+  background: #f6f6f6;
+  color: #354150;
 }
 
 .react-demo__editor textarea,
@@ -65,27 +54,16 @@
 .react-demo__status {
   min-height: 38px;
   padding: 0 16px;
-  background: #343434;
-  color: #aaa;
+  background: #eef2f4;
+  color: #788592;
 }
 
 .react-code-preview {
   --codice-code-padding: 18px 18px 22px;
-  --codice-title-color: rgba(221, 221, 221, 0.45);
-  --codice-control-color: #8d8989;
-  --codice-code-line-number-color: #858585;
-  --codice-code-highlight-color: #555;
-  --sh-class: #4ec9b0;
-  --sh-identifier: #9cdcfe;
-  --sh-sign: #d4d4d4;
-  --sh-property: #9cdcfe;
-  --sh-entity: #dcdcaa;
-  --sh-jsxliterals: #ff8c42;
-  --sh-string: #ce9178;
-  --sh-keyword: #569cd6;
-  --sh-comment: #6a9955;
-  background: #343434;
-  color: #d5d5d5;
+  --codice-code-line-number-color: #a4a4a4;
+  --codice-code-highlight-color: #dff1ff;
+  background: #f6f6f6;
+  color: #354150;
 }
 
 .react-product .sh__line {
@@ -93,20 +71,7 @@
 }
 
 .react-product [data-highlight] {
-  background: #555;
-}
-
-.react-product .product-card:has(.product-code) .product-card__bar,
-.react-product .product-card:has(.react-demo) .product-card__bar,
-.react-product .product-card:has(.react-code-preview) .product-card__bar {
-  background: #2b2b2b;
-  color: #aaa;
-}
-
-.react-product .product-card:has(.product-code) .product-card__dot,
-.react-product .product-card:has(.react-demo) .product-card__dot,
-.react-product .product-card:has(.react-code-preview) .product-card__dot {
-  background: #666;
+  background: #dff1ff;
 }
 
 @media (max-width: 680px) {

--- a/apps/docs/app/react/page.css
+++ b/apps/docs/app/react/page.css
@@ -58,12 +58,18 @@
   color: #788592;
 }
 
-.react-code-preview {
-  --codice-code-padding: 18px 18px 22px;
+.react-code-preview[data-codice-code] {
+  --codice-code-padding: 0px;
   --codice-code-line-number-color: #a4a4a4;
   --codice-code-highlight-color: #dff1ff;
+  padding: 0;
   background: #f6f6f6;
   color: #354150;
+}
+
+.react-code-preview .sh__line [data-codice-code-line-number] {
+  position: static;
+  vertical-align: baseline;
 }
 
 .react-product .sh__line {

--- a/apps/docs/app/react/page.tsx
+++ b/apps/docs/app/react/page.tsx
@@ -34,9 +34,6 @@ function Window({ title, children }: { title: string; children: React.ReactNode 
   return (
     <div className="product-card">
       <div className="product-card__bar">
-        <span className="product-card__dot" />
-        <span className="product-card__dot" />
-        <span className="product-card__dot" />
         <span className="product-card__title">{title}</span>
       </div>
       {children}

--- a/apps/docs/app/react/page.tsx
+++ b/apps/docs/app/react/page.tsx
@@ -1,0 +1,121 @@
+import { Code } from '@sugar-high/react/code'
+import Link from 'next/link'
+import { ReactDemo } from './react-demo'
+import '../product-page.css'
+import './page.css'
+
+const editorCode = `import { Editor } from '@sugar-high/react'
+
+<Editor
+  lang="typescript"
+  title="app.tsx"
+  value={code}
+  onChange={setCode}
+/>`
+
+const codeBlockCode = `import { Code } from '@sugar-high/react/code'
+
+<Code
+  lang="python"
+  title="main.py"
+  lineNumbers
+  highlightLines={[2]}
+>
+  {source}
+</Code>`
+
+const pythonCode = `def greet(name):
+    message = f"Hello, {name}!"
+    return message
+
+print(greet("Sugar High"))`
+
+function Window({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="product-card">
+      <div className="product-card__bar">
+        <span className="product-card__dot" />
+        <span className="product-card__dot" />
+        <span className="product-card__dot" />
+        <span className="product-card__title">{title}</span>
+      </div>
+      {children}
+    </div>
+  )
+}
+
+export default function ReactPage() {
+  return (
+    <div className="product-page react-product">
+      <div className="product-shell">
+        <nav className="product-nav" aria-label="Product navigation">
+          <Link className="product-nav__brand" href="/">Sugar High</Link>
+          <div className="product-nav__links">
+            <Link href="/remark">Remark</Link>
+            <a href="https://github.com/huozhi/sugar-high/tree/main/packages/react">Source ↗</a>
+          </div>
+        </nav>
+
+        <header className="product-hero">
+          <div className="product-eyebrow">React components</div>
+          <h1>Code that feels<br />at home.</h1>
+          <p className="product-lede">
+            The Codice editor and code block now live next to Sugar High: lightweight React
+            primitives for presenting and editing highlighted code.
+          </p>
+          <div className="product-install"><code>npm install @sugar-high/react sugar-high</code></div>
+        </header>
+
+        <section className="product-section">
+          <div className="product-section__head">
+            <h2>Edit in place.</h2>
+            <p>
+              A controlled editor with highlighted text, editable filenames, line numbers, and the
+              same markup contract as the static code component.
+            </p>
+          </div>
+          <Window title="counter.tsx"><ReactDemo /></Window>
+        </section>
+
+        <section className="product-section">
+          <div className="product-section__head">
+            <h2>Two primitives,<br />one visual system.</h2>
+            <p>Use the editor for interaction and the code block for presentation. Both resolve languages through Sugar High.</p>
+          </div>
+          <div className="product-grid react-api-grid">
+            <Window title="editor.tsx">
+              <Code className="product-code" lang="typescript">{editorCode}</Code>
+            </Window>
+            <Window title="code-block.tsx">
+              <Code className="product-code" lang="typescript">{codeBlockCode}</Code>
+            </Window>
+          </div>
+        </section>
+
+        <section className="product-section">
+          <div className="product-section__head">
+            <h2>Presentation included.</h2>
+            <p>Titles, controls, highlighted lines, and line numbers are opt-in props—not a separate rendering layer.</p>
+          </div>
+          <Window title="main.py">
+            <Code
+              className="react-code-preview"
+              lang="python"
+              title="main.py"
+              controls
+              lineNumbers
+              highlightLines={[2]}
+            >
+              {pythonCode}
+            </Code>
+          </Window>
+        </section>
+
+        <section className="product-grid" aria-label="React package features">
+          <div className="product-note"><h3>Small by composition</h3><p>Bring the React surface you need while Sugar High remains the highlighting engine underneath.</p></div>
+          <div className="product-note"><h3>Migration without a rewrite</h3><p>Existing Codice data attributes and CSS variables remain available for current themes and integrations.</p></div>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/apps/docs/app/react/page.tsx
+++ b/apps/docs/app/react/page.tsx
@@ -4,26 +4,6 @@ import { ReactDemo } from './react-demo'
 import '../product-page.css'
 import './page.css'
 
-const editorCode = `import { Editor } from '@sugar-high/react'
-
-<Editor
-  lang="typescript"
-  title="app.tsx"
-  value={code}
-  onChange={setCode}
-/>`
-
-const codeBlockCode = `import { Code } from '@sugar-high/react/code'
-
-<Code
-  lang="python"
-  title="main.py"
-  lineNumbers
-  highlightLines={[2]}
->
-  {source}
-</Code>`
-
 const pythonCode = `def greet(name):
     message = f"Hello, {name}!"
     return message
@@ -65,7 +45,7 @@ export default function ReactPage() {
 
         <section className="product-section">
           <div className="product-section__head">
-            <h2>Edit in place.</h2>
+            <h2>{'<Editor />'}</h2>
             <p>
               A controlled editor with highlighted text, editable filenames, line numbers, and the
               same markup contract as the static code component.
@@ -76,23 +56,8 @@ export default function ReactPage() {
 
         <section className="product-section">
           <div className="product-section__head">
-            <h2>Two primitives,<br />one visual system.</h2>
-            <p>Use the editor for interaction and the code block for presentation. Both resolve languages through Sugar High.</p>
-          </div>
-          <div className="product-grid react-api-grid">
-            <Window title="editor.tsx">
-              <Code className="product-code" lang="typescript">{editorCode}</Code>
-            </Window>
-            <Window title="code-block.tsx">
-              <Code className="product-code" lang="typescript">{codeBlockCode}</Code>
-            </Window>
-          </div>
-        </section>
-
-        <section className="product-section">
-          <div className="product-section__head">
-            <h2>Presentation included.</h2>
-            <p>Titles, controls, highlighted lines, and line numbers are opt-in props—not a separate rendering layer.</p>
+            <h2>{'<Code />'}</h2>
+            <p>A lightweight presentation block with optional filenames, highlighted lines, and line numbers.</p>
           </div>
           <Window title="main.py">
             <Code

--- a/apps/docs/app/react/page.tsx
+++ b/apps/docs/app/react/page.tsx
@@ -101,8 +101,6 @@ export default function ReactPage() {
             <Code
               className="react-code-preview"
               lang="python"
-              title="main.py"
-              controls
               lineNumbers
               highlightLines={[2]}
             >

--- a/apps/docs/app/react/page.tsx
+++ b/apps/docs/app/react/page.tsx
@@ -4,11 +4,29 @@ import { ReactDemo } from './react-demo'
 import '../product-page.css'
 import './page.css'
 
-const pythonCode = `def greet(name):
-    message = f"Hello, {name}!"
-    return message
+const codeBlockExample = `import { Code } from '@sugar-high/react/code'
+import { highlight } from 'sugar-high'
 
-print(greet("Sugar High"))`
+function renderMarkup() {
+  const code = "return 'long live sugar-high'"
+  return highlight(code)
+}
+
+const markup = renderMarkup()
+console.log(markup)
+
+render(
+  <div>
+    <Code
+      controls
+      title="app/index.js"
+      lineNumbers
+      highlightLines={[1, [14, 19]]}
+    >
+      {'<div>Hello World</div>'}
+    </Code>
+  </div>
+)`
 
 function Window({ title, children }: { title: string; children: React.ReactNode }) {
   return (
@@ -34,11 +52,10 @@ export default function ReactPage() {
         </nav>
 
         <header className="product-hero">
-          <div className="product-eyebrow">React components</div>
-          <h1>Code that feels<br />at home.</h1>
+          <div className="product-eyebrow">@sugar-high/react</div>
+          <h1>Code editor & block</h1>
           <p className="product-lede">
-            The Codice editor and code block now live next to Sugar High: lightweight React
-            primitives for presenting and editing highlighted code.
+            Edit and present highlighted code with two lightweight React components.
           </p>
           <div className="product-install"><code>npm install @sugar-high/react sugar-high</code></div>
         </header>
@@ -46,35 +63,29 @@ export default function ReactPage() {
         <section className="product-section">
           <div className="product-section__head">
             <h2>{'<Editor />'}</h2>
-            <p>
-              A controlled editor with highlighted text, editable filenames, line numbers, and the
-              same markup contract as the static code component.
-            </p>
+            <p>A controlled, highlighted editor with optional line numbers.</p>
           </div>
-          <Window title="counter.tsx"><ReactDemo /></Window>
+          <Window title="editor-example.tsx"><ReactDemo /></Window>
         </section>
 
         <section className="product-section">
           <div className="product-section__head">
             <h2>{'<Code />'}</h2>
-            <p>A lightweight presentation block with optional filenames, highlighted lines, and line numbers.</p>
+            <p>Present code with optional line numbers and marked lines.</p>
           </div>
-          <Window title="main.py">
+          <Window title="code-example.tsx">
             <Code
               className="react-code-preview"
-              lang="python"
+              lang="typescript"
               lineNumbers
-              highlightLines={[2]}
+              padding="0"
+              highlightLines={[1, [14, 19]]}
             >
-              {pythonCode}
+              {codeBlockExample}
             </Code>
           </Window>
         </section>
 
-        <section className="product-grid" aria-label="React package features">
-          <div className="product-note"><h3>Small by composition</h3><p>Bring the React surface you need while Sugar High remains the highlighting engine underneath.</p></div>
-          <div className="product-note"><h3>Migration without a rewrite</h3><p>Existing Codice data attributes and CSS variables remain available for current themes and integrations.</p></div>
-        </section>
       </div>
     </div>
   )

--- a/apps/docs/app/react/react-demo.tsx
+++ b/apps/docs/app/react/react-demo.tsx
@@ -17,13 +17,20 @@ export function Counter() {
 
 export function ReactDemo() {
   const [code, setCode] = useState(initialCode)
-  const [title, setTitle] = useState('counter.tsx')
   const [lineNumbers, setLineNumbers] = useState(true)
 
   return (
     <div className="react-demo">
-      <div className="react-demo__toolbar">
-        <span>Live editor</span>
+      <Editor
+        className="react-demo__editor"
+        lang="typescript"
+        title={null}
+        controls={false}
+        value={code}
+        lineNumbers={lineNumbers}
+        onChange={setCode}
+      />
+      <div className="react-demo__status">
         <label>
           <input
             type="checkbox"
@@ -32,18 +39,6 @@ export function ReactDemo() {
           />
           line numbers
         </label>
-      </div>
-      <Editor
-        className="react-demo__editor"
-        lang="typescript"
-        title={title}
-        value={code}
-        lineNumbers={lineNumbers}
-        onChange={setCode}
-        onChangeTitle={setTitle}
-      />
-      <div className="react-demo__status">
-        <span>{title}</span>
         <span>{code.split('\n').length} lines · {code.length} characters</span>
       </div>
     </div>

--- a/apps/docs/app/react/react-demo.tsx
+++ b/apps/docs/app/react/react-demo.tsx
@@ -4,14 +4,21 @@ import { useState } from 'react'
 import { Editor } from '@sugar-high/react'
 
 const initialCode = `import { useState } from 'react'
+import { Editor } from '@sugar-high/react'
 
-export function Counter() {
-  const [count, setCount] = useState(0)
+const defaultText = 'console.log("hello world")'
+
+export default function Page() {
+  const [code, setCode] = useState(defaultText)
+  const [title, setTitle] = useState('index.js')
 
   return (
-    <button onClick={() => setCount(count + 1)}>
-      Count: {count}
-    </button>
+    <Editor
+      value={code}
+      title={title}
+      onChange={(text) => setCode(text)}
+      onChangeTitle={(title) => setTitle(title)}
+    />
   )
 }`
 

--- a/apps/docs/app/react/react-demo.tsx
+++ b/apps/docs/app/react/react-demo.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { useState } from 'react'
+import { Editor } from '@sugar-high/react'
+
+const initialCode = `import { useState } from 'react'
+
+export function Counter() {
+  const [count, setCount] = useState(0)
+
+  return (
+    <button onClick={() => setCount(count + 1)}>
+      Count: {count}
+    </button>
+  )
+}`
+
+export function ReactDemo() {
+  const [code, setCode] = useState(initialCode)
+  const [title, setTitle] = useState('counter.tsx')
+  const [lineNumbers, setLineNumbers] = useState(true)
+
+  return (
+    <div className="react-demo">
+      <div className="react-demo__toolbar">
+        <span>Live editor</span>
+        <label>
+          <input
+            type="checkbox"
+            checked={lineNumbers}
+            onChange={(event) => setLineNumbers(event.target.checked)}
+          />
+          line numbers
+        </label>
+      </div>
+      <Editor
+        className="react-demo__editor"
+        lang="typescript"
+        title={title}
+        value={code}
+        lineNumbers={lineNumbers}
+        onChange={setCode}
+        onChangeTitle={setTitle}
+      />
+      <div className="react-demo__status">
+        <span>{title}</span>
+        <span>{code.split('\n').length} lines · {code.length} characters</span>
+      </div>
+    </div>
+  )
+}

--- a/apps/docs/app/remark/page.css
+++ b/apps/docs/app/remark/page.css
@@ -1,65 +1,86 @@
-.remark-page {
-  font-family: var(--font-geist-sans), system-ui, -apple-system,
-    BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial, Noto Sans,
-    sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol,
-    Noto Color Emoji;
-  font-feature-settings: 'liga', 'clig', 'calt';
-  
-  padding: 2rem;
-  background-color: #f7fcfc;
-
-  /* theme */
+.remark-product {
+  --product-accent: #2876db;
   --sh-class: #2d5e9d;
   --sh-identifier: #354150;
   --sh-sign: #8996a3;
   --sh-property: #0550ae;
-  --sh-entity: #9eb8d6;
+  --sh-entity: #249a97;
   --sh-jsxliterals: #6266d1;
   --sh-string: #73747c;
   --sh-keyword: #2876db;
   --sh-comment: #a19595;
-  /* codice */
-  --codice-code-padding: 0;
 }
 
-.remark-page main {
-  width: 600px;
+.remark-source,
+.remark-preview {
+  min-height: 300px;
+  padding: 22px;
 }
 
-.remark-page a {
-  color: #888;
-}
-.remark-page a:hover {
-  color: #333;
+.remark-source {
+  --sh-class: #4ec9b0;
+  --sh-identifier: #9cdcfe;
+  --sh-sign: #d4d4d4;
+  --sh-string: #ce9178;
+  --sh-keyword: #569cd6;
+  --sh-comment: #6a9955;
+  background: #343434;
+  color: #d5d5d5;
 }
 
-.remark-page pre {
-  background-color: #ffffff;
-}
-
-.code {
-  margin-top: 1rem;
-  margin-bottom: 1rem;
-  width: 100%;
-}
-div[data-codice-editor-header="true"] {
-  background-color: #d6e1eb;
-  padding: 4px 6px;
-  color: #507a99;
+.remark-source pre {
   margin: 0;
+  padding: 0;
+  white-space: pre-wrap;
 }
-/* Override */
-[data-codice-code] pre,
-[data-codice-code] code {
-  width: 100%;
+
+.remark-preview h1 {
+  margin: 0 0 14px;
+  color: #354150;
+  font-size: 1.55rem;
 }
-.code[data-codice-code="true"] pre {
-  padding: 8px 0;
+
+.remark-preview p {
+  color: #788592;
 }
-.sh__line {
+
+.remark-preview pre {
   display: block;
-  padding: 0 0.5em;
+  margin: 22px 0 0;
+  padding: 16px;
+  border-radius: 7px;
+  background: #f5f8fa;
+  white-space: pre-wrap;
 }
-.sh__line--highlighted {
-  background-color: #dff1ff;
+
+.remark-preview .sh__line,
+.remark-product .product-code .sh__line {
+  display: block;
+  padding: 0;
+}
+
+.remark-product .product-code[data-codice-code] {
+  border-radius: 0;
+}
+
+.remark-product .product-card .product-code [data-codice-header] {
+  display: none;
+}
+
+.remark-product .product-card:has(.remark-source) .product-card__bar,
+.remark-product .product-card:has(.product-code) .product-card__bar {
+  background: #2b2b2b;
+  color: #aaa;
+}
+
+.remark-product .product-card:has(.remark-source) .product-card__dot,
+.remark-product .product-card:has(.product-code) .product-card__dot {
+  background: #666;
+}
+
+@media (max-width: 680px) {
+  .remark-source,
+  .remark-preview {
+    min-height: 240px;
+  }
 }

--- a/apps/docs/app/remark/page.css
+++ b/apps/docs/app/remark/page.css
@@ -18,14 +18,8 @@
 }
 
 .remark-source {
-  --sh-class: #4ec9b0;
-  --sh-identifier: #9cdcfe;
-  --sh-sign: #d4d4d4;
-  --sh-string: #ce9178;
-  --sh-keyword: #569cd6;
-  --sh-comment: #6a9955;
-  background: #343434;
-  color: #d5d5d5;
+  background: #f6f6f6;
+  color: #62707e;
 }
 
 .remark-source pre {
@@ -65,17 +59,6 @@
 
 .remark-product .product-card .product-code [data-codice-header] {
   display: none;
-}
-
-.remark-product .product-card:has(.remark-source) .product-card__bar,
-.remark-product .product-card:has(.product-code) .product-card__bar {
-  background: #2b2b2b;
-  color: #aaa;
-}
-
-.remark-product .product-card:has(.remark-source) .product-card__dot,
-.remark-product .product-card:has(.product-code) .product-card__dot {
-  background: #666;
 }
 
 @media (max-width: 680px) {

--- a/apps/docs/app/remark/page.tsx
+++ b/apps/docs/app/remark/page.tsx
@@ -64,11 +64,10 @@ export default function RemarkPage() {
         </nav>
 
         <header className="product-hero">
-          <div className="product-eyebrow">Markdown integration</div>
-          <h1>Remark,<br />with more color.</h1>
+          <div className="product-eyebrow">@sugar-high/remark</div>
+          <h1>Remark plugin.</h1>
           <p className="product-lede">
-            A small Remark plugin that turns fenced code blocks into Sugar High markup—without a
-            runtime highlighter in the browser.
+            Highlight fenced code blocks with Sugar High during your Markdown build.
           </p>
           <div className="product-install"><code>npm install @sugar-high/remark</code></div>
         </header>
@@ -76,10 +75,7 @@ export default function RemarkPage() {
         <section className="product-section">
           <div className="product-section__head">
             <h2>Markdown in.<br />Highlighted HTML out.</h2>
-            <p>
-              Keep authoring ordinary fenced code. Language aliases are normalized and line metadata
-              stays available to the generated markup.
-            </p>
+            <p>Transform fenced code into highlighted HTML.</p>
           </div>
           <div className="product-grid remark-demo-grid">
             <Window title="readme.md"><div className="remark-source"><pre>{previewMarkdown}</pre></div></Window>
@@ -90,7 +86,7 @@ export default function RemarkPage() {
         <section className="product-section">
           <div className="product-section__head">
             <h2>One plugin.</h2>
-            <p>Place it before your HTML compiler. The output uses the same semantic token classes as Sugar High.</p>
+            <p>Add it before your HTML compiler.</p>
           </div>
           <Window title="remark-plugin.js">
             <Code className="product-code" title="remark-plugin.js" lang="javascript">{usageCode}</Code>
@@ -100,7 +96,7 @@ export default function RemarkPage() {
         <section className="product-section">
           <div className="product-section__head">
             <h2>Across languages.</h2>
-            <p>The plugin delegates language selection to Sugar High, keeping the integration thin.</p>
+            <p>Use every language supported by Sugar High.</p>
           </div>
           <div className="product-grid">
             <Window title="script.js"><CodeExample filename="script.js" code={jsCode} /></Window>
@@ -108,10 +104,6 @@ export default function RemarkPage() {
           </div>
         </section>
 
-        <section className="product-grid" aria-label="Remark features">
-          <div className="product-note"><h3>Server friendly</h3><p>Generate HTML during your existing Markdown build with no client-side runtime.</p></div>
-          <div className="product-note"><h3>Style it once</h3><p>Reuse Sugar High token classes, CSS variables, and your existing code presentation.</p></div>
-        </section>
       </div>
     </div>
   )

--- a/apps/docs/app/remark/page.tsx
+++ b/apps/docs/app/remark/page.tsx
@@ -30,9 +30,6 @@ function Window({ title, children }: { title: string; children: React.ReactNode 
   return (
     <div className="product-card">
       <div className="product-card__bar">
-        <span className="product-card__dot" />
-        <span className="product-card__dot" />
-        <span className="product-card__dot" />
         <span className="product-card__title">{title}</span>
       </div>
       {children}

--- a/apps/docs/app/remark/page.tsx
+++ b/apps/docs/app/remark/page.tsx
@@ -1,88 +1,121 @@
+import { Code } from '@sugar-high/react'
+import Link from 'next/link'
 import { renderMarkdown } from './markdown'
 import { code as jsCode } from './languages/javascript'
-import { code as cssCode } from './languages/css'
-import { code as htmlCode } from './languages/html'
-import { code as pythonCode } from './languages/python'
 import { code as rustCode } from './languages/rust'
-import { Code } from '@sugar-high/react'
 import './page.css'
-import Link from 'next/link'
+import '../product-page.css'
 
-const usageCode = `\
-\`\`\`javascript {2,9}
-import { remark } from 'remark'
+const usageCode = `import { remark } from 'remark'
 import { highlight } from '@sugar-high/remark'
 import html from 'remark-html'
-import gfm from 'remark-gfm'
 
-async function renderMarkdown(input) {
-  const markdown = await remark()
-    .use(gfm)
-    .use(highlight)
-    .use(html, { sanitize: false })
-    .process(input)
+const result = await remark()
+  .use(highlight)
+  .use(html, { sanitize: false })
+  .process(markdown)
 
-  return markdown.toString()
-}
+return result.toString()`
 
-export default async Preview({ markdown }) {
-  const html = await renderMarkdown(markdown)
+const previewMarkdown = `# Built for Markdown
+
+Sugar High turns fenced code into lightweight, highlighted HTML.
+
+\`\`\`typescript
+const message = 'Small API, bright code'
+console.log(message)
+\`\`\``
+
+function Window({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div dangerouslySetInnerHTML={{ __html: html }} /> 
+    <div className="product-card">
+      <div className="product-card__bar">
+        <span className="product-card__dot" />
+        <span className="product-card__dot" />
+        <span className="product-card__dot" />
+        <span className="product-card__title">{title}</span>
+      </div>
+      {children}
+    </div>
   )
 }
-\`\`\`
-`
 
-async function CodeExample({
-  filename,
-  code,
-}: {
-  filename: string
-  code: string
-}) {
+async function MarkdownPreview() {
+  const html = await renderMarkdown(previewMarkdown)
+  return <div className="remark-preview" dangerouslySetInnerHTML={{ __html: html }} />
+}
+
+async function CodeExample({ filename, code }: { filename: string; code: string }) {
   const html = await renderMarkdown(code)
   return (
-    <Code className="code" title={filename} preformatted={false} asMarkup>
+    <Code className="product-code" title={filename} preformatted={false} asMarkup>
       {html}
     </Code>
   )
 }
 
-export default async function RemarkPage() {
+export default function RemarkPage() {
   return (
-    <div className="remark-page">
-      <main>
-        <h1>Remark Sugar High</h1>
-        
-        <p>
-          Use{' '}
-          <Link href="/">
-            Sugar High Syntax Highlighting 
-          </Link> with Remark Plugin.{' '}
-          <a href="https://github.com/huozhi/sugar-high/tree/main/packages/remark" target="_blank">
-            Source Code ↗
-          </a>
-        </p>
-        
-        <h2>Usage</h2>
-        <h3>Install</h3>
-        <pre>
-          <code>{`npm install remark remark-html remark-gfm @sugar-high/remark`}</code>
-        </pre>
+    <div className="product-page remark-product">
+      <div className="product-shell">
+        <nav className="product-nav" aria-label="Product navigation">
+          <Link className="product-nav__brand" href="/">Sugar High</Link>
+          <div className="product-nav__links">
+            <Link href="/react">React</Link>
+            <a href="https://github.com/huozhi/sugar-high/tree/main/packages/remark">Source ↗</a>
+          </div>
+        </nav>
 
-        <h3>API</h3>
+        <header className="product-hero">
+          <div className="product-eyebrow">Markdown integration</div>
+          <h1>Remark,<br />with more color.</h1>
+          <p className="product-lede">
+            A small Remark plugin that turns fenced code blocks into Sugar High markup—without a
+            runtime highlighter in the browser.
+          </p>
+          <div className="product-install"><code>npm install @sugar-high/remark</code></div>
+        </header>
 
-        <CodeExample filename="remark-plugin.js" code={usageCode} />
+        <section className="product-section">
+          <div className="product-section__head">
+            <h2>Markdown in.<br />Highlighted HTML out.</h2>
+            <p>
+              Keep authoring ordinary fenced code. Language aliases are normalized and line metadata
+              stays available to the generated markup.
+            </p>
+          </div>
+          <div className="product-grid remark-demo-grid">
+            <Window title="readme.md"><div className="remark-source"><pre>{previewMarkdown}</pre></div></Window>
+            <Window title="preview.html"><MarkdownPreview /></Window>
+          </div>
+        </section>
 
-        <h2>Examples</h2>
+        <section className="product-section">
+          <div className="product-section__head">
+            <h2>One plugin.</h2>
+            <p>Place it before your HTML compiler. The output uses the same semantic token classes as Sugar High.</p>
+          </div>
+          <Window title="remark-plugin.js">
+            <Code className="product-code" title="remark-plugin.js" lang="javascript">{usageCode}</Code>
+          </Window>
+        </section>
 
-        <CodeExample filename="script.js" code={jsCode} />
-        <CodeExample filename="mod.rs" code={rustCode} />
-        <CodeExample filename="print.py" code={pythonCode} />
-        <CodeExample filename="styles.css" code={cssCode} />
-        <CodeExample filename="index.html" code={htmlCode} />
-      </main>
+        <section className="product-section">
+          <div className="product-section__head">
+            <h2>Across languages.</h2>
+            <p>The plugin delegates language selection to Sugar High, keeping the integration thin.</p>
+          </div>
+          <div className="product-grid">
+            <Window title="script.js"><CodeExample filename="script.js" code={jsCode} /></Window>
+            <Window title="mod.rs"><CodeExample filename="mod.rs" code={rustCode} /></Window>
+          </div>
+        </section>
+
+        <section className="product-grid" aria-label="Remark features">
+          <div className="product-note"><h3>Server friendly</h3><p>Generate HTML during your existing Markdown build with no client-side runtime.</p></div>
+          <div className="product-note"><h3>Style it once</h3><p>Reuse Sugar High token classes, CSS variables, and your existing code presentation.</p></div>
+        </section>
+      </div>
     </div>
   )
 }

--- a/apps/docs/app/styles.css
+++ b/apps/docs/app/styles.css
@@ -53,7 +53,7 @@ a:hover {
 /* Showcase band — a bit narrower than the old 1200px layout */
 .container-showcase {
   max-width: min(900px, 94vw);
-  padding: 0 16px 40px;
+  padding: 16px;
   margin-left: auto;
   margin-right: auto;
   box-sizing: border-box;
@@ -136,7 +136,7 @@ input[type='checkbox']:checked {
   width: 100%;
   max-width: 100%;
   margin: 2rem auto 0;
-  padding: 2rem 12px 2.5rem;
+  padding: 2rem 12px 0rem;
   box-sizing: border-box;
   overflow: visible;
   min-height: calc(var(--showcase-preview-max-h) + 150px);

--- a/packages/react/src/editor/editor.tsx
+++ b/packages/react/src/editor/editor.tsx
@@ -41,7 +41,7 @@ export const Editor = forwardRef(function Editor(
   } & {
     fontSize?: string | number
     fontFamily?: string
-  } & React.HTMLAttributes<HTMLDivElement>,
+  } & Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'>,
   ref: React.Ref<HTMLDivElement>
 ) {
   const [code, setCode] = useState(value)


### PR DESCRIPTION
## Summary

- redesign `/remark` in the Sugar High homepage visual language with a Markdown-to-HTML preview, focused plugin usage, and language examples
- add `/react` as the new home for the migrated Codice editor and code block components
- share a responsive product-page system across both routes
- use Codice-inspired dark code canvases, soft shadows, and borderless supporting surfaces
- fix the React editor prop type so its string `onChange` no longer intersects the native div event handler

The React page includes a live controlled editor and side-by-side API examples. The Remark page keeps server-rendered examples while presenting the integration as part of the same product family.