### PR TITLE
Keep the root API boundary explicit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,20 @@
 - Add a Changeset with `pnpm changeset` for user-facing package changes. Do not add one for
   internal-only work unless requested.
 
+# Architecture
+
+- Keep the default API focused on the common path. Put advanced composition in existing subpaths
+  such as `sugar-high/core`; do not add an export or option when the current API can express it.
+- Prefer short canonical names with one meaning. Avoid aliases for the same operation, duplicate
+  exports, and separate language implementations for compatible dialects.
+- Keep options few and orthogonal: language selection, class composition, and mutable display
+  hooks should remain distinct. The root highlighter must not forward undocumented options into
+  core parsing.
+- Treat exported language metadata and configurations as shared read-only data. Do not mutate the
+  registry at runtime; copy a configuration before extending it.
+- Bundle size is part of every API and architecture decision. Measure affected entry points and
+  prefer the simpler design when added abstraction does not earn its bytes.
+
 # Releases
 
 - Pushes to `main` may create/update the Changesets version PR but must never publish packages.

--- a/packages/sugar-high/lib/index.js
+++ b/packages/sugar-high/lib/index.js
@@ -13,8 +13,8 @@ function configFor(name) {
 
 /** @param {string} code @param {HighlightOptions | undefined} options */
 function highlight(code, options) {
-  const { lang, cx, mark, markLine, ...config } = options || {}
-  const parsed = parse(code, { ...configFor(lang), ...config })
+  const { lang, cx, mark, markLine } = options || {}
+  const parsed = parse(code, configFor(lang))
   return render(parsed, { cx, mark, markLine })
 }
 

--- a/packages/sugar-high/lib/lang.js
+++ b/packages/sugar-high/lib/lang.js
@@ -26,8 +26,6 @@ import * as toml from './presets/lang/toml.js'
 import * as typescript from './presets/lang/typescript.js'
 import * as yaml from './presets/lang/yaml.js'
 
-const freeze = Object.freeze
-
 /**
  * @typedef {import('./core.js').ParseOptions} ParseOptions
  * @typedef {{
@@ -53,33 +51,33 @@ function nonJavaScript(config) {
 }
 
 /** @type {readonly Language[]} */
-const languages = freeze([
-  { id: 'javascript', extension: 'js', aliases: freeze(['js', 'jsx', 'node']), config: javascript },
-  { id: 'typescript', extension: 'ts', aliases: freeze(['ts', 'tsx']), config: typescript },
-  { id: 'css', extension: 'css', aliases: freeze(['scss']), config: nonJavaScript(css) },
-  { id: 'python', extension: 'py', aliases: freeze(['py', 'python3']), config: nonJavaScript(python) },
-  { id: 'c', extension: 'c', aliases: freeze([]), config: nonJavaScript(c) },
-  { id: 'go', extension: 'go', aliases: freeze(['golang']), config: nonJavaScript(go) },
-  { id: 'java', extension: 'java', aliases: freeze([]), config: nonJavaScript(java) },
-  { id: 'rust', extension: 'rs', aliases: freeze(['rs']), config: nonJavaScript(rust) },
-  { id: 'json', extension: 'json', aliases: freeze(['jsonc']), config: nonJavaScript(json) },
-  { id: 'diff', extension: 'diff', aliases: freeze(['patch']), config: nonJavaScript(diff) },
-  { id: 'shell', extension: 'sh', aliases: freeze(['sh', 'bash', 'zsh']), config: nonJavaScript(shell) },
-  { id: 'cpp', extension: 'cpp', aliases: freeze(['c++', 'cc', 'cxx']), config: nonJavaScript(cpp) },
-  { id: 'csharp', extension: 'cs', aliases: freeze(['c#', 'cs', 'dotnet']), config: nonJavaScript(csharp) },
-  { id: 'sql', extension: 'sql', aliases: freeze([]), config: nonJavaScript(sql) },
-  { id: 'html', extension: 'html', aliases: freeze(['htm', 'xml']), config: html },
-  { id: 'yaml', extension: 'yaml', aliases: freeze(['yml']), config: nonJavaScript(yaml) },
-  { id: 'markdown', extension: 'md', aliases: freeze(['md', 'mdx']), config: nonJavaScript(markdown) },
-  { id: 'kotlin', extension: 'kt', aliases: freeze(['kts']), config: nonJavaScript(kotlin) },
-  { id: 'swift', extension: 'swift', aliases: freeze([]), config: nonJavaScript(swift) },
-  { id: 'php', extension: 'php', aliases: freeze([]), config: nonJavaScript(php) },
-  { id: 'toml', extension: 'toml', aliases: freeze([]), config: nonJavaScript(toml) },
-  { id: 'powershell', extension: 'ps1', aliases: freeze(['pwsh']), config: nonJavaScript(powershell) },
-  { id: 'dockerfile', extension: 'dockerfile', aliases: freeze(['docker']), config: nonJavaScript(dockerfile) },
-  { id: 'graphql', extension: 'graphql', aliases: freeze(['gql']), config: nonJavaScript(graphql) },
-  { id: 'hcl', extension: 'hcl', aliases: freeze(['terraform', 'tf']), config: nonJavaScript(hcl) },
-])
+const languages = [
+  { id: 'javascript', extension: 'js', aliases: ['js', 'jsx', 'node'], config: javascript },
+  { id: 'typescript', extension: 'ts', aliases: ['ts', 'tsx'], config: typescript },
+  { id: 'css', extension: 'css', aliases: ['scss'], config: nonJavaScript(css) },
+  { id: 'python', extension: 'py', aliases: ['py', 'python3'], config: nonJavaScript(python) },
+  { id: 'c', extension: 'c', aliases: [], config: nonJavaScript(c) },
+  { id: 'go', extension: 'go', aliases: ['golang'], config: nonJavaScript(go) },
+  { id: 'java', extension: 'java', aliases: [], config: nonJavaScript(java) },
+  { id: 'rust', extension: 'rs', aliases: ['rs'], config: nonJavaScript(rust) },
+  { id: 'json', extension: 'json', aliases: ['jsonc'], config: nonJavaScript(json) },
+  { id: 'diff', extension: 'diff', aliases: ['patch'], config: nonJavaScript(diff) },
+  { id: 'shell', extension: 'sh', aliases: ['sh', 'bash', 'zsh'], config: nonJavaScript(shell) },
+  { id: 'cpp', extension: 'cpp', aliases: ['c++', 'cc', 'cxx'], config: nonJavaScript(cpp) },
+  { id: 'csharp', extension: 'cs', aliases: ['c#', 'cs', 'dotnet'], config: nonJavaScript(csharp) },
+  { id: 'sql', extension: 'sql', aliases: [], config: nonJavaScript(sql) },
+  { id: 'html', extension: 'html', aliases: ['htm', 'xml'], config: html },
+  { id: 'yaml', extension: 'yaml', aliases: ['yml'], config: nonJavaScript(yaml) },
+  { id: 'markdown', extension: 'md', aliases: ['md', 'mdx'], config: nonJavaScript(markdown) },
+  { id: 'kotlin', extension: 'kt', aliases: ['kts'], config: nonJavaScript(kotlin) },
+  { id: 'swift', extension: 'swift', aliases: [], config: nonJavaScript(swift) },
+  { id: 'php', extension: 'php', aliases: [], config: nonJavaScript(php) },
+  { id: 'toml', extension: 'toml', aliases: [], config: nonJavaScript(toml) },
+  { id: 'powershell', extension: 'ps1', aliases: ['pwsh'], config: nonJavaScript(powershell) },
+  { id: 'dockerfile', extension: 'dockerfile', aliases: ['docker'], config: nonJavaScript(dockerfile) },
+  { id: 'graphql', extension: 'graphql', aliases: ['gql'], config: nonJavaScript(graphql) },
+  { id: 'hcl', extension: 'hcl', aliases: ['terraform', 'tf'], config: nonJavaScript(hcl) },
+]
 
 /** @param {string} value */
 function normalizeLanguageName(value) {

--- a/packages/sugar-high/test/core.test.ts
+++ b/packages/sugar-high/test/core.test.ts
@@ -26,6 +26,15 @@ describe('composable core export', () => {
     )
   })
 
+  it('keeps parser configuration exclusive to core', () => {
+    const html = highlight('custom', {
+      keywords: new Set(['custom']),
+    } as any)
+
+    expect(html).toContain('sh__token--identifier')
+    expect(html).not.toContain('sh__token--keyword')
+  })
+
   it('retains the JavaScript defaults when no preset is supplied', () => {
     const source = 'const answer = 42'
     expect(tokenize(source).map(([, value]) => value).join('')).toBe(source)


### PR DESCRIPTION
Part of #186.

Tightens the final v2 architecture around the common path:

```js
highlight(code, { lang, cx, mark, markLine })
```

The root highlighter no longer forwards undocumented options into core parsing. Custom keyword sets, scanner behavior, and tokenizer configuration remain exclusive to `sugar-high/core`.

The language registry now uses plain arrays and objects without runtime freezing. `AGENTS.md` records the project conventions instead: registry data is shared read-only by convention, the default API stays minimal, advanced composition belongs in existing subpaths, names have one canonical meaning, and every API decision must justify its bundle cost.

No Changeset is included.