### PR TITLE
Redesign the v2 highlighting API

### DIFF
--- a/apps/docs/app/components/install-banner.tsx
+++ b/apps/docs/app/components/install-banner.tsx
@@ -83,8 +83,9 @@ ${formatPlateAsCssVars(darkPlate)}
   const presetByTitleMarkup = useMemo(
     () =>
       highlight(presetByTitleExample, {
-        lineClassName: (_line, index) =>
-          index === 1 ? 'sh__line--highlighted' : undefined,
+        markLine: (line) => {
+          if (line.index === 1) line.className += ' sh__line--highlighted'
+        },
       }),
     []
   )
@@ -92,8 +93,11 @@ ${formatPlateAsCssVars(darkPlate)}
   const lineHighlightMarkup = useMemo(
     () =>
       highlight(lineHighlightCss, {
-        lineClassName: (_line, index) =>
-          index === 0 || index === 1 ? 'sh__line--highlighted' : undefined,
+        markLine: (line) => {
+          if (line.index === 0 || line.index === 1) {
+            line.className += ' sh__line--highlighted'
+          }
+        },
       }),
     []
   )

--- a/docs/API.md
+++ b/docs/API.md
@@ -8,7 +8,7 @@ The default export path includes the built-in language registry. JavaScript is u
 omitted.
 
 ```js
-import { highlight, tokenize, generate } from 'sugar-high'
+import { highlight } from 'sugar-high'
 
 highlight('const ready = true')
 highlight('print("hi")', { lang: 'python' })
@@ -19,15 +19,18 @@ names.
 
 ### `sugar-high/core`
 
-The core export contains the tokenizer and generator without the built-in language registry. Pass
-tokenizer configuration rather than a language name.
+The core export separates syntax parsing from HTML rendering and does not include the built-in
+language registry. Pass tokenizer configuration to `parse()` and display options to `render()`.
 
 ```js
-import { highlight } from 'sugar-high/core'
+import { parse, render } from 'sugar-high/core'
 
