### PR TITLE
Define the generated syntax tree contract

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -232,3 +232,9 @@ type ParsedCode = {
 
 Core API. Converts parsed code to HTML and accepts only display customization: `cx`, `mark`, and
 `markLine`.
+
+### `generate(parsed, options?)`
+
+Core API. Builds typed line and token nodes for integrations that render through React or another
+syntax tree instead of HTML. Generated token nodes expose their semantic `tokenType` separately
+from the syntax-tree `type: 'element'` field.

--- a/packages/react/src/code/code.test.tsx
+++ b/packages/react/src/code/code.test.tsx
@@ -97,7 +97,7 @@ describe('Code', () => {
         --codice-code-padding: 1rem;
       }
 
-      }</style><pre data-codice-code-content="true"><code><span class="sh__line" data-codice-code-line="true"><span data-sh-token-type="element" class="sh__token--identifier" style="color:var(--sh-identifier)">test</span></span></code></pre></div>"
+      }</style><pre data-codice-code-content="true"><code><span class="sh__line" data-codice-code-line="true"><span data-sh-token-type="identifier" class="sh__token--identifier" style="color:var(--sh-identifier)">test</span></span></code></pre></div>"
     `)
   })
 
@@ -238,7 +238,7 @@ describe('Code', () => {
         background-color: var(--codice-control-color);
       }
 
-      }</style><input data-codice-title="true" readOnly="" value="file.js"/></div><pre data-codice-code-content="true"><code><span class="sh__line" data-codice-code-line="true"><span data-sh-token-type="element" class="sh__token--identifier" style="color:var(--sh-identifier)">test</span></span></code></pre></div>"
+      }</style><input data-codice-title="true" readOnly="" value="file.js"/></div><pre data-codice-code-content="true"><code><span class="sh__line" data-codice-code-line="true"><span data-sh-token-type="identifier" class="sh__token--identifier" style="color:var(--sh-identifier)">test</span></span></code></pre></div>"
     `)
   })
 
@@ -379,7 +379,7 @@ describe('Code', () => {
         background-color: var(--codice-control-color);
       }
 
-      }</style><div data-codice-controls="true"><span data-codice-control="true"></span><span data-codice-control="true"></span><span data-codice-control="true"></span></div></div><pre data-codice-code-content="true"><code><span class="sh__line" data-codice-code-line="true"><span data-sh-token-type="element" class="sh__token--identifier" style="color:var(--sh-identifier)">test</span></span></code></pre></div>"
+      }</style><div data-codice-controls="true"><span data-codice-control="true"></span><span data-codice-control="true"></span><span data-codice-control="true"></span></div></div><pre data-codice-code-content="true"><code><span class="sh__line" data-codice-code-line="true"><span data-sh-token-type="identifier" class="sh__token--identifier" style="color:var(--sh-identifier)">test</span></span></code></pre></div>"
     `)
   })
 
@@ -477,7 +477,7 @@ describe('Code', () => {
         --codice-code-padding: 1rem;
       }
 
-      }</style><pre data-codice-code-content="true"><code><span class="sh__line" data-codice-code-line="true"><span data-sh-token-type="element" class="sh__token--identifier" style="color:var(--sh-identifier)">test</span></span></code></pre></div>"
+      }</style><pre data-codice-code-content="true"><code><span class="sh__line" data-codice-code-line="true"><span data-sh-token-type="identifier" class="sh__token--identifier" style="color:var(--sh-identifier)">test</span></span></code></pre></div>"
     `)
 
     expect(renderToString(<Code fontSize={'1rem'}>test</Code>)).toMatchInlineSnapshot(`
@@ -573,7 +573,7 @@ describe('Code', () => {
         --codice-code-padding: 1rem;
       }
 
-      }</style><pre data-codice-code-content="true"><code><span class="sh__line" data-codice-code-line="true"><span data-sh-token-type="element" class="sh__token--identifier" style="color:var(--sh-identifier)">test</span></span></code></pre></div>"
+      }</style><pre data-codice-code-content="true"><code><span class="sh__line" data-codice-code-line="true"><span data-sh-token-type="identifier" class="sh__token--identifier" style="color:var(--sh-identifier)">test</span></span></code></pre></div>"
     `)
   })
 })

