### PR TITLE
Keep language normalization lightweight

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -57,6 +57,23 @@ highlight(source, { lang: 'python' })
 highlight(source, { lang: lang(extension) })
 ```
 
+This entry contains only language metadata and normalization logic, so using `lang()` does not
+bundle the syntax implementations.
+
+### `sugar-high/registry`
+
+Advanced integrations that combine built-in languages with `parse()` can use the heavier registry:
+
+```js
+import { parse } from 'sugar-high/core'
+import { registry } from 'sugar-high/registry'
+
+const python = registry.find(language => language.id === 'python')
+const parsed = parse(source, python?.config)
+```
+
+Most applications should use `highlight()` and do not need the registry.
+
 ## `lang()` mapping
 
 Canonical names appear in the first column. The preferred extension and every additional accepted

--- a/packages/react/src/code/code.tsx
+++ b/packages/react/src/code/code.tsx
@@ -3,7 +3,8 @@
 import { type HighlightOptions, type LanguageName } from 'sugar-high'
 import { parse, generate } from 'sugar-high/core'
 import { css, HEADER_CSS } from './css'
-import { lang as canonicalLang, languages } from 'sugar-high/lang'
+import { lang as canonicalLang } from 'sugar-high/lang'
+import { registry } from 'sugar-high/registry'
 import { useMemo } from 'react'
 import { ScopedStyle } from '../style'
 
@@ -25,7 +26,7 @@ function generateHighlightedLines(
 ) {
   const ext = extension || getExtension(title)
   const resolvedLang = language || canonicalLang(ext)
-  const config = languages.find(({ id }) => id === (resolvedLang || 'javascript'))?.config
+  const config = registry.find(({ id }) => id === (resolvedLang || 'javascript'))?.config
   const parsed = parse(codeText, config)
   const childrenLines = generate(parsed, { cx, mark, markLine })
 

--- a/packages/remark/src/index.ts
+++ b/packages/remark/src/index.ts
@@ -1,6 +1,7 @@
 import { type HighlightOptions } from 'sugar-high'
 import { parse, generate } from 'sugar-high/core'
-import { lang as canonicalizeLang, languages } from 'sugar-high/lang'
+import { lang as canonicalizeLang } from 'sugar-high/lang'
+import { registry } from 'sugar-high/registry'
 import { map as unistMap } from 'unist-util-map'
 
 type HighlightRange = number | [number, number]
@@ -77,7 +78,7 @@ const highlight = ({ cx, mark, markLine }: RemarkSugarHighOptions = {}) => (tree
         .map(({ value }) => value)
         .pop()
 
-    const config = languages.find(({ id }) => id === (canonicalLang || 'javascript'))?.config
+    const config = registry.find(({ id }) => id === (canonicalLang || 'javascript'))?.config
     const parsed = parse(codeText, config)
     const childrenLines = generate(parsed, {
       cx,

--- a/packages/sugar-high/README.md
+++ b/packages/sugar-high/README.md
@@ -48,8 +48,9 @@ lang('.yml')  // 'yaml'
 ```
 
 If you already have a canonical name, pass it directly—`lang()` is not required.
+The `/lang` entry is metadata-only and does not bundle the syntax implementations.
 
