### PR TITLE
Harden the v2 release boundary

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v4
-
-
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
         with:
-          node-version: '18'
-      - run: pnpm install
+          version: 9.15.9
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          package-manager-cache: false
+      - run: pnpm install --frozen-lockfile
       - run: pnpm test
+      - run: pnpm build
+      - run: pnpm check:packages

--- a/apps/docs/app/react/page.tsx
+++ b/apps/docs/app/react/page.tsx
@@ -1,10 +1,10 @@
-import { Code } from '@sugar-high/react/code'
+import { Code } from '@sugar-high/react'
 import Link from 'next/link'
 import { ReactDemo } from './react-demo'
 import '../product-page.css'
 import './page.css'
 
-const codeBlockExample = `import { Code } from '@sugar-high/react/code'
+const codeBlockExample = `import { Code } from '@sugar-high/react'
 import { highlight } from 'sugar-high'
 
 function renderMarkup() {

--- a/docs/API.md
+++ b/docs/API.md
@@ -15,7 +15,8 @@ highlight('print("hi")', { lang: 'python' })
 ```
 
 The `lang` option accepts canonical language names only. TypeScript autocompletes the supported
-names.
+names. In plain JavaScript, an unrecognized name uses the general-purpose lexer. Normalize external
+input with `lang()` when you want to detect unsupported names before highlighting.
 
 ### `sugar-high/core`
 
@@ -34,7 +35,7 @@ const html = render(parsed, {
 })
 ```
 
-### `sugar-high/lang`
+### Advanced: `sugar-high/lang`
 
 `lang(input)` normalizes a canonical name, filename extension, or common fence alias to the
 canonical name accepted by the default highlighter. It trims whitespace, ignores case, accepts a
@@ -49,8 +50,9 @@ lang('.PY')    // 'python'
 lang('unknown') // undefined
 ```
 
-Use it at integration boundaries, such as Markdown fence names or a file extension supplied by an
-editor. If you already have a canonical name, pass it directly to `highlight`.
+You do not need `lang()` when the language is already known. Use it at integration boundaries,
+such as Markdown fence names or a file extension supplied by an editor. If you already have a
+canonical name, pass it directly to `highlight`.
 
 ```js
 highlight(source, { lang: 'python' })
@@ -195,7 +197,7 @@ highlight(source, {
 The higher-level integrations provide their own line-selection syntax:
 
 ```tsx
-import { Code } from '@sugar-high/react/code'
+import { Code } from '@sugar-high/react'
 
 <Code highlightLines={[1, [4, 7]]}>{source}</Code>
 ```
@@ -238,3 +240,13 @@ Core API. Converts parsed code to HTML and accepts only display customization: `
 Core API. Builds typed line and token nodes for integrations that render through React or another
 syntax tree instead of HTML. Generated token nodes expose their semantic `tokenType` separately
 from the syntax-tree `type: 'element'` field.
+
+## Processing order
+
+Parsing tokenizes the source, assembles lines, and then runs the language configuration's
+`annotateLine` hook. Generation creates default annotation classes and runs `markLine`; each token
+then receives its default class and style, followed by `cx` and `mark`. `render()` serializes those
+generated nodes to HTML.
+
+`annotateLine` belongs to language configurations and records syntax meaning. `markLine`, `cx`, and
+`mark` belong to display options and control presentation.

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,0 +1,76 @@
+# Migrating to Sugar High v2
+
+Sugar High v2 keeps one-step highlighting small while making languages and rendering explicitly
+composable.
+
+## Highlight with options
+
+Pass the canonical language in the options object:
+
+```js
+import { highlight } from 'sugar-high'
+
+highlight(source, { lang: 'python' })
+```
+
+JavaScript, including JSX, remains the default. TypeScript includes TSX.
+
+## Normalize external language names
+
+The root package accepts canonical names. Normalize filename extensions and fence aliases at the
+integration boundary:
+
+```js
+import { lang } from 'sugar-high/lang'
+
+highlight(source, { lang: lang(extension) })
+```
+
+`lang('py')` returns `python`, `lang('bash')` returns `shell`, and unsupported inputs return
+`undefined`.
+
+## Move low-level work to core
+
+Parsing, tokenization, node generation, and rendering live under `sugar-high/core`:
+
+```js
+import { parse, render } from 'sugar-high/core'
+
+const parsed = parse(source, config)
+const html = render(parsed, options)
+```
+
+## Customize output
+
+Use `cx` for token classes, `mark` for individual generated tokens, and `markLine` for generated
+lines:
+
+```js
+highlight(source, {
+  cx: { keyword: 'font-bold' },
+  mark(token) {
+    if (token.value === 'TODO') token.properties['data-todo'] = true
+  },
+  markLine(line) {
+    if (line.index === 1) line.className += ' selected'
+  },
+})
+```
+
+These callbacks mutate their argument and return nothing.
+
+## React and Remark
+
+The editor and code block are available from `@sugar-high/react`:
+
+```tsx
+import { Code, Editor } from '@sugar-high/react'
+```
+
+The Remark plugin is ESM and supports both default and named imports:
+
+```js
+import remarkSugarHigh, { highlight } from '@sugar-high/remark'
+```
+
+See the [API reference](API.md) for the full language mapping and v2 types.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "clean": "pnpm -r run clean",
     "site": "pnpm --filter docs dev",
     "docs:build": "pnpm build && pnpm --filter docs build",
+    "check:packages": "node scripts/check-packages.mjs",
     "release-video:studio": "pnpm --filter release-video dev",
     "release-video:render": "pnpm --filter release-video render",
     "changeset": "changeset",

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -24,7 +24,7 @@ import { Editor } from '@sugar-high/react'
 ## Code
 
 ```tsx
-import { Code } from '@sugar-high/react/code'
+import { Code } from '@sugar-high/react'
 
 <Code lang="python" title="main.py" lineNumbers cx={{ keyword: 'font-bold' }}>
   {'def hello():\n    return "world"'}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -14,14 +14,6 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
-    },
-    "./editor": {
-      "types": "./dist/editor/index.d.ts",
-      "default": "./dist/editor/index.js"
-    },
-    "./code": {
-      "types": "./dist/code/index.d.ts",
-      "default": "./dist/code/index.js"
     }
   },
   "files": [

--- a/packages/sugar-high/README.md
+++ b/packages/sugar-high/README.md
@@ -33,10 +33,11 @@ highlight('+ added', { lang: 'diff' })
 
 The `lang` option is typed and accepts canonical names only.
 
-## Normalize extensions and aliases
+## Advanced: normalize extensions and aliases
 
-Use `lang()` when input comes from a filename extension, Markdown fence, or another integration.
-It converts aliases to the canonical name expected by `highlight`:
+You do not need `lang()` when the language is already known. Use it only when input comes from a
+filename extension, Markdown fence, or another integration. It converts aliases to the canonical
+name expected by `highlight`:
 
 ```js
 import { lang } from 'sugar-high/lang'
@@ -178,8 +179,7 @@ pre code {
 and textarea-overlay `<Editor />` as separate composable exports.
 
 ```tsx
-import { Editor } from '@sugar-high/react'
-import { Code } from '@sugar-high/react/code'
+import { Code, Editor } from '@sugar-high/react'
 
 <Editor lang="typescript" value={source} onChange={setSource} />
 <Code lang="typescript" lineNumbers>{source}</Code>
@@ -192,8 +192,9 @@ processing Markdown. Fence aliases are normalized through the same `lang()` mapp
 
 ## API
 
-See [`docs/API.md`](../../docs/API.md) for package exports, the full language mapping, highlighting
-options, and lower-level functions.
+See [`docs/API.md`](https://github.com/huozhi/sugar-high/blob/main/docs/API.md) for package exports, the full language mapping, highlighting
+options, and lower-level functions. Upgrading from v1? Read the
+[v2 migration guide](https://github.com/huozhi/sugar-high/blob/main/docs/MIGRATION.md).
 
 ## Benchmarking
 

--- a/packages/sugar-high/lib/lang.js
+++ b/packages/sugar-high/lib/lang.js
@@ -26,6 +26,8 @@ import * as toml from './presets/lang/toml.js'
 import * as typescript from './presets/lang/typescript.js'
 import * as yaml from './presets/lang/yaml.js'
 
+const freeze = Object.freeze
+
 /**
  * @typedef {import('./core.js').ParseOptions} ParseOptions
  * @typedef {{
@@ -51,32 +53,32 @@ function nonJavaScript(config) {
 }
 
 /** @type {readonly Language[]} */
-const languages = Object.freeze([
-  { id: 'javascript', extension: 'js', aliases: Object.freeze(['js', 'jsx', 'node']), config: javascript },
-  { id: 'typescript', extension: 'ts', aliases: Object.freeze(['ts', 'tsx']), config: typescript },
-  { id: 'css', extension: 'css', aliases: Object.freeze(['scss']), config: nonJavaScript(css) },
-  { id: 'python', extension: 'py', aliases: Object.freeze(['py', 'python3']), config: nonJavaScript(python) },
-  { id: 'c', extension: 'c', aliases: Object.freeze([]), config: nonJavaScript(c) },
-  { id: 'go', extension: 'go', aliases: Object.freeze(['golang']), config: nonJavaScript(go) },
-  { id: 'java', extension: 'java', aliases: Object.freeze([]), config: nonJavaScript(java) },
-  { id: 'rust', extension: 'rs', aliases: Object.freeze(['rs']), config: nonJavaScript(rust) },
-  { id: 'json', extension: 'json', aliases: Object.freeze(['jsonc']), config: nonJavaScript(json) },
-  { id: 'diff', extension: 'diff', aliases: Object.freeze(['patch']), config: nonJavaScript(diff) },
-  { id: 'shell', extension: 'sh', aliases: Object.freeze(['sh', 'bash', 'zsh']), config: nonJavaScript(shell) },
-  { id: 'cpp', extension: 'cpp', aliases: Object.freeze(['c++', 'cc', 'cxx']), config: nonJavaScript(cpp) },
-  { id: 'csharp', extension: 'cs', aliases: Object.freeze(['c#', 'cs', 'dotnet']), config: nonJavaScript(csharp) },
-  { id: 'sql', extension: 'sql', aliases: Object.freeze([]), config: nonJavaScript(sql) },
-  { id: 'html', extension: 'html', aliases: Object.freeze(['htm', 'xml']), config: html },
-  { id: 'yaml', extension: 'yaml', aliases: Object.freeze(['yml']), config: nonJavaScript(yaml) },
-  { id: 'markdown', extension: 'md', aliases: Object.freeze(['md', 'mdx']), config: nonJavaScript(markdown) },
-  { id: 'kotlin', extension: 'kt', aliases: Object.freeze(['kts']), config: nonJavaScript(kotlin) },
-  { id: 'swift', extension: 'swift', aliases: Object.freeze([]), config: nonJavaScript(swift) },
-  { id: 'php', extension: 'php', aliases: Object.freeze([]), config: nonJavaScript(php) },
-  { id: 'toml', extension: 'toml', aliases: Object.freeze([]), config: nonJavaScript(toml) },
-  { id: 'powershell', extension: 'ps1', aliases: Object.freeze(['pwsh']), config: nonJavaScript(powershell) },
-  { id: 'dockerfile', extension: 'dockerfile', aliases: Object.freeze(['docker']), config: nonJavaScript(dockerfile) },
-  { id: 'graphql', extension: 'graphql', aliases: Object.freeze(['gql']), config: nonJavaScript(graphql) },
-  { id: 'hcl', extension: 'hcl', aliases: Object.freeze(['terraform', 'tf']), config: nonJavaScript(hcl) },
+const languages = freeze([
+  { id: 'javascript', extension: 'js', aliases: freeze(['js', 'jsx', 'node']), config: javascript },
+  { id: 'typescript', extension: 'ts', aliases: freeze(['ts', 'tsx']), config: typescript },
+  { id: 'css', extension: 'css', aliases: freeze(['scss']), config: nonJavaScript(css) },
+  { id: 'python', extension: 'py', aliases: freeze(['py', 'python3']), config: nonJavaScript(python) },
+  { id: 'c', extension: 'c', aliases: freeze([]), config: nonJavaScript(c) },
+  { id: 'go', extension: 'go', aliases: freeze(['golang']), config: nonJavaScript(go) },
+  { id: 'java', extension: 'java', aliases: freeze([]), config: nonJavaScript(java) },
+  { id: 'rust', extension: 'rs', aliases: freeze(['rs']), config: nonJavaScript(rust) },
+  { id: 'json', extension: 'json', aliases: freeze(['jsonc']), config: nonJavaScript(json) },
+  { id: 'diff', extension: 'diff', aliases: freeze(['patch']), config: nonJavaScript(diff) },
+  { id: 'shell', extension: 'sh', aliases: freeze(['sh', 'bash', 'zsh']), config: nonJavaScript(shell) },
+  { id: 'cpp', extension: 'cpp', aliases: freeze(['c++', 'cc', 'cxx']), config: nonJavaScript(cpp) },
+  { id: 'csharp', extension: 'cs', aliases: freeze(['c#', 'cs', 'dotnet']), config: nonJavaScript(csharp) },
+  { id: 'sql', extension: 'sql', aliases: freeze([]), config: nonJavaScript(sql) },
+  { id: 'html', extension: 'html', aliases: freeze(['htm', 'xml']), config: html },
+  { id: 'yaml', extension: 'yaml', aliases: freeze(['yml']), config: nonJavaScript(yaml) },
+  { id: 'markdown', extension: 'md', aliases: freeze(['md', 'mdx']), config: nonJavaScript(markdown) },
+  { id: 'kotlin', extension: 'kt', aliases: freeze(['kts']), config: nonJavaScript(kotlin) },
+  { id: 'swift', extension: 'swift', aliases: freeze([]), config: nonJavaScript(swift) },
+  { id: 'php', extension: 'php', aliases: freeze([]), config: nonJavaScript(php) },
+  { id: 'toml', extension: 'toml', aliases: freeze([]), config: nonJavaScript(toml) },
+  { id: 'powershell', extension: 'ps1', aliases: freeze(['pwsh']), config: nonJavaScript(powershell) },
+  { id: 'dockerfile', extension: 'dockerfile', aliases: freeze(['docker']), config: nonJavaScript(dockerfile) },
+  { id: 'graphql', extension: 'graphql', aliases: freeze(['gql']), config: nonJavaScript(graphql) },
+  { id: 'hcl', extension: 'hcl', aliases: freeze(['terraform', 'tf']), config: nonJavaScript(hcl) },
 ])
 
 /** @param {string} value */

--- a/packages/sugar-high/package.json
+++ b/packages/sugar-high/package.json
@@ -23,7 +23,7 @@
       "default": "./lib/lang.js"
     }
   },
-  "description": "Super lightweight JSX syntax highlighter",
+  "description": "Lightweight, zero-dependency syntax highlighting for popular programming languages",
   "files": [
     "lib"
   ],

--- a/packages/sugar-high/test/core.test.ts
+++ b/packages/sugar-high/test/core.test.ts
@@ -70,4 +70,29 @@ describe('composable core export', () => {
     expect(line.children[0].type).toBe('element')
     expect(line.children[0].tokenType).toBe('keyword')
   })
+
+  it('runs syntax annotation before line and token display hooks', () => {
+    const calls: string[] = []
+    const parsed = parse('const', {
+      keywords: new Set(['const']),
+      annotateLine(line) {
+        calls.push('annotateLine')
+        line.annotations.push('example')
+      },
+    })
+
+    generate(parsed, {
+      cx: { keyword: 'bold' },
+      markLine(line) {
+        calls.push('markLine')
+        expect(line.className).toContain('sh__line--example')
+      },
+      mark(token) {
+        calls.push('mark')
+        expect(token.className).toContain('bold')
+      },
+    })
+
+    expect(calls).toEqual(['annotateLine', 'markLine', 'mark'])
+  })
 })

--- a/scripts/check-packages.mjs
+++ b/scripts/check-packages.mjs
@@ -1,0 +1,88 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)))
+const temporary = mkdtempSync(join(tmpdir(), 'sugar-high-packages-'))
+
+const run = (command, args, cwd = root) => execFileSync(command, args, {
+  cwd,
+  stdio: 'inherit',
+})
+
+const pack = (directory, name) => {
+  run('pnpm', ['pack', '--pack-destination', temporary], join(root, directory))
+  return join(temporary, readdirSync(temporary).find(file => file.startsWith(name) && file.endsWith('.tgz')))
+}
+
+try {
+  const sugarHigh = pack('packages/sugar-high', 'sugar-high-')
+  const react = pack('packages/react', 'sugar-high-react-')
+  const remark = pack('packages/remark', 'sugar-high-remark-')
+
+  writeFileSync(join(temporary, 'package.json'), JSON.stringify({
+    private: true,
+    type: 'module',
+    dependencies: {
+      '@sugar-high/react': `file:${react}`,
+      '@sugar-high/remark': `file:${remark}`,
+      '@types/react': '^19.2.0',
+      react: '^19.2.0',
+      'sugar-high': `file:${sugarHigh}`,
+    },
+    pnpm: {
+      overrides: {
+        '@sugar-high/remark>sugar-high': `file:${sugarHigh}`,
+      },
+    },
+  }, null, 2))
+
+  writeFileSync(join(temporary, 'check.mjs'), `
+import { highlight } from 'sugar-high'
+import { generate, parse, render, tokenize, SugarHigh } from 'sugar-high/core'
+import { lang, languages } from 'sugar-high/lang'
+import { Code, Editor } from '@sugar-high/react'
+import remarkSugarHigh, { highlight as remarkHighlight } from '@sugar-high/remark'
+
+if (!highlight('const ready = true').includes('sh__token--keyword')) throw new Error('root export')
+if (!render(parse('const ready = true')).includes('sh__line')) throw new Error('core export')
+if (generate(parse('value'))[0].children[0].tokenType !== 'identifier') throw new Error('generated nodes')
+if (!tokenize('value').length || !SugarHigh.TokenMap.size) throw new Error('low-level core')
+if (lang('py') !== 'python' || !languages.length) throw new Error('language exports')
+if (!Editor || !Code || remarkSugarHigh !== remarkHighlight) throw new Error('integration exports')
+`)
+
+  writeFileSync(join(temporary, 'check.ts'), `
+import { highlight, type HighlightOptions, type LanguageName } from 'sugar-high'
+import { generate, parse, render, tokenize, SugarHigh } from 'sugar-high/core'
+import { lang, languages } from 'sugar-high/lang'
+import { Code, Editor } from '@sugar-high/react'
+import remarkSugarHigh, { highlight as remarkHighlight } from '@sugar-high/remark'
+
+const language: LanguageName = 'typescript'
+const options: HighlightOptions = { lang: language, cx: { keyword: 'bold' } }
+highlight('const ready = true', options)
+render(parse('value'))
+generate(parse('value'))[0].children[0].tokenType
+tokenize('value')
+SugarHigh.TokenMap.size
+lang('tsx')
+languages.length
+Editor
+Code
+remarkSugarHigh
+remarkHighlight
+`)
+
+  run('pnpm', ['install', '--prefer-offline', '--ignore-scripts'], temporary)
+  run('node', ['check.mjs'], temporary)
+  run('pnpm', [
+    '--filter', 'sugar-high', 'exec', 'tsc', '--noEmit', '--strict', '--skipLibCheck',
+    '--module', 'NodeNext', '--moduleResolution', 'NodeNext', '--target', 'ES2022',
+    join(temporary, 'check.ts'),
+  ])
+} finally {
+  rmSync(temporary, { recursive: true, force: true })
+}


### PR DESCRIPTION
Part of #186.

Finishes the non-release v2 preparation:

- imports both Code and Editor from @sugar-high/react and removes unnecessary component subpaths
- checks packed tarballs through runtime and TypeScript consumer imports
- treats lang() as an advanced extension and fence normalization helper
- documents unknown-language behavior and hook ordering
- reuses Object.freeze in the language registry to reduce repeated bytes
- adds the v1 to v2 migration guide
- modernizes test CI and refreshes package metadata

No new package export is introduced. No Changeset is included.