--- a/packages/react/src/code/code.tsx
+++ b/packages/react/src/code/code.tsx
@@ -52,10 +52,10 @@ function generateHighlightedLines(
       const { tagName: Line, properties: lineProperties } = line
       const tokens = line.children
         .map((child, childIndex) => {
-          const { tagName: Token, type, children, properties } = child
+          const { tagName: Token, tokenType, children, properties } = child
           return (
             <Token
-              data-sh-token-type={type}
+              data-sh-token-type={tokenType}
               key={childIndex}
               {...properties}
             >

--- a/packages/sugar-high/lib/core.d.ts
+++ b/packages/sugar-high/lib/core.d.ts
@@ -53,6 +53,32 @@ export type ParsedCode = {
   readonly lines: readonly ParsedLine[]
 }
 
+export type GeneratedProperties = {
+  className: string
+  style: Record<string, string | number>
+  [name: string]: unknown
+}
+
+export type GeneratedText = {
+  type: 'text'
+  value: string
+}
+
+export type GeneratedToken = {
+  type: 'element'
+  tokenType: TokenType
+  tagName: 'span'
+  children: GeneratedText[]
+  properties: GeneratedProperties
+}
+
+export type GeneratedLine = {
+  type: 'element'
+  tagName: 'span'
+  children: GeneratedToken[]
+  properties: GeneratedProperties
+}
+
 export type DisplayOptions = {
   cx?: Partial<Record<TokenType, string>>
   mark?: (token: MarkToken) => void
@@ -81,8 +107,8 @@ export function render(parsed: ParsedCode, options?: DisplayOptions): string
 
 /** Low-level token API used by language presets and integrations. */
 export function tokenize(code: string, options?: ParseOptions): Array<[number, string]>
-/** Build renderable nodes from parsed code. */
-export function generate(parsed: ParsedCode, options?: DisplayOptions): Array<any>
+/** Build renderable line nodes for HTML, React, and syntax-tree integrations. */
+export function generate(parsed: ParsedCode, options?: DisplayOptions): GeneratedLine[]
 
 export const SugarHigh: {
   TokenTypes: { [key: number]: string }

--- a/packages/sugar-high/lib/shared.js
+++ b/packages/sugar-high/lib/shared.js
@@ -100,6 +100,7 @@ function generate(parsed, options) {
         mark?.(token)
         return {
           type: 'element',
+          tokenType: token.type,
           tagName: 'span',
           children: [{ type: 'text', value: token.value }],
           properties: {

--- a/packages/sugar-high/test/core.test.ts
+++ b/packages/sugar-high/test/core.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { highlight } from 'sugar-high'
-import { parse, render, tokenize } from 'sugar-high/core'
+import { generate, parse, render, tokenize } from 'sugar-high/core'
 import * as javascript from '../lib/presets/lang/javascript.js'
 import * as python from '../lib/presets/lang/python.js'
 import * as typescript from '../lib/presets/lang/typescript.js'
@@ -61,5 +61,13 @@ describe('composable core export', () => {
     expect(html).toContain('style="font-weight:700"')
     expect(html).toContain('data-line="2"')
     expect(parsed.lines[1].annotations).toEqual([])
+  })
+
+  it('keeps syntax-tree and semantic token types separate', () => {
+    const [line] = generate(parse('const ready = true', javascript))
+
+    expect(line.type).toBe('element')
+    expect(line.children[0].type).toBe('element')
+    expect(line.children[0].tokenType).toBe('keyword')
   })
 })


### PR DESCRIPTION
Part of #186.

Defines typed generated line and token nodes, separates the syntax-tree node type from the semantic token type, and fixes React output so data-sh-token-type contains values such as keyword and comment instead of element.

```ts
const [line] = generate(parse(source))
line.type // element
line.children[0].tokenType // keyword
```