-See [the API reference](../../docs/API.md#lang-mapping) for the complete mapping and normalization
+See [the API reference](https://github.com/huozhi/sugar-high/blob/main/docs/API.md#lang-mapping) for the complete mapping and normalization
 behavior.
 
 ## Built-in languages
@@ -192,7 +193,7 @@ processing Markdown. Fence aliases are normalized through the same `lang()` mapp
 
 ## API
 
-See [`docs/API.md`](../../docs/API.md) for package exports, the full language mapping, highlighting
+See [`docs/API.md`](https://github.com/huozhi/sugar-high/blob/main/docs/API.md) for package exports, the full language mapping, highlighting
 options, and lower-level functions.
 
 ## Benchmarking

--- a/packages/sugar-high/lib/index.js
+++ b/packages/sugar-high/lib/index.js
@@ -4,11 +4,11 @@ import {
   parse,
   render,
 } from './core.js'
-import { languages } from './lang.js'
+import { registry } from './registry.js'
 
 /** @param {string | undefined} name */
 function configFor(name) {
-  return languages.find(({ id }) => id === (name || 'javascript'))?.config
+  return registry.find(({ id }) => id === (name || 'javascript'))?.config
 }
 
 /** @param {string} code @param {HighlightOptions | undefined} options */

--- a/packages/sugar-high/lib/lang.d.ts
+++ b/packages/sugar-high/lib/lang.d.ts
@@ -1,12 +1,9 @@
 import type { LanguageName } from './index.js'
-import type { ParseOptions } from './core.js'
-
 export type Language = Readonly<{
   id: LanguageName
   /** Preferred file extension without a leading dot. */
   extension: string
   aliases: readonly string[]
-  config?: ParseOptions
 }>
 
 export const languages: readonly Language[]

--- a/packages/sugar-high/lib/lang.js
+++ b/packages/sugar-high/lib/lang.js
@@ -1,83 +1,43 @@
 // @ts-check
 
-import * as c from './presets/lang/c.js'
-import * as cpp from './presets/lang/cpp.js'
-import * as csharp from './presets/lang/csharp.js'
-import * as css from './presets/lang/css.js'
-import * as diff from './presets/lang/diff.js'
-import * as dockerfile from './presets/lang/dockerfile.js'
-import * as go from './presets/lang/go.js'
-import * as html from './presets/lang/html.js'
-import * as graphql from './presets/lang/graphql.js'
-import * as hcl from './presets/lang/hcl.js'
-import * as java from './presets/lang/java.js'
-import * as json from './presets/lang/json.js'
-import * as javascript from './presets/lang/javascript.js'
-import * as kotlin from './presets/lang/kotlin.js'
-import * as markdown from './presets/lang/markdown.js'
-import * as php from './presets/lang/php.js'
-import * as powershell from './presets/lang/powershell.js'
-import * as python from './presets/lang/python.js'
-import * as rust from './presets/lang/rust.js'
-import * as shell from './presets/lang/shell.js'
-import * as sql from './presets/lang/sql.js'
-import * as swift from './presets/lang/swift.js'
-import * as toml from './presets/lang/toml.js'
-import * as typescript from './presets/lang/typescript.js'
-import * as yaml from './presets/lang/yaml.js'
-
 /**
- * @typedef {import('./core.js').ParseOptions} ParseOptions
  * @typedef {{
  *   id: string
  *   extension: string
  *   aliases: readonly string[]
- *   config?: ParseOptions
  * }} Language
  */
 
-/**
- * Disable JavaScript-only scanner modes for a non-JavaScript language.
- * @param {ParseOptions} config
- * @returns {ParseOptions}
- */
-function nonJavaScript(config) {
-  return {
-    ...config,
-    jsx: false,
-    regex: false,
-    templateStrings: false,
-  }
-}
+const definitions = Object.freeze([
+  { id: 'javascript', extension: 'js', aliases: Object.freeze(['js', 'jsx', 'node']) },
+  { id: 'typescript', extension: 'ts', aliases: Object.freeze(['ts', 'tsx']) },
+  { id: 'css', extension: 'css', aliases: Object.freeze(['scss']) },
+  { id: 'python', extension: 'py', aliases: Object.freeze(['py', 'python3']) },
+  { id: 'c', extension: 'c', aliases: Object.freeze([]) },
+  { id: 'go', extension: 'go', aliases: Object.freeze(['golang']) },
+  { id: 'java', extension: 'java', aliases: Object.freeze([]) },
+  { id: 'rust', extension: 'rs', aliases: Object.freeze(['rs']) },
+  { id: 'json', extension: 'json', aliases: Object.freeze(['jsonc']) },
+  { id: 'diff', extension: 'diff', aliases: Object.freeze(['patch']) },
+  { id: 'shell', extension: 'sh', aliases: Object.freeze(['sh', 'bash', 'zsh']) },
+  { id: 'cpp', extension: 'cpp', aliases: Object.freeze(['c++', 'cc', 'cxx']) },
+  { id: 'csharp', extension: 'cs', aliases: Object.freeze(['c#', 'cs', 'dotnet']) },
+  { id: 'sql', extension: 'sql', aliases: Object.freeze([]) },
+  { id: 'html', extension: 'html', aliases: Object.freeze(['htm', 'xml']) },
+  { id: 'yaml', extension: 'yaml', aliases: Object.freeze(['yml']) },
+  { id: 'markdown', extension: 'md', aliases: Object.freeze(['md', 'mdx']) },
+  { id: 'kotlin', extension: 'kt', aliases: Object.freeze(['kts']) },
+  { id: 'swift', extension: 'swift', aliases: Object.freeze([]) },
+  { id: 'php', extension: 'php', aliases: Object.freeze([]) },
+  { id: 'toml', extension: 'toml', aliases: Object.freeze([]) },
+  { id: 'powershell', extension: 'ps1', aliases: Object.freeze(['pwsh']) },
+  { id: 'dockerfile', extension: 'dockerfile', aliases: Object.freeze(['docker']) },
+  { id: 'graphql', extension: 'graphql', aliases: Object.freeze(['gql']) },
+  { id: 'hcl', extension: 'hcl', aliases: Object.freeze(['terraform', 'tf']) },
+])
 
 /** @type {readonly Language[]} */
-const languages = Object.freeze([
-  { id: 'javascript', extension: 'js', aliases: Object.freeze(['js', 'jsx', 'node']), config: javascript },
-  { id: 'typescript', extension: 'ts', aliases: Object.freeze(['ts', 'tsx']), config: typescript },
-  { id: 'css', extension: 'css', aliases: Object.freeze(['scss']), config: nonJavaScript(css) },
-  { id: 'python', extension: 'py', aliases: Object.freeze(['py', 'python3']), config: nonJavaScript(python) },
-  { id: 'c', extension: 'c', aliases: Object.freeze([]), config: nonJavaScript(c) },
-  { id: 'go', extension: 'go', aliases: Object.freeze(['golang']), config: nonJavaScript(go) },
-  { id: 'java', extension: 'java', aliases: Object.freeze([]), config: nonJavaScript(java) },
-  { id: 'rust', extension: 'rs', aliases: Object.freeze(['rs']), config: nonJavaScript(rust) },
-  { id: 'json', extension: 'json', aliases: Object.freeze(['jsonc']), config: nonJavaScript(json) },
-  { id: 'diff', extension: 'diff', aliases: Object.freeze(['patch']), config: nonJavaScript(diff) },
-  { id: 'shell', extension: 'sh', aliases: Object.freeze(['sh', 'bash', 'zsh']), config: nonJavaScript(shell) },
-  { id: 'cpp', extension: 'cpp', aliases: Object.freeze(['c++', 'cc', 'cxx']), config: nonJavaScript(cpp) },
-  { id: 'csharp', extension: 'cs', aliases: Object.freeze(['c#', 'cs', 'dotnet']), config: nonJavaScript(csharp) },
-  { id: 'sql', extension: 'sql', aliases: Object.freeze([]), config: nonJavaScript(sql) },
-  { id: 'html', extension: 'html', aliases: Object.freeze(['htm', 'xml']), config: html },
-  { id: 'yaml', extension: 'yaml', aliases: Object.freeze(['yml']), config: nonJavaScript(yaml) },
-  { id: 'markdown', extension: 'md', aliases: Object.freeze(['md', 'mdx']), config: nonJavaScript(markdown) },
-  { id: 'kotlin', extension: 'kt', aliases: Object.freeze(['kts']), config: nonJavaScript(kotlin) },
-  { id: 'swift', extension: 'swift', aliases: Object.freeze([]), config: nonJavaScript(swift) },
-  { id: 'php', extension: 'php', aliases: Object.freeze([]), config: nonJavaScript(php) },
-  { id: 'toml', extension: 'toml', aliases: Object.freeze([]), config: nonJavaScript(toml) },
-  { id: 'powershell', extension: 'ps1', aliases: Object.freeze(['pwsh']), config: nonJavaScript(powershell) },
-  { id: 'dockerfile', extension: 'dockerfile', aliases: Object.freeze(['docker']), config: nonJavaScript(dockerfile) },
-  { id: 'graphql', extension: 'graphql', aliases: Object.freeze(['gql']), config: nonJavaScript(graphql) },
-  { id: 'hcl', extension: 'hcl', aliases: Object.freeze(['terraform', 'tf']), config: nonJavaScript(hcl) },
-])
+const languages = definitions
 
 /** @param {string} value */
 function normalizeLanguageName(value) {
@@ -87,7 +47,7 @@ function normalizeLanguageName(value) {
 /** @type {Map<string, Language>} */
 const languageLookup = new Map()
 
-for (const language of languages) {
+for (const language of definitions) {
   const names = new Set([language.id, language.extension, ...language.aliases])
   for (const name of names) {
     const normalized = normalizeLanguageName(name)

--- a/packages/sugar-high/lib/registry.d.ts
+++ b/packages/sugar-high/lib/registry.d.ts
@@ -1,0 +1,10 @@
+import type { ParseOptions } from './core.js'
+import type { Language } from './lang.js'
+
+export type RegisteredLanguage = Language & Readonly<{
+  config: ParseOptions
+}>
+
+export type Registry = readonly RegisteredLanguage[]
+
+export const registry: Registry

--- a/packages/sugar-high/lib/registry.js
+++ b/packages/sugar-high/lib/registry.js
@@ -1,0 +1,51 @@
+// @ts-check
+
+import * as c from './presets/lang/c.js'
+import * as cpp from './presets/lang/cpp.js'
+import * as csharp from './presets/lang/csharp.js'
+import * as css from './presets/lang/css.js'
+import * as diff from './presets/lang/diff.js'
+import * as dockerfile from './presets/lang/dockerfile.js'
+import * as go from './presets/lang/go.js'
+import * as html from './presets/lang/html.js'
+import * as graphql from './presets/lang/graphql.js'
+import * as hcl from './presets/lang/hcl.js'
+import * as java from './presets/lang/java.js'
+import * as json from './presets/lang/json.js'
+import * as javascript from './presets/lang/javascript.js'
+import * as kotlin from './presets/lang/kotlin.js'
+import * as markdown from './presets/lang/markdown.js'
+import * as php from './presets/lang/php.js'
+import * as powershell from './presets/lang/powershell.js'
+import * as python from './presets/lang/python.js'
+import * as rust from './presets/lang/rust.js'
+import * as shell from './presets/lang/shell.js'
+import * as sql from './presets/lang/sql.js'
+import * as swift from './presets/lang/swift.js'
+import * as toml from './presets/lang/toml.js'
+import * as typescript from './presets/lang/typescript.js'
+import * as yaml from './presets/lang/yaml.js'
+import { languages } from './lang.js'
+
+const configs = {
+  c, cpp, csharp, css, diff, dockerfile, go, graphql, hcl, html, java, javascript,
+  json, kotlin, markdown, php, powershell, python, rust, shell, sql, swift, toml,
+  typescript, yaml,
+}
+
+const javascriptModes = new Set(['javascript', 'typescript', 'html'])
+
+/** @type {import('./registry.js').Registry} */
+const registry = Object.freeze(languages.map(language => Object.freeze({
+  ...language,
+  config: javascriptModes.has(language.id)
+    ? configs[language.id]
+    : {
+        ...configs[language.id],
+        jsx: false,
+        regex: false,
+        templateStrings: false,
+      },
+})))
+
+export { registry }

--- a/packages/sugar-high/package.json
+++ b/packages/sugar-high/package.json
@@ -21,6 +21,10 @@
     "./lang": {
       "types": "./lib/lang.d.ts",
       "default": "./lib/lang.js"
+    },
+    "./registry": {
+      "types": "./lib/registry.d.ts",
+      "default": "./lib/registry.js"
     }
   },
   "description": "Super lightweight JSX syntax highlighter",

--- a/packages/sugar-high/scripts/benchmark.mjs
+++ b/packages/sugar-high/scripts/benchmark.mjs
@@ -60,16 +60,22 @@ const benchmarkDir = mkdtempSync(join(tmpdir(), 'sugar-high-benchmark-'))
 
 try {
   const javascriptEntry = join(benchmarkDir, 'javascript-entry.js')
+  const langEntry = join(benchmarkDir, 'lang-entry.js')
   writeFileSync(javascriptEntry, [
     `import { parse, render } from ${JSON.stringify(join(process.cwd(), 'lib/core.js'))}`,
     `import * as javascript from ${JSON.stringify(join(process.cwd(), 'lib/presets/lang/javascript.js'))}`,
     'export const run = code => render(parse(code, javascript))',
+  ].join('\n'))
+  writeFileSync(langEntry, [
+    `import { lang } from ${JSON.stringify(join(process.cwd(), 'lib/lang.js'))}`,
+    'export const run = lang',
   ].join('\n'))
 
   const sizes = [
     ['sugar-high', measureBundle('lib/index.js', join(benchmarkDir, 'builtin.js'))],
     ['sugar-high/core', measureBundle('lib/core.js', join(benchmarkDir, 'core.js'))],
     ['core + javascript', measureBundle(javascriptEntry, join(benchmarkDir, 'javascript.js'))],
+    ['sugar-high/lang', measureBundle(langEntry, join(benchmarkDir, 'lang.js'))],
   ]
 
   console.log(`Size (Bun browser ESM, minified)\n`)

--- a/packages/sugar-high/test/languages.test.ts
+++ b/packages/sugar-high/test/languages.test.ts
@@ -2,10 +2,11 @@ import { describe, expect, it } from 'vitest'
 import { highlight } from 'sugar-high'
 import * as core from 'sugar-high/core'
 import { lang, languages } from 'sugar-high/lang'
+import { registry } from 'sugar-high/registry'
 import { getTokensAsString } from './testing-utils'
 
 const tokenize = (code, { lang }) =>
-  core.tokenize(code, languages.find(({ id }) => id === lang)?.config)
+  core.tokenize(code, registry.find(({ id }) => id === lang)?.config)
 
 describe('language registry', () => {
   it.each([
@@ -76,7 +77,7 @@ describe('language registry', () => {
   })
 
   it('disables JavaScript-only scanner modes for other languages', () => {
-    const language = languages.find(({ id }) => id === lang('jsonc'))
+    const language = registry.find(({ id }) => id === lang('jsonc'))
     expect(language?.config).toMatchObject({
       jsx: false,
       regex: false,

--- a/packages/sugar-high/test/preset/first-wave.test.ts
+++ b/packages/sugar-high/test/preset/first-wave.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import { highlight } from '../..'
 import * as core from '../../lib/core.js'
-import { languages } from '../../lib/lang.js'
+import { registry } from '../../lib/registry.js'
 import { getTokensAsString } from '../testing-utils'
 
 const tokenize = (code, { lang }) =>
-  core.tokenize(code, languages.find(({ id }) => id === lang)?.config)
+  core.tokenize(code, registry.find(({ id }) => id === lang)?.config)
 
 describe('first-wave language presets', () => {
   it('highlights the canonical shell language and hash comments', () => {

--- a/packages/sugar-high/test/preset/second-wave.test.ts
+++ b/packages/sugar-high/test/preset/second-wave.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import type { LanguageName } from '../..'
 import * as core from '../../lib/core.js'
-import { languages } from '../../lib/lang.js'
+import { registry } from '../../lib/registry.js'
 import { getTokensAsString } from '../testing-utils'
 
 const tokenize = (code, { lang }) =>
-  core.tokenize(code, languages.find(({ id }) => id === lang)?.config)
+  core.tokenize(code, registry.find(({ id }) => id === lang)?.config)
 
 const cases: Array<[LanguageName, string, string, string]> = [
   ['kotlin', 'data class User(val name: String)', 'data => keyword', 'String => class'],


### PR DESCRIPTION
Stacked on #188. Part of #186.

Separates language metadata from the built-in syntax registry:

```js
import { lang } from "sugar-high/lang"
import { registry } from "sugar-high/registry"
```

Most applications only need lang(). Advanced integrations that combine built-ins with parse() use registry. The lang-only browser bundle drops from about 20.8 KiB to 2.0 KiB minified (about 0.65 KiB gzip), and the benchmark now tracks it.