### PR TITLE
Report bundle sizes on pull requests

### DIFF
--- a/.github/workflows/size-comment.yml
+++ b/.github/workflows/size-comment.yml
@@ -1,0 +1,49 @@
+name: Bundle size comment
+
+on:
+  workflow_run:
+    workflows:
+      - Test
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+jobs:
+  comment:
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.pull_requests[0]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download bundle size report
+        uses: actions/download-artifact@v7
+        with:
+          name: bundle-size-report-${{ github.event.workflow_run.pull_requests[0].number }}
+          path: report
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: Update pull request comment
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs')
+            const body = fs.readFileSync('report/size-report.md', 'utf8')
+            const { owner, repo } = context.repo
+            const issue_number = context.payload.workflow_run.pull_requests[0].number
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+            })
+            const previous = comments.find(comment =>
+              comment.user?.type === 'Bot' && comment.body?.includes('<!-- sugar-high-size-report -->')
+            )
+            if (previous) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: previous.id, body })
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body })

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,13 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - uses: pnpm/action-setup@v6
         with:
           version: 9.15.9
@@ -23,3 +27,21 @@ jobs:
       - run: pnpm test
       - run: pnpm build
       - run: pnpm check:packages
+      - name: Set up Bun for bundle measurement
+        if: github.event_name == 'pull_request'
+        uses: oven-sh/setup-bun@v2
+      - name: Compare bundle size
+        if: github.event_name == 'pull_request'
+        working-directory: packages/sugar-high
+        run: node scripts/benchmark.mjs --markdown --base origin/${{ github.base_ref }} > size-report.md
+      - name: Add bundle size to summary
+        if: github.event_name == 'pull_request'
+        working-directory: packages/sugar-high
+        run: cat size-report.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload bundle size report
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v6
+        with:
+          name: bundle-size-report-${{ github.event.number }}
+          path: packages/sugar-high/size-report.md
+          retention-days: 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,8 @@
   registry at runtime; copy a configuration before extending it.
 - Bundle size is part of every API and architecture decision. Measure affected entry points and
   prefer the simpler design when added abstraction does not earn its bytes.
+- Run `pnpm --filter sugar-high benchmark` for architecture changes and include the affected
+  minified and gzip sizes in the pull request description.
 
 # Releases
 

--- a/packages/sugar-high/README.md
+++ b/packages/sugar-high/README.md
@@ -200,6 +200,12 @@ options, and lower-level functions. Upgrading from v1? Read the
 
 Measure bundle size and highlighting throughput locally:
 
