### PR TITLE
Fix bundle size comment script

### DIFF
--- a/.github/workflows/size-comment.yml
+++ b/.github/workflows/size-comment.yml
@@ -47,3 +47,4 @@ jobs:
               await github.rest.issues.updateComment({ owner, repo, comment_id: previous.id, body })
             } else {
               await github.rest.issues.createComment({ owner, repo, issue_number, body })
+            }


### PR DESCRIPTION
The draft size-report test successfully produced and uploaded its bundle report, but exposed a missing closing brace in the trusted `workflow_run` comment script.

This adds the missing brace. The workflow must merge before another draft PR can test the corrected commenter because GitHub loads `workflow_run` definitions from the default branch.