-highlight('select * from users', {
+const parsed = parse('select * from users', {
   keywords: new Set(['select', 'from', 'where']),
-  comment: /--.*$/gm,
+})
+
+const html = render(parsed, {
+  cx: { keyword: 'font-bold' },
 })
 ```
 
@@ -95,14 +98,11 @@ includes TSX, JSON includes JSONC comments, Shell includes sh/Bash/Zsh, and HCL 
 ```ts
 type HighlightOptions = {
   lang?: LanguageName
-  lineClassName?: (line: string, index: number) => string | null | undefined
   cx?: Partial<Record<TokenType, string>>
   mark?: (token: MarkToken) => void
+  markLine?: (line: MarkLine) => void
 }
 ```
-
-The default package also accepts the lower-level tokenizer configuration documented by the
-`sugar-high/core` types.
 
 ### `cx`
 
@@ -135,13 +135,16 @@ highlight(source, {
 
 ## Highlighted lines
 
-The string highlighter exposes line styling through `lineClassName`. The callback receives the
-source line and its zero-based index:
+Use `markLine` to mutate a generated line before rendering. It follows the same void-returning
+model as `mark`; `line.index` is zero-based.
 
 ```js
 highlight(source, {
-  lineClassName(_line, index) {
-    return index === 1 ? 'sh__line--highlighted' : undefined
+  markLine(line) {
+    if (line.index === 1) {
+      line.className += ' sh__line--highlighted'
+      line.properties['data-highlight'] = true
+    }
   },
 })
 ```
@@ -171,13 +174,29 @@ The Remark plugin reads the same one-based ranges from fenced-code metadata such
 
 ### `highlight(code, options?)`
 
-Tokenizes code and returns highlighted HTML.
+Selects a built-in language, parses the source with core, and returns highlighted HTML. This is the
+only function most applications need.
 
-### `tokenize(code, options?)`
+### `parse(code, config?)`
 
-Returns Sugar High's compact token tuples.
+Core API. Returns structured source data containing lines and semantic tokens. Parsing accepts
+tokenizer configuration and does not produce HTML.
 
-### `generate(tokens, options?)`
+```ts
+type ParsedCode = {
+  value: string
+  lines: Array<{
+    index: number
+    value: string
+    tokens: Array<{ type: TokenType; value: string }>
+    className: string
+    style: Record<string, string | number>
+    properties: Record<string, string | number | boolean>
+  }>
+}
+```
 
-Converts token tuples into line and token nodes. Generation accepts `lineClassName`, `cx`, and
-`mark` options.
+### `render(parsed, options?)`
+
+Core API. Converts parsed code to HTML and accepts only display customization: `cx`, `mark`, and
+`markLine`.

--- a/packages/react/src/code/code.tsx
+++ b/packages/react/src/code/code.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { parse, generate, type HighlightOptions, type LanguageName } from 'sugar-high'
+import { type HighlightOptions, type LanguageName } from 'sugar-high'
+import { parse, generate } from 'sugar-high/core'
 import { css, HEADER_CSS } from './css'
-import { lang as canonicalLang } from 'sugar-high/lang'
+import { lang as canonicalLang, languages } from 'sugar-high/lang'
 import { useMemo } from 'react'
 import { ScopedStyle } from '../style'
 
@@ -24,7 +25,8 @@ function generateHighlightedLines(
 ) {
   const ext = extension || getExtension(title)
   const resolvedLang = language || canonicalLang(ext)
-  const parsed = parse(codeText, resolvedLang ? { lang: resolvedLang } : undefined)
+  const config = languages.find(({ id }) => id === (resolvedLang || 'javascript'))?.config
+  const parsed = parse(codeText, config)
   const childrenLines = generate(parsed, { cx, mark, markLine })
 
   // each line will contain class name 'sh__line',

--- a/packages/react/src/code/code.tsx
+++ b/packages/react/src/code/code.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { tokenize, generate, type HighlightOptions, type LanguageName } from 'sugar-high'
+import { parse, generate, type HighlightOptions, type LanguageName } from 'sugar-high'
 import { css, HEADER_CSS } from './css'
 import { lang as canonicalLang } from 'sugar-high/lang'
 import { useMemo } from 'react'
@@ -19,14 +19,13 @@ function generateHighlightedLines(
   extension: string | undefined,
   language: LanguageName | undefined,
   cx: HighlightOptions['cx'],
-  mark: HighlightOptions['mark']
+  mark: HighlightOptions['mark'],
+  markLine: HighlightOptions['markLine']
 ) {
   const ext = extension || getExtension(title)
   const resolvedLang = language || canonicalLang(ext)
-  const options: HighlightOptions | undefined = resolvedLang || cx || mark
-    ? { ...(resolvedLang ? { lang: resolvedLang } : {}), cx, mark }
-    : undefined
-  const childrenLines = generate(tokenize(codeText, options), options)
+  const parsed = parse(codeText, resolvedLang ? { lang: resolvedLang } : undefined)
+  const childrenLines = generate(parsed, { cx, mark, markLine })
 
   // each line will contain class name 'sh__line',
   // if it's highlighted, it will contain [data-highlight]
@@ -164,6 +163,7 @@ export function Code({
   lang,
   cx,
   mark,
+  markLine,
   ...props
 }: {
   children: string
@@ -181,12 +181,13 @@ export function Code({
   lang?: LanguageName
   cx?: HighlightOptions['cx']
   mark?: HighlightOptions['mark']
+  markLine?: HighlightOptions['markLine']
 } & React.HTMLAttributes<HTMLDivElement>) {
   const lineElements = useMemo(() =>
     asMarkup
       ? code
-      : generateHighlightedLines(code, highlightLines, lineNumbers, title, extension, lang, cx, mark),
-    [code, highlightLines, lineNumbers, title, extension, lang, cx, mark, asMarkup]
+      : generateHighlightedLines(code, highlightLines, lineNumbers, title, extension, lang, cx, mark, markLine),
+    [code, highlightLines, lineNumbers, title, extension, lang, cx, mark, markLine, asMarkup]
   )
 
   return (

--- a/packages/remark/src/index.ts
+++ b/packages/remark/src/index.ts
@@ -1,11 +1,7 @@
-import { tokenize, generate, type HighlightOptions } from 'sugar-high'
+import { parse, generate, type HighlightOptions } from 'sugar-high'
 import { lang as canonicalizeLang } from 'sugar-high/lang'
 import { map as unistMap } from 'unist-util-map'
 import rangeParser from 'parse-numeric-range'
-
-function join(...args: any[]): string {
-  return args.filter(Boolean).join(' ')
-}
 
 type HighlightRange = number | [number, number]
 
@@ -71,9 +67,10 @@ const h = (type, attrs, children) => {
 type RemarkSugarHighOptions = {
   cx?: HighlightOptions['cx']
   mark?: HighlightOptions['mark']
+  markLine?: HighlightOptions['markLine']
 }
 
-const highlight = ({ cx, mark }: RemarkSugarHighOptions = {}) => (tree) => {
+const highlight = ({ cx, mark, markLine }: RemarkSugarHighOptions = {}) => (tree) => {
   return unistMap(tree, (node) => {
     const { type, tagName } = node
     if (tagName !== 'code' && type !== 'code') return node
@@ -94,10 +91,6 @@ const highlight = ({ cx, mark }: RemarkSugarHighOptions = {}) => (tree) => {
 
     const canonicalLang = canonicalizeLang(lang)
     const outputLang = canonicalLang || lang
-    const options: HighlightOptions | undefined = canonicalLang || cx || mark
-      ? { ...(canonicalLang ? { lang: canonicalLang } : {}), cx, mark }
-      : undefined
-
     const codeText =
       node.value ||
       node.children
@@ -105,18 +98,20 @@ const highlight = ({ cx, mark }: RemarkSugarHighOptions = {}) => (tree) => {
         .map(({ value }) => value)
         .pop()
 
-    const childrenLines = generate(tokenize(codeText, options), options)
+    const parsed = parse(codeText, canonicalLang ? { lang: canonicalLang } : undefined)
+    const childrenLines = generate(parsed, {
+      cx,
+      mark,
+      markLine(line) {
+        markLine?.(line)
+        if (highlightLineNumbers.has(line.index + 1)) {
+          line.className += ' sh__line--highlighted'
+        }
+      },
+    })
 
-    let lineIndex = 1
     for (let i = 0; i < childrenLines.length; i++) {
       const line = childrenLines[i]
-      // if it's highlighted lines, add a classname `sh__line--highlighted`
-      let highLightClassName = ''
-      let isCurrentLineHighlighted = highlightLineNumbers.has(lineIndex)
-
-      if (isCurrentLineHighlighted) {
-        highLightClassName = 'sh__line--highlighted'
-      }
       
       for (let j = 0; j < line.children.length; j++) {
         const token = line.children[j]
@@ -144,13 +139,6 @@ const highlight = ({ cx, mark }: RemarkSugarHighOptions = {}) => (tree) => {
         )
       )
 
-      // add class to line
-      line.properties.className = join(
-        line.properties.className,
-        highLightClassName
-      )
-
-      lineIndex++
     }
 
     const code = h(

--- a/packages/remark/src/index.ts
+++ b/packages/remark/src/index.ts
@@ -1,5 +1,6 @@
-import { parse, generate, type HighlightOptions } from 'sugar-high'
-import { lang as canonicalizeLang } from 'sugar-high/lang'
+import { type HighlightOptions } from 'sugar-high'
+import { parse, generate } from 'sugar-high/core'
+import { lang as canonicalizeLang, languages } from 'sugar-high/lang'
 import { map as unistMap } from 'unist-util-map'
 import rangeParser from 'parse-numeric-range'
 
@@ -98,7 +99,8 @@ const highlight = ({ cx, mark, markLine }: RemarkSugarHighOptions = {}) => (tree
         .map(({ value }) => value)
         .pop()
 
-    const parsed = parse(codeText, canonicalLang ? { lang: canonicalLang } : undefined)
+    const config = languages.find(({ id }) => id === (canonicalLang || 'javascript'))?.config
+    const parsed = parse(codeText, config)
     const childrenLines = generate(parsed, {
       cx,
       mark,

--- a/packages/sugar-high/README.md
+++ b/packages/sugar-high/README.md
@@ -63,19 +63,22 @@ includes JSONC comments, Shell includes sh/Bash/Zsh, and HCL includes Terraform.
 
 ## Composable core
 
-Use `sugar-high/core` for the tokenizer and generator without the built-in language registry. Core
-takes tokenizer configuration, not a language name:
+Use `sugar-high/core` to separate configurable syntax parsing from HTML rendering. It does not
+include the built-in language registry:
 
 ```js
-import { highlight } from 'sugar-high/core'
+import { parse, render } from 'sugar-high/core'
 
-highlight('select * from users', {
+const parsed = parse('select * from users', {
   keywords: new Set(['select', 'from', 'where']),
-  comment: /--.*$/gm,
+})
+
+const html = render(parsed, {
+  cx: { keyword: 'font-bold' },
 })
 ```
 
-Use the default `sugar-high` export when you want built-in languages through `{ lang }`.
+Use the default `sugar-high` export when you want built-in languages and one-step `highlight()`.
 
 ## Customize tokens
 
@@ -110,12 +113,15 @@ highlight(source, {
 
 ## Highlight lines
 
-Use `lineClassName` to attach a class to generated lines. Its index is zero-based:
+Use `markLine` to customize generated lines. Its index is zero-based:
 
 ```js
 highlight(source, {
-  lineClassName: (_line, index) =>
-    index === 1 ? 'sh__line--highlighted' : undefined,
+  markLine(line) {
+    if (line.index === 1) {
+      line.className += ' sh__line--highlighted'
+    }
+  },
 })
 ```
 

--- a/packages/sugar-high/lib/core.d.ts
+++ b/packages/sugar-high/lib/core.d.ts
@@ -11,54 +11,65 @@ export type TokenType =
   | 'break'
   | 'space'
 
-export type MarkToken = {
+export type ParsedToken = {
   type: TokenType
   value: string
+}
+
+export type MarkToken = ParsedToken & {
   className: string
   style: Record<string, string | number>
   properties: Record<string, string | number | boolean>
 }
 
-export type HighlightOptions = {
+export type ParsedLine = {
+  index: number
+  value: string
+  tokens: ParsedToken[]
+  className: string
+  style: Record<string, string | number>
+  properties: Record<string, string | number | boolean>
+}
+
+export type MarkLine = ParsedLine
+
+export type ParsedCode = {
+  value: string
+  lines: ParsedLine[]
+}
+
+export type DisplayOptions = {
+  cx?: Partial<Record<TokenType, string>>
+  mark?: (token: MarkToken) => void
+  markLine?: (line: MarkLine) => void
+}
+
+export type ParseOptions = {
   keywords?: Set<string>
-  /**
-   * Highlighted as the `class` token type (e.g. built-in types). Checked before `keywords`.
-   */
   typeKeywords?: Set<string>
   onCommentStart?: (curr: string, next: string, index: number, code: string) => number | boolean
   onCommentEnd?: (prev: string, curr: string, index: number, code: string) => number | boolean
-  /**
-   * At `code[i] === "'"`: return how many code units to consume from `i` as one token,
-   * or null/undefined or a number below 1 for default JS single-quoted string rules.
-   */
-  onQuote?: (curr: string, i: number, code: string) => number | null | undefined
-  /** Highlight quoted object keys followed by `:` as `property` tokens. */
+  onQuote?: (curr: string, index: number, code: string) => number | null | undefined
   quotedKeys?: boolean
-  /** Enable JavaScript-style JSX tag parsing. */
   jsx?: boolean
-  /** Enable JavaScript-style regular expression literals. */
   regex?: boolean
-  /** Enable JavaScript template strings. */
   templateStrings?: boolean
-  /** Match keywords and type keywords without regard to case. */
   caseInsensitive?: boolean
-  /** Override heuristic TypeScript detection. */
   typescript?: boolean
-  /** Replace the general lexer for a complex language family. */
-  tokenize?: (code: string, options: HighlightOptions) => Array<[number, string]>
-  lineClassName?: (line: string, index: number) => string | null | undefined
-  /** Additional classes keyed by token type. */
-  cx?: Partial<Record<TokenType, string>>
-  /** Mutate a token before it is rendered. */
-  mark?: (token: MarkToken) => void
+  tokenize?: (code: string, options: ParseOptions) => Array<[number, string]>
+  /** Apply syntax-specific line metadata while parsing. */
+  markLine?: (line: MarkLine) => void
 }
 
-export function highlight(code: string, options?: HighlightOptions): string
-export function tokenize(code: string, options?: HighlightOptions): Array<[number, string]>
-export function generate(tokens: Array<[number, string]>, options?: Pick<HighlightOptions, 'lineClassName' | 'cx' | 'mark'>): Array<any>
+export function parse(code: string, options?: ParseOptions): ParsedCode
+export function render(parsed: ParsedCode, options?: DisplayOptions): string
+
+/** Low-level token API used by language presets and integrations. */
+export function tokenize(code: string, options?: ParseOptions): Array<[number, string]>
+/** Build renderable nodes from parsed code. */
+export function generate(parsed: ParsedCode, options?: DisplayOptions): Array<any>
+
 export const SugarHigh: {
-  TokenTypes: {
-    [key: number]: string
-  }
+  TokenTypes: { [key: number]: string }
   TokenMap: Map<string, number>
 }

--- a/packages/sugar-high/lib/core.js
+++ b/packages/sugar-high/lib/core.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import {
-  generate, toParsedCode, SugarHigh, toHtml, T_BREAK, T_CLASS, T_COMMENT, T_IDENTIFIER,
+  assemble, generate, SugarHigh, toHtml, T_BREAK, T_CLASS, T_COMMENT, T_IDENTIFIER,
   T_KEYWORD, T_PROPERTY, T_SIGN, T_SPACE, T_STRING,
 } from './shared.js'
 
@@ -133,7 +133,7 @@ function tokenize(code, options) {
 
 /** @param {string} code @param {ParseOptions | undefined} options */
 function parse(code, options) {
-  const parsed = toParsedCode(code, tokenize(code, options))
+  const parsed = assemble(code, tokenize(code, options))
   if (options?.markLine) {
     for (const line of parsed.lines) options.markLine(line)
   }

--- a/packages/sugar-high/lib/core.js
+++ b/packages/sugar-high/lib/core.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import {
-  generate, parseTokens, SugarHigh, toHtml, T_BREAK, T_CLASS, T_COMMENT, T_IDENTIFIER,
+  generate, toParsedCode, SugarHigh, toHtml, T_BREAK, T_CLASS, T_COMMENT, T_IDENTIFIER,
   T_KEYWORD, T_PROPERTY, T_SIGN, T_SPACE, T_STRING,
 } from './shared.js'
 
@@ -133,7 +133,7 @@ function tokenize(code, options) {
 
 /** @param {string} code @param {ParseOptions | undefined} options */
 function parse(code, options) {
-  const parsed = parseTokens(code, tokenize(code, options))
+  const parsed = toParsedCode(code, tokenize(code, options))
   if (options?.markLine) {
     for (const line of parsed.lines) options.markLine(line)
   }

--- a/packages/sugar-high/lib/core.js
+++ b/packages/sugar-high/lib/core.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import {
-  generate, SugarHigh, toHtml, T_BREAK, T_CLASS, T_COMMENT, T_IDENTIFIER,
+  generate, parseTokens, SugarHigh, toHtml, T_BREAK, T_CLASS, T_COMMENT, T_IDENTIFIER,
   T_KEYWORD, T_PROPERTY, T_SIGN, T_SPACE, T_STRING,
 } from './shared.js'
 
@@ -131,15 +131,24 @@ function tokenize(code, options) {
   return tokens
 }
 
-/** @param {string} code @param {HighlightOptions | undefined} options */
-function highlight(code, options) {
-  return toHtml(generate(tokenize(code, options), options))
+/** @param {string} code @param {ParseOptions | undefined} options */
+function parse(code, options) {
+  const parsed = parseTokens(code, tokenize(code, options))
+  if (options?.markLine) {
+    for (const line of parsed.lines) options.markLine(line)
+  }
+  return parsed
 }
 
-export { generate, highlight, SugarHigh, tokenize }
+/** @param {ParsedCode} parsed @param {DisplayOptions | undefined} options */
+function render(parsed, options) {
+  return toHtml(generate(parsed, options))
+}
+
+export { generate, parse, render, SugarHigh, tokenize }
 
 /**
- * @typedef {Object} HighlightOptions
+ * @typedef {Object} ParseOptions
  * @property {Set<string>} [keywords]
  * @property {Set<string>} [typeKeywords]
  * @property {(curr: string, next: string, index: number, code: string) => number | boolean} [onCommentStart]
@@ -148,10 +157,15 @@ export { generate, highlight, SugarHigh, tokenize }
  * @property {boolean} [quotedKeys]
  * @property {boolean} [caseInsensitive]
  * @property {boolean} [templateStrings]
- * @property {(line: string, index: number) => string | null | undefined} [lineClassName]
- * @property {(code: string, options: HighlightOptions) => Array<[number, string]>} [tokenize]
+ * @property {(code: string, options: ParseOptions) => Array<[number, string]>} [tokenize]
+ * @property {(line: MarkLine) => void} [markLine]
+ */
+
+/**
+ * @typedef {Object} DisplayOptions
  * @property {Partial<Record<TokenType, string>>} [cx]
  * @property {(token: MarkToken) => void} [mark]
+ * @property {(line: MarkLine) => void} [markLine]
  */
 
 /**
@@ -163,4 +177,15 @@ export { generate, highlight, SugarHigh, tokenize }
  *   style: Record<string, string | number>
  *   properties: Record<string, string | number | boolean>
  * }} MarkToken
+ * @typedef {{ type: TokenType, value: string }} ParsedToken
+ * @typedef {{
+ *   index: number
+ *   value: string
+ *   tokens: ParsedToken[]
+ *   className: string
+ *   style: Record<string, string | number>
+ *   properties: Record<string, string | number | boolean>
+ * }} ParsedLine
+ * @typedef {ParsedLine} MarkLine
+ * @typedef {{ value: string, lines: ParsedLine[] }} ParsedCode
  */

--- a/packages/sugar-high/lib/index.d.ts
+++ b/packages/sugar-high/lib/index.d.ts
@@ -1,6 +1,13 @@
-import type { HighlightOptions as CoreHighlightOptions } from './core.js'
+import type {
+  DisplayOptions,
+  MarkLine,
+  MarkToken,
+  ParsedCode,
+  ParsedLine,
+  TokenType,
+} from './core.js'
 
-export type { MarkToken, TokenType } from './core.js'
+export type { DisplayOptions, MarkLine, MarkToken, ParsedCode, ParsedLine, TokenType }
 
 export type LanguageName =
   | 'javascript'
@@ -29,14 +36,20 @@ export type LanguageName =
   | 'graphql'
   | 'hcl'
 
-export type HighlightOptions = CoreHighlightOptions & {
+export type HighlightOptions = DisplayOptions & {
   /** Canonical language name. Fence and extension aliases must be normalized first. */
   lang?: LanguageName
 }
 
 export function highlight(code: string, options?: HighlightOptions): string
-export function tokenize(code: string, options?: HighlightOptions): Array<[number, string]>
-export function generate(tokens: Array<[number, string]>, options?: HighlightOptions): Array<any>
+
+/** Structured parsing for integrations. Most users only need highlight(). */
+export function parse(code: string, options?: { lang?: LanguageName }): ParsedCode
+export { generate, render } from './core.js'
+
+/** Low-level compatibility export. */
+export function tokenize(code: string, options?: { lang?: LanguageName }): Array<[number, string]>
+
 export const SugarHigh: {
   TokenTypes: { [key: number]: string }
   TokenMap: Map<string, number>

--- a/packages/sugar-high/lib/index.d.ts
+++ b/packages/sugar-high/lib/index.d.ts
@@ -2,12 +2,10 @@ import type {
   DisplayOptions,
   MarkLine,
   MarkToken,
-  ParsedCode,
-  ParsedLine,
   TokenType,
 } from './core.js'
 
-export type { DisplayOptions, MarkLine, MarkToken, ParsedCode, ParsedLine, TokenType }
+export type { DisplayOptions, MarkLine, MarkToken, TokenType }
 
 export type LanguageName =
   | 'javascript'
@@ -42,13 +40,6 @@ export type HighlightOptions = DisplayOptions & {
 }
 
 export function highlight(code: string, options?: HighlightOptions): string
-
-/** Structured parsing for integrations. Most users only need highlight(). */
-export function parse(code: string, options?: { lang?: LanguageName }): ParsedCode
-export { generate, render } from './core.js'
-
-/** Low-level compatibility export. */
-export function tokenize(code: string, options?: { lang?: LanguageName }): Array<[number, string]>
 
 export const SugarHigh: {
   TokenTypes: { [key: number]: string }

--- a/packages/sugar-high/lib/index.js
+++ b/packages/sugar-high/lib/index.js
@@ -2,41 +2,52 @@
 
 import {
   generate as generateCore,
-  highlight as highlightCore,
+  parse as parseCore,
+  render,
   SugarHigh,
   tokenize as tokenizeCore,
 } from './core.js'
 import { languages } from './lang.js'
+import { parseTokens } from './shared.js'
 
-/** @param {HighlightOptions | undefined} options */
-function optionsFor(options) {
-  const language = options?.lang
-    ? languages.find(({ id }) => id === options.lang)
-    : languages.find(({ id }) => id === 'javascript')
+/** @param {string | undefined} name */
+function configFor(name) {
+  return languages.find(({ id }) => id === (name || 'javascript'))?.config
+}
 
-  return {
-    ...language?.config,
-    ...options,
-  }
+/** @param {string} code @param {{ lang?: string } | undefined} options */
+function parse(code, options) {
+  const { lang, ...config } = options || {}
+  return parseCore(code, { ...configFor(lang), ...config })
 }
 
 /** @param {string} code @param {HighlightOptions | undefined} options */
 function highlight(code, options) {
-  return highlightCore(code, optionsFor(options))
+  const { lang, cx, mark, markLine, ...config } = options || {}
+  const parsed = parseCore(code, { ...configFor(lang), ...config })
+  return render(parsed, { cx, mark, markLine })
 }
 
-/** @param {string} code @param {HighlightOptions | undefined} options */
+/** @param {string} code @param {{ lang?: string } | undefined} options */
 function tokenize(code, options) {
-  return tokenizeCore(code, optionsFor(options))
+  const { lang, ...config } = options || {}
+  return tokenizeCore(code, { ...configFor(lang), ...config })
 }
-
-/** @param {Array<[number, string]>} tokens @param {HighlightOptions | undefined} options */
-function generate(tokens, options) {
-  return generateCore(tokens, optionsFor(options))
-}
-
-export { generate, highlight, SugarHigh, tokenize }
 
 /**
- * @typedef {import('./core.js').HighlightOptions & { lang?: string }} HighlightOptions
+ * @param {import('./core.js').ParsedCode | Array<[number, string]>} parsed
+ * @param {import('./core.js').DisplayOptions | undefined} options
+ */
+function generate(parsed, options) {
+  if (Array.isArray(parsed)) {
+    const value = parsed.map(([, tokenValue]) => tokenValue).join('')
+    return generateCore(parseTokens(value, parsed), options)
+  }
+  return generateCore(parsed, options)
+}
+
+export { generate, highlight, parse, render, SugarHigh, tokenize }
+
+/**
+ * @typedef {import('./core.js').DisplayOptions & { lang?: string }} HighlightOptions
  */

--- a/packages/sugar-high/lib/index.js
+++ b/packages/sugar-high/lib/index.js
@@ -8,7 +8,7 @@ import {
   tokenize as tokenizeCore,
 } from './core.js'
 import { languages } from './lang.js'
-import { parseTokens } from './shared.js'
+import { toParsedCode } from './shared.js'
 
 /** @param {string | undefined} name */
 function configFor(name) {
@@ -41,7 +41,7 @@ function tokenize(code, options) {
 function generate(parsed, options) {
   if (Array.isArray(parsed)) {
     const value = parsed.map(([, tokenValue]) => tokenValue).join('')
-    return generateCore(parseTokens(value, parsed), options)
+    return generateCore(toParsedCode(value, parsed), options)
   }
   return generateCore(parsed, options)
 }

--- a/packages/sugar-high/lib/index.js
+++ b/packages/sugar-high/lib/index.js
@@ -1,52 +1,25 @@
 // @ts-check
 
 import {
-  generate as generateCore,
-  parse as parseCore,
+  parse,
   render,
   SugarHigh,
-  tokenize as tokenizeCore,
 } from './core.js'
 import { languages } from './lang.js'
-import { toParsedCode } from './shared.js'
 
 /** @param {string | undefined} name */
 function configFor(name) {
   return languages.find(({ id }) => id === (name || 'javascript'))?.config
 }
 
-/** @param {string} code @param {{ lang?: string } | undefined} options */
-function parse(code, options) {
-  const { lang, ...config } = options || {}
-  return parseCore(code, { ...configFor(lang), ...config })
-}
-
 /** @param {string} code @param {HighlightOptions | undefined} options */
 function highlight(code, options) {
   const { lang, cx, mark, markLine, ...config } = options || {}
-  const parsed = parseCore(code, { ...configFor(lang), ...config })
+  const parsed = parse(code, { ...configFor(lang), ...config })
   return render(parsed, { cx, mark, markLine })
 }
 
-/** @param {string} code @param {{ lang?: string } | undefined} options */
-function tokenize(code, options) {
-  const { lang, ...config } = options || {}
-  return tokenizeCore(code, { ...configFor(lang), ...config })
-}
-
-/**
- * @param {import('./core.js').ParsedCode | Array<[number, string]>} parsed
- * @param {import('./core.js').DisplayOptions | undefined} options
- */
-function generate(parsed, options) {
-  if (Array.isArray(parsed)) {
-    const value = parsed.map(([, tokenValue]) => tokenValue).join('')
-    return generateCore(toParsedCode(value, parsed), options)
-  }
-  return generateCore(parsed, options)
-}
-
-export { generate, highlight, parse, render, SugarHigh, tokenize }
+export { highlight, SugarHigh }
 
 /**
  * @typedef {import('./core.js').DisplayOptions & { lang?: string }} HighlightOptions

--- a/packages/sugar-high/lib/lang.d.ts
+++ b/packages/sugar-high/lib/lang.d.ts
@@ -1,11 +1,12 @@
-import type { HighlightOptions, LanguageName } from './index.js'
+import type { LanguageName } from './index.js'
+import type { ParseOptions } from './core.js'
 
 export type Language = Readonly<{
   id: LanguageName
   /** Preferred file extension without a leading dot. */
   extension: string
   aliases: readonly string[]
-  config?: HighlightOptions
+  config?: ParseOptions
 }>
 
 export const languages: readonly Language[]

--- a/packages/sugar-high/lib/lang.js
+++ b/packages/sugar-high/lib/lang.js
@@ -27,19 +27,19 @@ import * as typescript from './presets/lang/typescript.js'
 import * as yaml from './presets/lang/yaml.js'
 
 /**
- * @typedef {import('./index.js').HighlightOptions} HighlightOptions
+ * @typedef {import('./core.js').ParseOptions} ParseOptions
  * @typedef {{
  *   id: string
  *   extension: string
  *   aliases: readonly string[]
- *   config?: HighlightOptions
+ *   config?: ParseOptions
  * }} Language
  */
 
 /**
  * Disable JavaScript-only scanner modes for a non-JavaScript language.
- * @param {HighlightOptions} config
- * @returns {HighlightOptions}
+ * @param {ParseOptions} config
+ * @returns {ParseOptions}
  */
 function nonJavaScript(config) {
   return {

--- a/packages/sugar-high/lib/presets/index.d.ts
+++ b/packages/sugar-high/lib/presets/index.d.ts
@@ -10,7 +10,7 @@ type LanguageConfig = {
   templateStrings?: boolean
   caseInsensitive?: boolean
   tokenize?(code: string, options: LanguageConfig): Array<[number, string]>
-  lineClassName?(line: string, index: number): string | null | undefined
+  markLine?(line: import('../core.js').MarkLine): void
 }
 
 export const css: LanguageConfig

--- a/packages/sugar-high/lib/presets/lang/diff.js
+++ b/packages/sugar-high/lib/presets/lang/diff.js
@@ -2,10 +2,11 @@
 
 export const keywords = new Set([])
 
-export const lineClassName = (line) => {
-  if (line.startsWith('+') && !line.startsWith('+++')) return 'sh__line--diff-add'
-  if (line.startsWith('-') && !line.startsWith('---')) return 'sh__line--diff-remove'
-  if (line.startsWith('@@')) return 'sh__line--diff-hunk'
-  if (/^(diff --git|index |--- |\+\+\+ )/.test(line)) return 'sh__line--diff-meta'
-  return undefined
+export const markLine = (line) => {
+  let className = ''
+  if (line.value.startsWith('+') && !line.value.startsWith('+++')) className = 'sh__line--diff-add'
+  else if (line.value.startsWith('-') && !line.value.startsWith('---')) className = 'sh__line--diff-remove'
+  else if (line.value.startsWith('@@')) className = 'sh__line--diff-hunk'
+  else if (/^(diff --git|index |--- |\+\+\+ )/.test(line.value)) className = 'sh__line--diff-meta'
+  if (className) line.className += ` ${className}`
 }

--- a/packages/sugar-high/lib/presets/lang/javascript-runtime.js
+++ b/packages/sugar-high/lib/presets/lang/javascript-runtime.js
@@ -777,5 +777,5 @@ export { tokenize }
  * @property {boolean} [templateStrings] Whether JavaScript template strings are enabled.
  * @property {boolean} [caseInsensitive] Whether keyword matching ignores case.
  * @property {boolean} [typescript] Override heuristic TypeScript detection.
- * @property {(line: string, index: number) => string | null | undefined} [lineClassName]
+ * @property {(line: import('../../core.js').MarkLine) => void} [markLine]
  */

--- a/packages/sugar-high/lib/presets/lang/markdown.js
+++ b/packages/sugar-high/lib/presets/lang/markdown.js
@@ -3,12 +3,13 @@ import { onCommentEnd, onCommentStart } from './plain-base.js'
 
 export const keywords = new Set([])
 
-export const lineClassName = (line) => {
-  if (/^#{1,6}\s/.test(line)) return 'sh__line--heading'
-  if (/^\s*>/.test(line)) return 'sh__line--quote'
-  if (/^\s*(?:[-*+] |\d+[.)] )/.test(line)) return 'sh__line--list'
-  if (/^\s*```/.test(line)) return 'sh__line--fence'
-  return undefined
+export const markLine = (line) => {
+  let className = ''
+  if (/^#{1,6}\s/.test(line.value)) className = 'sh__line--heading'
+  else if (/^\s*>/.test(line.value)) className = 'sh__line--quote'
+  else if (/^\s*(?:[-*+] |\d+[.)] )/.test(line.value)) className = 'sh__line--list'
+  else if (/^\s*```/.test(line.value)) className = 'sh__line--fence'
+  if (className) line.className += ` ${className}`
 }
 
 export { onCommentEnd, onCommentStart }

--- a/packages/sugar-high/lib/shared.js
+++ b/packages/sugar-high/lib/shared.js
@@ -12,7 +12,7 @@ const SugarHigh = /** @type {const} */ ({
 })
 
 /** @param {string} value @param {Array<[number, string]>} tokens */
-function parseTokens(value, tokens) {
+function toParsedCode(value, tokens) {
   const lines = []
   let lineIndex = 0
   /** @type {Array<[number, string]>} */
@@ -144,6 +144,6 @@ function toHtml(lines) {
 }
 
 export {
-  encode, generate, parseTokens, SugarHigh, toHtml, TokenTypes, T_BREAK, T_CLASS, T_COMMENT, T_ENTITY, T_IDENTIFIER,
+  encode, generate, toParsedCode, SugarHigh, toHtml, TokenTypes, T_BREAK, T_CLASS, T_COMMENT, T_ENTITY, T_IDENTIFIER,
   T_JSX_LITERALS, T_KEYWORD, T_PROPERTY, T_SIGN, T_SPACE, T_STRING,
 }

--- a/packages/sugar-high/lib/shared.js
+++ b/packages/sugar-high/lib/shared.js
@@ -11,19 +11,9 @@ const SugarHigh = /** @type {const} */ ({
   TokenMap: new Map(TokenTypes.map((type, index) => [type, index])),
 })
 
-/**
- * @param {Array<[number, string]>} tokens
- * @param {{
- *   lineClassName?: (line: string, index: number) => string | null | undefined
- *   cx?: Partial<Record<import('./core.js').TokenType, string>>
- *   mark?: (token: import('./core.js').MarkToken) => void
- * } | undefined} options
- */
-function generate(tokens, options) {
+/** @param {string} value @param {Array<[number, string]>} tokens */
+function parseTokens(value, tokens) {
   const lines = []
-  const lineClassName = typeof options?.lineClassName === 'function' ? options.lineClassName : null
-  const cx = options?.cx
-  const mark = options?.mark
   let lineIndex = 0
   /** @type {Array<[number, string]>} */
   const lineTokens = []
@@ -31,37 +21,16 @@ function generate(tokens, options) {
 
   /** @param {Array<[number, string]>} tokens */
   function flushLine(tokens) {
-    const text = tokens.map(([, value]) => value).join('')
-    const extraClassName = lineClassName ? lineClassName(text, lineIndex) : ''
-    lineIndex++
     lines.push({
-      type: 'element',
-      tagName: 'span',
-      children: tokens.map(([type, value]) => {
-        const tokenType = TokenTypes[type]
-        const extraClassName = cx?.[tokenType]
-        const token = {
-          type: tokenType,
-          value,
-          className: `sh__token--${tokenType}${extraClassName ? ` ${extraClassName}` : ''}`,
-          style: { color: `var(--sh-${tokenType})` },
-          properties: {},
-        }
-        mark?.(token)
-        return {
-          type: 'element',
-          tagName: 'span',
-          children: [{ type: 'text', value: token.value }],
-          properties: {
-            ...token.properties,
-            className: token.className,
-            style: token.style,
-          },
-        }
-      }),
-      properties: {
-        className: extraClassName ? `sh__line ${extraClassName}` : 'sh__line',
-      },
+      index: lineIndex++,
+      value: tokens.map(([, tokenValue]) => tokenValue).join(''),
+      tokens: tokens.map(([type, tokenValue]) => ({
+        type: TokenTypes[type],
+        value: tokenValue,
+      })),
+      className: 'sh__line',
+      style: {},
+      properties: {},
     })
   }
 
@@ -94,30 +63,87 @@ function generate(tokens, options) {
   }
 
   if (lineTokens.length) flushLine(lineTokens)
-  return lines
+  return { value, lines }
+}
+
+/**
+ * @param {import('./core.js').ParsedCode} parsed
+ * @param {import('./core.js').DisplayOptions | undefined} options
+ */
+function generate(parsed, options) {
+  const cx = options?.cx
+  const mark = options?.mark
+  const markLine = options?.markLine
+
+  return parsed.lines.map((parsedLine) => {
+    const line = {
+      index: parsedLine.index,
+      value: parsedLine.value,
+      tokens: parsedLine.tokens,
+      className: parsedLine.className,
+      style: { ...parsedLine.style },
+      properties: { ...parsedLine.properties },
+    }
+    markLine?.(line)
+
+    return {
+      type: 'element',
+      tagName: 'span',
+      children: parsedLine.tokens.map(({ type, value }) => {
+        const extraClassName = cx?.[type]
+        const token = {
+          type,
+          value,
+          className: `sh__token--${type}${extraClassName ? ` ${extraClassName}` : ''}`,
+          style: { color: `var(--sh-${type})` },
+          properties: {},
+        }
+        mark?.(token)
+        return {
+          type: 'element',
+          tagName: 'span',
+          children: [{ type: 'text', value: token.value }],
+          properties: {
+            ...token.properties,
+            className: token.className,
+            style: token.style,
+          },
+        }
+      }),
+      properties: {
+        ...line.properties,
+        className: line.className,
+        style: line.style,
+      },
+    }
+  })
 }
 
 const entities = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#039;' }
 /** @param {string} value */
 const encode = (value) => value.replace(/[&<>"']/g, character => entities[character])
 
+/** @param {Record<string, any>} values */
+function attributes(values) {
+  const style = Object.entries(values.style || {})
+    .map(([key, value]) => `${key.replace(/[A-Z]/g, match => `-${match.toLowerCase()}`)}:${value}`).join(';')
+  const properties = Object.entries(values)
+    .filter(([key, value]) => /^[\w:-]+$/.test(key) && key !== 'className' && key !== 'style' && value !== false && value != null)
+    .map(([key, value]) => value === true ? key : `${key}="${encode(String(value))}"`).join(' ')
+  return `class="${encode(values.className || '')}"${style ? ` style="${encode(style)}"` : ''}${properties ? ` ${properties}` : ''}`
+}
+
 /** @param {Array<any>} lines */
 function toHtml(lines) {
   return lines.map(line => {
     const children = line.children.map(token => {
-      const style = Object.entries(token.properties.style)
-        .map(([key, value]) => `${key.replace(/[A-Z]/g, match => `-${match.toLowerCase()}`)}:${value}`).join(';')
-      const properties = Object.entries(token.properties)
-        .filter(([key, value]) => /^[\w:-]+$/.test(key) && key !== 'className' && key !== 'style' && value !== false && value != null)
-        .map(([key, value]) => value === true ? key : `${key}="${encode(String(value))}"`).join(' ')
-      const attributes = `class="${encode(token.properties.className)}" style="${encode(style)}"${properties ? ` ${properties}` : ''}`
-      return `<${token.tagName} ${attributes}>${encode(token.children[0].value)}</${token.tagName}>`
+      return `<${token.tagName} ${attributes(token.properties)}>${encode(token.children[0].value)}</${token.tagName}>`
     }).join('')
-    return `<${line.tagName} class="${line.properties.className}">${children}</${line.tagName}>`
+    return `<${line.tagName} ${attributes(line.properties)}>${children}</${line.tagName}>`
   }).join('\n')
 }
 
 export {
-  encode, generate, SugarHigh, toHtml, TokenTypes, T_BREAK, T_CLASS, T_COMMENT, T_ENTITY, T_IDENTIFIER,
+  encode, generate, parseTokens, SugarHigh, toHtml, TokenTypes, T_BREAK, T_CLASS, T_COMMENT, T_ENTITY, T_IDENTIFIER,
   T_JSX_LITERALS, T_KEYWORD, T_PROPERTY, T_SIGN, T_SPACE, T_STRING,
 }

--- a/packages/sugar-high/lib/shared.js
+++ b/packages/sugar-high/lib/shared.js
@@ -12,7 +12,7 @@ const SugarHigh = /** @type {const} */ ({
 })
 
 /** @param {string} value @param {Array<[number, string]>} tokens */
-function toParsedCode(value, tokens) {
+function assemble(value, tokens) {
   const lines = []
   let lineIndex = 0
   /** @type {Array<[number, string]>} */
@@ -144,6 +144,6 @@ function toHtml(lines) {
 }
 
 export {
-  encode, generate, toParsedCode, SugarHigh, toHtml, TokenTypes, T_BREAK, T_CLASS, T_COMMENT, T_ENTITY, T_IDENTIFIER,
+  assemble, encode, generate, SugarHigh, toHtml, TokenTypes, T_BREAK, T_CLASS, T_COMMENT, T_ENTITY, T_IDENTIFIER,
   T_JSX_LITERALS, T_KEYWORD, T_PROPERTY, T_SIGN, T_SPACE, T_STRING,
 }

--- a/packages/sugar-high/scripts/benchmark.mjs
+++ b/packages/sugar-high/scripts/benchmark.mjs
@@ -3,7 +3,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { brotliCompressSync, constants, gzipSync } from 'node:zlib'
-import { highlight as highlightBuiltin } from '../lib/index.js'
+import { highlight } from '../lib/index.js'
 import { parse, render } from '../lib/core.js'
 import * as python from '../lib/presets/lang/python.js'
 
@@ -81,7 +81,7 @@ try {
   })))
 
   const performance = [
-    benchmark('builtin: { lang: "python" }', () => highlightBuiltin(source, { lang: 'python' })),
+    benchmark('builtin: { lang: "python" }', () => highlight(source, { lang: 'python' })),
     benchmark('core: parse and render python', () => render(parse(source, python))),
   ]
 

--- a/packages/sugar-high/scripts/benchmark.mjs
+++ b/packages/sugar-high/scripts/benchmark.mjs
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { brotliCompressSync, constants, gzipSync } from 'node:zlib'
 import { highlight as highlightBuiltin } from '../lib/index.js'
-import { highlight as highlightCore } from '../lib/core.js'
+import { parse, render } from '../lib/core.js'
 import * as python from '../lib/presets/lang/python.js'
 
 const iterations = Number.parseInt(process.env.BENCH_ITERATIONS || '50000', 10)
@@ -61,9 +61,9 @@ const benchmarkDir = mkdtempSync(join(tmpdir(), 'sugar-high-benchmark-'))
 try {
   const javascriptEntry = join(benchmarkDir, 'javascript-entry.js')
   writeFileSync(javascriptEntry, [
-    `import { highlight } from ${JSON.stringify(join(process.cwd(), 'lib/core.js'))}`,
+    `import { parse, render } from ${JSON.stringify(join(process.cwd(), 'lib/core.js'))}`,
     `import * as javascript from ${JSON.stringify(join(process.cwd(), 'lib/presets/lang/javascript.js'))}`,
-    'export const run = code => highlight(code, javascript)',
+    'export const run = code => render(parse(code, javascript))',
   ].join('\n'))
 
   const sizes = [
@@ -82,7 +82,7 @@ try {
 
   const performance = [
     benchmark('builtin: { lang: "python" }', () => highlightBuiltin(source, { lang: 'python' })),
-    benchmark('core: composed python preset', () => highlightCore(source, python)),
+    benchmark('core: parse and render python', () => render(parse(source, python))),
   ]
 
   console.log(`\nHighlight performance (${iterations.toLocaleString('en-US')} iterations)\n`)

--- a/packages/sugar-high/test/ast.test.ts
+++ b/packages/sugar-high/test/ast.test.ts
@@ -1043,7 +1043,9 @@ describe('newline handling', () => {
   it('should add custom class names to generated lines', () => {
     const code = 'const a = 1\nconst b = 2'
     const options = {
-      lineClassName: (_line, index) => index === 1 ? 'sh__line--marked' : undefined,
+      markLine(line) {
+        if (line.index === 1) line.className += ' sh__line--marked'
+      },
     }
 
     const lines = generate(tokenize(code), options)

--- a/packages/sugar-high/test/ast.test.ts
+++ b/packages/sugar-high/test/ast.test.ts
@@ -1,8 +1,19 @@
 import { describe, expect, it } from 'vitest'
-import { tokenize, generate, highlight } from '../lib'
+import { highlight } from '../lib'
+import * as core from '../lib/core.js'
+import * as javascript from '../lib/presets/lang/javascript.js'
+import { assemble } from '../lib/shared.js'
 import {
   getTokensAsString,
 } from './testing-utils'
+
+const tokenize = (code, options = {}) =>
+  core.tokenize(code, { ...javascript, ...options })
+
+const generate = (tokens, options?) => {
+  const value = tokens.map(([, tokenValue]) => tokenValue).join('')
+  return core.generate(assemble(value, tokens), options)
+}
 
 describe('HTML encoding', () => {
   it('encodes all characters with special meaning in HTML', () => {

--- a/packages/sugar-high/test/core.test.ts
+++ b/packages/sugar-high/test/core.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { highlight as highlightBuiltin } from 'sugar-high'
+import { highlight } from 'sugar-high'
 import { parse, render, tokenize } from 'sugar-high/core'
 import { javascript, python, typescript } from '../lib/presets/index.js'
 
@@ -20,7 +20,7 @@ describe('composable core export', () => {
   it('composes a selected preset without the built-in registry API', () => {
     const source = '# note\ndef greet(name):\n  return "Hi " + name'
     expect(render(parse(source, python))).toBe(
-      highlightBuiltin(source, { lang: 'python' })
+      highlight(source, { lang: 'python' })
     )
   })
 
@@ -32,14 +32,14 @@ describe('composable core export', () => {
   it('composes JavaScript with JSX as one preset', () => {
     const source = 'const view = <Button aria-label="Save">Save</Button>'
     expect(render(parse(source, javascript))).toBe(
-      highlightBuiltin(source, { lang: 'javascript' })
+      highlight(source, { lang: 'javascript' })
     )
   })
 
   it('composes TypeScript with TSX as one preset', () => {
     const source = 'interface Props { label: string }\nconst View = (p: Props) => <div>{p.label}</div>'
     expect(render(parse(source, typescript))).toBe(
-      highlightBuiltin(source, { lang: 'typescript' })
+      highlight(source, { lang: 'typescript' })
     )
   })
 

--- a/packages/sugar-high/test/core.test.ts
+++ b/packages/sugar-high/test/core.test.ts
@@ -1,12 +1,25 @@
 import { describe, expect, it } from 'vitest'
 import { highlight as highlightBuiltin } from 'sugar-high'
-import { highlight as highlightCore, tokenize } from 'sugar-high/core'
+import { parse, render, tokenize } from 'sugar-high/core'
 import { javascript, python, typescript } from '../lib/presets/index.js'
 
 describe('composable core export', () => {
+  it('returns structured lines and semantic tokens from parse', () => {
+    const parsed = parse('const ready = true', javascript)
+
+    expect(parsed.value).toBe('const ready = true')
+    expect(parsed.lines).toHaveLength(1)
+    expect(parsed.lines[0].index).toBe(0)
+    expect(parsed.lines[0].value).toBe('const ready = true')
+    expect(parsed.lines[0].tokens[0]).toEqual({
+      type: 'keyword',
+      value: 'const',
+    })
+  })
+
   it('composes a selected preset without the built-in registry API', () => {
     const source = '# note\ndef greet(name):\n  return "Hi " + name'
-    expect(highlightCore(source, python)).toBe(
+    expect(render(parse(source, python))).toBe(
       highlightBuiltin(source, { lang: 'python' })
     )
   })
@@ -18,15 +31,33 @@ describe('composable core export', () => {
 
   it('composes JavaScript with JSX as one preset', () => {
     const source = 'const view = <Button aria-label="Save">Save</Button>'
-    expect(highlightCore(source, javascript)).toBe(
+    expect(render(parse(source, javascript))).toBe(
       highlightBuiltin(source, { lang: 'javascript' })
     )
   })
 
   it('composes TypeScript with TSX as one preset', () => {
     const source = 'interface Props { label: string }\nconst View = (p: Props) => <div>{p.label}</div>'
-    expect(highlightCore(source, typescript)).toBe(
+    expect(render(parse(source, typescript))).toBe(
       highlightBuiltin(source, { lang: 'typescript' })
     )
+  })
+
+  it('lets render mutate lines without changing the parsed result', () => {
+    const parsed = parse('first\nsecond')
+    const html = render(parsed, {
+      markLine(line) {
+        if (line.index === 1) {
+          line.className += ' selected'
+          line.style.fontWeight = 700
+          line.properties['data-line'] = 2
+        }
+      },
+    })
+
+    expect(html).toContain('class="sh__line selected"')
+    expect(html).toContain('style="font-weight:700"')
+    expect(html).toContain('data-line="2"')
+    expect(parsed.lines[1].className).toBe('sh__line')
   })
 })

--- a/packages/sugar-high/test/languages.test.ts
+++ b/packages/sugar-high/test/languages.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { highlight, tokenize } from 'sugar-high'
+import { highlight } from 'sugar-high'
+import * as core from 'sugar-high/core'
 import { lang, languages } from 'sugar-high/lang'
 import { getTokensAsString } from './testing-utils'
+
+const tokenize = (code, { lang }) =>
+  core.tokenize(code, languages.find(({ id }) => id === lang)?.config)
 
 describe('language registry', () => {
   it.each([

--- a/packages/sugar-high/test/preset/c.test.ts
+++ b/packages/sugar-high/test/preset/c.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { tokenize } from '../..'
+import { tokenize } from '../../lib/core.js'
 import { c } from '../../lib/presets/index.js'
 import { getTokensAsString } from '../testing-utils'
 

--- a/packages/sugar-high/test/preset/css.test.ts
+++ b/packages/sugar-high/test/preset/css.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { tokenize } from '../..'
+import { tokenize } from '../../lib/core.js'
 import { css } from '../../lib/presets/index.js'
 import { getTokensAsString } from '../testing-utils'
 

--- a/packages/sugar-high/test/preset/diff.test.ts
+++ b/packages/sugar-high/test/preset/diff.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
-import { generate, highlight, tokenize } from '../..'
-import { diff } from '../../lib/presets/index.js'
+import { highlight } from '../..'
+import { generate, parse } from '../../lib/core.js'
+import * as diff from '../../lib/presets/lang/diff.js'
 
 describe('diff preset', () => {
   it('adds line classes for simple line diffs', () => {
@@ -15,7 +16,7 @@ describe('diff preset', () => {
       '+const newValue = true',
     ].join('\n')
 
-    const lines = generate(tokenize(input, diff), diff)
+    const lines = generate(parse(input, diff))
     const classNames = lines.map((line) => line.properties.className)
 
     expect(classNames).toEqual([
@@ -31,7 +32,7 @@ describe('diff preset', () => {
   })
 
   it('includes diff line classes in highlighted HTML', () => {
-    const html = highlight('-old\n+new', diff)
+    const html = highlight('-old\n+new', { lang: 'diff' })
 
     expect(html).toContain('class="sh__line sh__line--diff-remove"')
     expect(html).toContain('class="sh__line sh__line--diff-add"')

--- a/packages/sugar-high/test/preset/first-wave.test.ts
+++ b/packages/sugar-high/test/preset/first-wave.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { highlight, tokenize } from '../..'
+import { highlight } from '../..'
+import * as core from '../../lib/core.js'
+import { languages } from '../../lib/lang.js'
 import { getTokensAsString } from '../testing-utils'
+
+const tokenize = (code, { lang }) =>
+  core.tokenize(code, languages.find(({ id }) => id === lang)?.config)
 
 describe('first-wave language presets', () => {
   it('highlights the canonical shell language and hash comments', () => {

--- a/packages/sugar-high/test/preset/go.test.ts
+++ b/packages/sugar-high/test/preset/go.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { tokenize } from '../..'
+import { tokenize } from '../../lib/core.js'
 import { go } from '../../lib/presets/index.js'
 import { getTokensAsString } from '../testing-utils'
 

--- a/packages/sugar-high/test/preset/java.test.ts
+++ b/packages/sugar-high/test/preset/java.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { tokenize } from '../..'
+import { tokenize } from '../../lib/core.js'
 import { java } from '../../lib/presets/index.js'
 import { getTokensAsString } from '../testing-utils'
 

--- a/packages/sugar-high/test/preset/json.test.ts
+++ b/packages/sugar-high/test/preset/json.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
-import { tokenize } from '../..'
+import { tokenize } from '../../lib/core.js'
 import { json } from '../../lib/presets/index.js'
+import * as javascript from '../../lib/presets/lang/javascript.js'
 import { getTokensAsString } from '../testing-utils'
 
 describe('tokenize - json preset', () => {
@@ -16,29 +17,19 @@ describe('tokenize - json preset', () => {
 
     expect(actual).toEqual([
       '{ => sign',
-      '" => property',
-      'name => property',
-      '" => property',
+      '"name" => property',
       ': => sign',
-      '" => string',
-      'Alice => string',
-      '" => string',
+      '"Alice" => string',
       ', => sign',
-      '" => property',
-      'age => property',
-      '" => property',
+      '"age" => property',
       ': => sign',
       '30 => class',
       ', => sign',
-      '" => property',
-      'active => property',
-      '" => property',
+      '"active" => property',
       ': => sign',
       'true => keyword',
       ', => sign',
-      '" => property',
-      'other => property',
-      '" => property',
+      '"other" => property',
       ': => sign',
       'null => keyword',
       '} => sign',
@@ -50,32 +41,25 @@ describe('tokenize - json preset', () => {
     const actual = getTokensAsString(tokenize(input, json))
 
     expect(actual.filter((token) => token.includes('=> property'))).toEqual([
-      '" => property',
-      'items => property',
-      '" => property',
-      '" => property',
-      'label => property',
-      '" => property',
+      '"items" => property',
+      '"label" => property',
     ])
-    expect(actual).toContain('one:two => string')
+    expect(actual).toContain('"one:two" => string')
   })
 
   it('handles an escaped quote inside a property key', () => {
     const actual = getTokensAsString(tokenize('{"a\\"b": 1}', json))
 
     expect(actual.filter((token) => token.includes('=> property'))).toEqual([
-      '" => property',
-      'a\\ => property',
-      '" => property',
-      'b => property',
-      '" => property',
+      '"a\\"b" => property',
     ])
   })
 
   it('does not change default JavaScript string classification', () => {
-    const actual = getTokensAsString(tokenize('{"name": "Alice"}'))
+    const actual = getTokensAsString(tokenize('{"name": "Alice"}', javascript))
 
     expect(actual).not.toContain('name => property')
+    expect(actual).toContain('" => string')
     expect(actual).toContain('name => string')
   })
 })

--- a/packages/sugar-high/test/preset/python.test.ts
+++ b/packages/sugar-high/test/preset/python.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { tokenize } from '../..'
+import { tokenize } from '../../lib/core.js'
 import { python } from '../../lib/presets/index.js'
 import { getTokensAsString } from '../testing-utils'
 
@@ -21,9 +21,7 @@ describe('tokenize - python preset', () => {
       '! => sign',
       '= => sign',
       '[ => sign',
-      '" => string',
-      'dev => string',
-      '" => string',
+      '"dev" => string',
       '] => sign',
       "# Verify urllib3 isn't installed from git. => comment",
     ])

--- a/packages/sugar-high/test/preset/rust.test.ts
+++ b/packages/sugar-high/test/preset/rust.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { tokenize } from '../..'
+import { tokenize } from '../../lib/core.js'
 import { rust } from '../../lib/presets/index.js'
 import { getTokensAsString } from '../testing-utils'
 

--- a/packages/sugar-high/test/preset/second-wave.test.ts
+++ b/packages/sugar-high/test/preset/second-wave.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { tokenize } from '../..'
 import type { LanguageName } from '../..'
+import * as core from '../../lib/core.js'
+import { languages } from '../../lib/lang.js'
 import { getTokensAsString } from '../testing-utils'
+
+const tokenize = (code, { lang }) =>
+  core.tokenize(code, languages.find(({ id }) => id === lang)?.config)
 
 const cases: Array<[LanguageName, string, string, string]> = [
   ['kotlin', 'data class User(val name: String)', 'data => keyword', 'String => class'],

--- a/packages/sugar-high/test/tokenize.test.ts
+++ b/packages/sugar-high/test/tokenize.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { tokenize } from '..'
+import * as core from '../lib/core.js'
+import * as javascript from '../lib/presets/lang/javascript.js'
 import { getTokensAsString } from './testing-utils'
+
+const tokenize = (code, options = {}) =>
+  core.tokenize(code, { ...javascript, ...options })
 
 describe('tokenize - typeKeywords', () => {
   it('classifies typeKeywords as class before keywords', () => {


### PR DESCRIPTION
## API design

The default package keeps one small display-oriented surface:

```ts
type HighlightOptions = {
  lang?: LanguageName
  cx?: Partial<Record<TokenType, string>>
  mark?: (token: MarkToken) => void
  markLine?: (line: MarkLine) => void
}
```

The flexible core separates syntax from presentation:

```js
import { parse, render } from 'sugar-high/core'

const parsed = parse(source, {
  keywords: new Set(['select', 'from', 'where']),
})

const html = render(parsed, {
  cx: { keyword: 'font-bold' },
  mark(token) {},
  markLine(line) {},
})
```

## Summary

- add structured `parse()` output with lines and semantic tokens
- add `render()` for HTML and display customization
- replace `lineClassName` with mutable `markLine`
- compose root `highlight()` from the core API and built-in presets
- narrow root `HighlightOptions` without runtime validation
- migrate React and Remark to structured parsed code
- update the API reference, README, examples, and benchmarks

This is intended for v2. No Changeset is included.