+[![sugar-high bundle size](https://deno.bundlejs.com/?q=sugar-high&badge=detailed)](https://bundlejs.com/?q=sugar-high)
+[![sugar-high/core bundle size](https://deno.bundlejs.com/?q=sugar-high%2Fcore&badge=detailed)](https://bundlejs.com/?q=sugar-high%2Fcore)
+
+The badges show the minified and gzip-compressed cost of the latest published package. To measure
+the current checkout together with highlighting performance:
+
 ```sh
 pnpm --filter sugar-high benchmark
 ```

--- a/packages/sugar-high/scripts/benchmark.mjs
+++ b/packages/sugar-high/scripts/benchmark.mjs
@@ -57,40 +57,78 @@ function measureBundle(entry, output) {
 const formatSize = (bytes) => `${(bytes / 1024).toFixed(2)} KiB`
 const formatRate = (rate) => `${Math.round(rate).toLocaleString('en-US')} ops/s`
 const benchmarkDir = mkdtempSync(join(tmpdir(), 'sugar-high-benchmark-'))
+const markdown = process.argv.includes('--markdown')
+const baseIndex = process.argv.indexOf('--base')
+const base = baseIndex === -1 ? undefined : process.argv[baseIndex + 1]
 
-try {
-  const javascriptEntry = join(benchmarkDir, 'javascript-entry.js')
+function measureSizes(directory, prefix) {
+  const javascriptEntry = join(benchmarkDir, `${prefix}-javascript-entry.js`)
   writeFileSync(javascriptEntry, [
-    `import { parse, render } from ${JSON.stringify(join(process.cwd(), 'lib/core.js'))}`,
-    `import * as javascript from ${JSON.stringify(join(process.cwd(), 'lib/presets/lang/javascript.js'))}`,
+    `import { parse, render } from ${JSON.stringify(join(directory, 'lib/core.js'))}`,
+    `import * as javascript from ${JSON.stringify(join(directory, 'lib/presets/lang/javascript.js'))}`,
     'export const run = code => render(parse(code, javascript))',
   ].join('\n'))
 
-  const sizes = [
-    ['sugar-high', measureBundle('lib/index.js', join(benchmarkDir, 'builtin.js'))],
-    ['sugar-high/core', measureBundle('lib/core.js', join(benchmarkDir, 'core.js'))],
-    ['core + javascript', measureBundle(javascriptEntry, join(benchmarkDir, 'javascript.js'))],
-  ]
+  return {
+    'sugar-high': measureBundle(join(directory, 'lib/index.js'), join(benchmarkDir, `${prefix}-builtin.js`)),
+    'sugar-high/core': measureBundle(join(directory, 'lib/core.js'), join(benchmarkDir, `${prefix}-core.js`)),
+    'core + javascript': measureBundle(javascriptEntry, join(benchmarkDir, `${prefix}-javascript.js`)),
+  }
+}
 
-  console.log(`Size (Bun browser ESM, minified)\n`)
-  console.table(sizes.map(([name, size]) => ({
-    entry: name,
-    minified: formatSize(size.minified),
-    gzip: formatSize(size.gzip),
-    brotli: formatSize(size.brotli),
-  })))
+function formatDelta(current, previous) {
+  const difference = current - previous
+  if (!difference) return '—'
+  const sign = difference > 0 ? '+' : '−'
+  const percentage = Math.abs(difference / previous * 100).toFixed(1)
+  return `${sign}${Math.abs(difference)} B (${sign}${percentage}%)`
+}
 
-  const performance = [
-    benchmark('builtin: { lang: "python" }', () => highlight(source, { lang: 'python' })),
-    benchmark('core: parse and render python', () => render(parse(source, python))),
-  ]
+try {
+  const sizes = measureSizes(process.cwd(), 'current')
 
-  console.log(`\nHighlight performance (${iterations.toLocaleString('en-US')} iterations)\n`)
-  console.table(performance.map(result => ({
-    benchmark: result.name,
-    time: `${result.milliseconds.toFixed(1)} ms`,
-    throughput: formatRate(result.operationsPerSecond),
-  })))
+  if (markdown) {
+    if (!base) throw new Error('--markdown requires --base <git-ref>')
+    const baseDirectory = join(benchmarkDir, 'base')
+    execFileSync('git', ['worktree', 'add', '--detach', baseDirectory, base], { stdio: 'pipe' })
+    try {
+      const previous = measureSizes(join(baseDirectory, 'packages/sugar-high'), 'base')
+      console.log('<!-- sugar-high-size-report -->')
+      console.log('### Bundle size')
+      console.log('')
+      console.log('| Entry | Base gzip | PR gzip | Change |')
+      console.log('| --- | ---: | ---: | ---: |')
+      for (const name of ['sugar-high', 'sugar-high/core']) {
+        console.log(`| \`${name}\` | ${formatSize(previous[name].gzip)} | ${formatSize(sizes[name].gzip)} | ${formatDelta(sizes[name].gzip, previous[name].gzip)} |`)
+      }
+      console.log('')
+      console.log('_Bun browser ESM bundle, minified and gzip-compressed._')
+    } finally {
+      execFileSync('git', ['worktree', 'remove', '--force', baseDirectory], { stdio: 'pipe' })
+    }
+  }
+
+  if (!markdown) {
+    console.log(`Size (Bun browser ESM, minified)\n`)
+    console.table(Object.entries(sizes).map(([name, size]) => ({
+      entry: name,
+      minified: formatSize(size.minified),
+      gzip: formatSize(size.gzip),
+      brotli: formatSize(size.brotli),
+    })))
+
+    const performance = [
+      benchmark('builtin: { lang: "python" }', () => highlight(source, { lang: 'python' })),
+      benchmark('core: parse and render python', () => render(parse(source, python))),
+    ]
+
+    console.log(`\nHighlight performance (${iterations.toLocaleString('en-US')} iterations)\n`)
+    console.table(performance.map(result => ({
+      benchmark: result.name,
+      time: `${result.milliseconds.toFixed(1)} ms`,
+      throughput: formatRate(result.operationsPerSecond),
+    })))
+  }
 } finally {
   rmSync(benchmarkDir, { recursive: true, force: true })
 }


### PR DESCRIPTION
Adds bundle-size visibility without putting it at the top of the project page.

The existing Benchmarking section now shows published BundleJS badges for `sugar-high` and `sugar-high/core`. Pull requests receive a `main` versus PR gzip table in the Actions summary and an updated conversation comment.

The comment runs in a separate trusted `workflow_run`; the workflow that executes PR code remains read-only.

`AGENTS.md` now requires architecture changes to run the benchmark and include affected minified and gzip sizes in the PR description.

Current output:

| Entry | Minified | Gzip |
| --- | ---: | ---: |
| `sugar-high` | 23.26 KiB | 8.37 KiB |
| `sugar-high/core` | 3.51 KiB | 1.70 KiB |

No runtime code or package API changes.