### PR TITLE
Prepare the Remark integration for v2

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -232,3 +232,9 @@ type ParsedCode = {
 
 Core API. Converts parsed code to HTML and accepts only display customization: `cx`, `mark`, and
 `markLine`.
+
+### `generate(parsed, options?)`
+
+Core API. Builds typed line and token nodes for integrations that render through React or another
+syntax tree instead of HTML. Generated token nodes expose their semantic `tokenType` separately
+from the syntax-tree `type: 'element'` field.

--- a/packages/react/src/code/code.test.tsx
+++ b/packages/react/src/code/code.test.tsx
@@ -97,7 +97,7 @@ describe('Code', () => {
         --codice-code-padding: 1rem;
       }
 
-      }</style><pre data-codice-code-content="true"><code><span class="sh__line" data-codice-code-line="true"><span data-sh-token-type="element" class="sh__token--identifier" style="color:var(--sh-identifier)">test</span></span></code></pre></div>"
+      }</style><pre data-codice-code-content="true"><code><span class="sh__line" data-codice-code-line="true"><span data-sh-token-type="identifier" class="sh__token--identifier" style="color:var(--sh-identifier)">test</span></span></code></pre></div>"
     `)
   })
 
@@ -238,7 +238,7 @@ describe('Code', () => {
         background-color: var(--codice-control-color);
       }
 
-      }</style><input data-codice-title="true" readOnly="" value="file.js"/></div><pre data-codice-code-content="true"><code><span class="sh__line" data-codice-code-line="true"><span data-sh-token-type="element" class="sh__token--identifier" style="color:var(--sh-identifier)">test</span></span></code></pre></div>"
+      }</style><input data-codice-title="true" readOnly="" value="file.js"/></div><pre data-codice-code-content="true"><code><span class="sh__line" data-codice-code-line="true"><span data-sh-token-type="identifier" class="sh__token--identifier" style="color:var(--sh-identifier)">test</span></span></code></pre></div>"
     `)
   })
 
@@ -379,7 +379,7 @@ describe('Code', () => {
         background-color: var(--codice-control-color);
       }
 
-      }</style><div data-codice-controls="true"><span data-codice-control="true"></span><span data-codice-control="true"></span><span data-codice-control="true"></span></div></div><pre data-codice-code-content="true"><code><span class="sh__line" data-codice-code-line="true"><span data-sh-token-type="element" class="sh__token--identifier" style="color:var(--sh-identifier)">test</span></span></code></pre></div>"
+      }</style><div data-codice-controls="true"><span data-codice-control="true"></span><span data-codice-control="true"></span><span data-codice-control="true"></span></div></div><pre data-codice-code-content="true"><code><span class="sh__line" data-codice-code-line="true"><span data-sh-token-type="identifier" class="sh__token--identifier" style="color:var(--sh-identifier)">test</span></span></code></pre></div>"
     `)
   })
 
@@ -477,7 +477,7 @@ describe('Code', () => {
         --codice-code-padding: 1rem;
       }
 
-      }</style><pre data-codice-code-content="true"><code><span class="sh__line" data-codice-code-line="true"><span data-sh-token-type="element" class="sh__token--identifier" style="color:var(--sh-identifier)">test</span></span></code></pre></div>"
+      }</style><pre data-codice-code-content="true"><code><span class="sh__line" data-codice-code-line="true"><span data-sh-token-type="identifier" class="sh__token--identifier" style="color:var(--sh-identifier)">test</span></span></code></pre></div>"
     `)
 
     expect(renderToString(<Code fontSize={'1rem'}>test</Code>)).toMatchInlineSnapshot(`
@@ -573,7 +573,7 @@ describe('Code', () => {
         --codice-code-padding: 1rem;
       }
 
-      }</style><pre data-codice-code-content="true"><code><span class="sh__line" data-codice-code-line="true"><span data-sh-token-type="element" class="sh__token--identifier" style="color:var(--sh-identifier)">test</span></span></code></pre></div>"
+      }</style><pre data-codice-code-content="true"><code><span class="sh__line" data-codice-code-line="true"><span data-sh-token-type="identifier" class="sh__token--identifier" style="color:var(--sh-identifier)">test</span></span></code></pre></div>"
     `)
   })
 })

--- a/packages/react/src/code/code.tsx
+++ b/packages/react/src/code/code.tsx
@@ -52,10 +52,10 @@ function generateHighlightedLines(
       const { tagName: Line, properties: lineProperties } = line
       const tokens = line.children
         .map((child, childIndex) => {
-          const { tagName: Token, type, children, properties } = child
+          const { tagName: Token, tokenType, children, properties } = child
           return (
             <Token
-              data-sh-token-type={type}
+              data-sh-token-type={tokenType}
               key={childIndex}
               {...properties}
             >

--- a/packages/remark/README.md
+++ b/packages/remark/README.md
@@ -1,69 +1,46 @@
 # @sugar-high/remark
 
-Remark plugin for [Sugar High](https://sugar-high.vercel.app) syntax highlighter.
+Remark plugin for the [Sugar High](https://sugar-high.vercel.app) syntax highlighter.
 
-[Website](https://sugar-high.vercel.app/remark)
+## Install
 
-
-## Installation
-
-```bash
-$ npm i -S @sugar-high/remark
+```sh
+npm install @sugar-high/remark sugar-high
 ```
 
 ## Usage
 
-Input markdown file:
+```js
+import { remark } from 'remark'
+import html from 'remark-html'
+import remarkSugarHigh from '@sugar-high/remark'
 
+const output = await remark()
+  .use(remarkSugarHigh, {
+    cx: { keyword: 'font-bold' },
+  })
+  .use(html, { sanitize: false })
+  .process(markdown)
 ```
-\`\`\`javascript {2,5}
-// Here is a simple function
-async function hello() {
-    console.log('Hello, world from JavaScript!')
-    return 123 // return a number
-}
 
-await hello()
-\`\`\`
-```
-
-Using [remark](https://github.com/remarkjs/remark):
+The named `highlight` export is available for integrations that prefer named imports:
 
 ```js
-const { highlight } = require('@sugar-high/remark');
-
-await remark()
-  .use(highlight, { cx: { keyword: 'font-bold' } })
-  .use(require('remark-html'))
-  .process(file, (err, file) => console.log(String(file)));
+import { highlight } from '@sugar-high/remark'
 ```
 
-Fence aliases are normalized to canonical Sugar High language names. For example, `bash` and `sh`
-use `shell`, `jsonc` uses `json`, and `tf` uses `hcl`. Generated `sh-lang--*` classes and the
-`data-sh-language` attribute use the canonical name.
+Fence aliases are normalized through [`lang()`](https://github.com/huozhi/sugar-high/blob/main/docs/API.md#sugar-highlang), so `bash` uses `shell`, `jsonc` uses `json`, and `tf` uses `hcl`.
 
-<details>
-<summary>Output HTML</summary>
-<p>
+Use one-based ranges in fence metadata to highlight lines:
 
-```html
-<pre
-  class="sh-lang--javascript"
-><code class="sh-lang--javascript" data-sh-language="javascript"><span class="sh__line"><span class="sh__token--comment" style="color: var(--sh-comment)">// Here is a simple function</span><span class="sh__token--line">
-</span></span><span class="sh__line sh__line--highlighted"><span class="sh__token--comment" style="color: var(--sh-comment)"></span><span class="sh__token--keyword" style="color: var(--sh-keyword)">async</span><span class="sh__token--space" style="color: var(--sh-space)"> </span><span class="sh__token--keyword" style="color: var(--sh-keyword)">function</span><span class="sh__token--space" style="color: var(--sh-space)"> </span><span class="sh__token--identifier" style="color: var(--sh-identifier)">hello</span><span class="sh__token--sign" style="color: var(--sh-sign)">(</span><span class="sh__token--sign" style="color: var(--sh-sign)">)</span><span class="sh__token--space" style="color: var(--sh-space)"> </span><span class="sh__token--sign" style="color: var(--sh-sign)">{</span><span class="sh__token--break" style="color: var(--sh-break)"></span><span class="sh__token--line">
-</span></span><span class="sh__line"><span class="sh__token--space" style="color: var(--sh-space)">    </span><span class="sh__token--identifier" style="color: var(--sh-identifier)">console</span><span class="sh__token--sign" style="color: var(--sh-sign)">.</span><span class="sh__token--property" style="color: var(--sh-property)">log</span><span class="sh__token--sign" style="color: var(--sh-sign)">(</span><span class="sh__token--string" style="color: var(--sh-string)">'</span><span class="sh__token--string" style="color: var(--sh-string)">Hello, world from JavaScript!</span><span class="sh__token--string" style="color: var(--sh-string)">'</span><span class="sh__token--sign" style="color: var(--sh-sign)">)</span><span class="sh__token--break" style="color: var(--sh-break)"></span><span class="sh__token--line">
-</span></span><span class="sh__line"><span class="sh__token--space" style="color: var(--sh-space)">    </span><span class="sh__token--keyword" style="color: var(--sh-keyword)">return</span><span class="sh__token--space" style="color: var(--sh-space)"> </span><span class="sh__token--class" style="color: var(--sh-class)">123</span><span class="sh__token--space" style="color: var(--sh-space)"> </span><span class="sh__token--comment" style="color: var(--sh-comment)">// return a number</span><span class="sh__token--line">
-</span></span><span class="sh__line sh__line--highlighted"><span class="sh__token--comment" style="color: var(--sh-comment)"></span><span class="sh__token--sign" style="color: var(--sh-sign)">}</span><span class="sh__token--break" style="color: var(--sh-break)"></span><span class="sh__token--line">
-</span></span><span class="sh__line"><span class="sh__token--break" style="color: var(--sh-break)"></span><span class="sh__token--line">
-</span></span><span class="sh__line"><span class="sh__token--keyword" style="color: var(--sh-keyword)">await</span><span class="sh__token--space" style="color: var(--sh-space)"> </span><span class="sh__token--identifier" style="color: var(--sh-identifier)">hello</span><span class="sh__token--sign" style="color: var(--sh-sign)">(</span><span class="sh__token--sign" style="color: var(--sh-sign)">)</span><span class="sh__token--line">
-</span></span></code></pre>
+````md
+```js {2,5-7}
+const ready = true
 ```
-</p>
+````
 
-</details>
-
-Customize the color theme with sugar-high CSS variables. Check [sugar-high highlight-with-css section](https://github.com/huozhi/sugar-high#highlight-with-css) for more details.
-
+The plugin accepts the same display options as `highlight`: `cx`, `mark`, and `markLine`. See the
+[API reference](https://github.com/huozhi/sugar-high/blob/main/docs/API.md#highlight-options).
 
 ## License
 

--- a/packages/remark/package.json
+++ b/packages/remark/package.json
@@ -10,8 +10,15 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "scripts": {
     "build": "bunchee",
+    "test": "vitest --run",
     "prepublishOnly": "pnpm build"
   },
   "files": [
@@ -26,13 +33,13 @@
     "access": "public"
   },
   "dependencies": {
-    "parse-numeric-range": "^1.3.0",
     "sugar-high": "workspace:^",
     "unist-util-map": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.12.0",
     "bunchee": "^7.0.1",
-    "typescript": "^6.0.2"
+    "typescript": "^6.0.2",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/remark/src/index.test.ts
+++ b/packages/remark/src/index.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest'
+import remarkSugarHigh, { highlight } from '.'
+
+const tree = (lang = 'javascript', meta?: string, value = 'const ready = true') => ({
+  type: 'root',
+  children: [{ type: 'code', lang, meta, value }],
+})
+
+describe('@sugar-high/remark', () => {
+  it('exports the plugin as both default and highlight', () => {
+    expect(remarkSugarHigh).toBe(highlight)
+  })
+
+  it('normalizes fence aliases and highlights selected lines', () => {
+    const output = highlight()(tree('bash', '{2}', 'echo one\necho two'))
+    const pre = output.children[0]
+    const code = pre.children[0]
+
+    expect(pre.properties.className).toBe('sh-lang--shell')
+    expect(code.properties['data-sh-language']).toBe('shell')
+    expect(code.children[1].properties.className).toContain('sh__line--highlighted')
+  })
+
+  it('composes semantic annotations and display hooks', () => {
+    const mark = vi.fn((token) => {
+      if (token.type === 'sign') token.properties['data-sign'] = true
+    })
+    const markLine = vi.fn((line) => {
+      if (line.annotations.includes('diff-add')) line.className += ' added'
+    })
+    const output = highlight({ cx: { sign: 'punctuation' }, mark, markLine })(
+      tree('diff', undefined, '+ added')
+    )
+    const line = output.children[0].children[0].children[0]
+
+    expect(line.properties.className).toBe('sh__line sh__line--diff-add added')
+    expect(line.children[0].properties.className).toContain('punctuation')
+    expect(line.children[0].properties['data-sign']).toBe(true)
+    expect(mark).toHaveBeenCalled()
+    expect(markLine).toHaveBeenCalled()
+  })
+})

--- a/packages/remark/src/index.ts
+++ b/packages/remark/src/index.ts
@@ -2,7 +2,6 @@ import { type HighlightOptions } from 'sugar-high'
 import { parse, generate } from 'sugar-high/core'
 import { lang as canonicalizeLang, languages } from 'sugar-high/lang'
 import { map as unistMap } from 'unist-util-map'
-import rangeParser from 'parse-numeric-range'
 
 type HighlightRange = number | [number, number]
 
@@ -30,27 +29,6 @@ function parseHighlightMeta(meta?: string): HighlightRange[] {
   return ranges
 }
 
-const parseLang = (str) => {
-  const match = (regexp) => {
-    const m = (str || '').match(regexp)
-    return Array.isArray(m) ? m.filter(Boolean) : []
-  }
-
-  const [lang = 'unknown'] = match(/^[a-zA-Z\d-]*/g)
-
-  const range = rangeParser(
-    match(/\{(.*?)\}$/g)
-      .join(',')
-      .replace(/^\{/, '')
-      .replace(/\}$/, '')
-  )
-
-  return {
-    lang,
-    range,
-  }
-}
-
 const h = (type, attrs, children) => {
   return {
     type: 'element',
@@ -65,7 +43,7 @@ const h = (type, attrs, children) => {
   }
 }
 
-type RemarkSugarHighOptions = {
+export type RemarkSugarHighOptions = {
   cx?: HighlightOptions['cx']
   mark?: HighlightOptions['mark']
   markLine?: HighlightOptions['markLine']
@@ -76,7 +54,7 @@ const highlight = ({ cx, mark, markLine }: RemarkSugarHighOptions = {}) => (tree
     const { type, tagName } = node
     if (tagName !== 'code' && type !== 'code') return node
 
-    const { lang } = parseLang(node.lang)
+    const language = String(node.lang || '').match(/^[a-zA-Z\d-]*/)?.[0] || 'unknown'
 
     const highlightRanges = parseHighlightMeta(node.meta)
     const highlightLineNumbers = new Set<number>()
@@ -90,8 +68,8 @@ const highlight = ({ cx, mark, markLine }: RemarkSugarHighOptions = {}) => (tree
       }
     })
 
-    const canonicalLang = canonicalizeLang(lang)
-    const outputLang = canonicalLang || lang
+    const canonicalLang = canonicalizeLang(language)
+    const outputLang = canonicalLang || language
     const codeText =
       node.value ||
       node.children

--- a/packages/sugar-high/lib/core.d.ts
+++ b/packages/sugar-high/lib/core.d.ts
@@ -53,6 +53,32 @@ export type ParsedCode = {
   readonly lines: readonly ParsedLine[]
 }
 
+export type GeneratedProperties = {
+  className: string
+  style: Record<string, string | number>
+  [name: string]: unknown
+}
+
+export type GeneratedText = {
+  type: 'text'
+  value: string
+}
+
+export type GeneratedToken = {
+  type: 'element'
+  tokenType: TokenType
+  tagName: 'span'
+  children: GeneratedText[]
+  properties: GeneratedProperties
+}
+
+export type GeneratedLine = {
+  type: 'element'
+  tagName: 'span'
+  children: GeneratedToken[]
+  properties: GeneratedProperties
+}
+
 export type DisplayOptions = {
   cx?: Partial<Record<TokenType, string>>
   mark?: (token: MarkToken) => void
@@ -81,8 +107,8 @@ export function render(parsed: ParsedCode, options?: DisplayOptions): string
 
 /** Low-level token API used by language presets and integrations. */
 export function tokenize(code: string, options?: ParseOptions): Array<[number, string]>
-/** Build renderable nodes from parsed code. */
-export function generate(parsed: ParsedCode, options?: DisplayOptions): Array<any>
+/** Build renderable line nodes for HTML, React, and syntax-tree integrations. */
+export function generate(parsed: ParsedCode, options?: DisplayOptions): GeneratedLine[]
 
 export const SugarHigh: {
   TokenTypes: { [key: number]: string }

--- a/packages/sugar-high/lib/shared.js
+++ b/packages/sugar-high/lib/shared.js
@@ -100,6 +100,7 @@ function generate(parsed, options) {
         mark?.(token)
         return {
           type: 'element',
+          tokenType: token.type,
           tagName: 'span',
           children: [{ type: 'text', value: token.value }],
           properties: {

--- a/packages/sugar-high/test/core.test.ts
+++ b/packages/sugar-high/test/core.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { highlight } from 'sugar-high'
-import { parse, render, tokenize } from 'sugar-high/core'
+import { generate, parse, render, tokenize } from 'sugar-high/core'
 import * as javascript from '../lib/presets/lang/javascript.js'
 import * as python from '../lib/presets/lang/python.js'
 import * as typescript from '../lib/presets/lang/typescript.js'
@@ -61,5 +61,13 @@ describe('composable core export', () => {
     expect(html).toContain('style="font-weight:700"')
     expect(html).toContain('data-line="2"')
     expect(parsed.lines[1].annotations).toEqual([])
+  })
+
+  it('keeps syntax-tree and semantic token types separate', () => {
+    const [line] = generate(parse('const ready = true', javascript))
+
+    expect(line.type).toBe('element')
+    expect(line.children[0].type).toBe('element')
+    expect(line.children[0].tokenType).toBe('keyword')
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,9 +112,6 @@ importers:
 
   packages/remark:
     dependencies:
-      parse-numeric-range:
-        specifier: ^1.3.0
-        version: 1.3.0
       sugar-high:
         specifier: workspace:^
         version: link:../sugar-high
@@ -131,6 +128,9 @@ importers:
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.12.0)(terser@5.46.1)
 
   packages/sugar-high:
     devDependencies:
@@ -2455,9 +2455,6 @@ packages:
 
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
-
-  parse-numeric-range@1.3.0:
-    resolution: {integrity: sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -5444,8 +5441,6 @@ snapshots:
   package-manager-detector@0.2.11:
     dependencies:
       quansync: 0.2.11
-
-  parse-numeric-range@1.3.0: {}
 
   path-exists@4.0.0: {}
 


### PR DESCRIPTION
Stacked on #187. Part of #186.

Modernizes the Remark package boundary for v2:

- documents the ESM-first default and named plugin exports
- adds an explicit package export map
- covers aliases, highlighted ranges, annotations, cx, mark, and markLine
- removes duplicate fence-range parsing and the parse-numeric-range dependency

The display options remain the same as sugar-high.