### PR TITLE
docs: move size details to API reference

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -253,3 +253,17 @@ generated nodes to HTML.
 
 `annotateLine` belongs to language configurations and records syntax meaning. `markLine`, `cx`, and
 `mark` belong to display options and control presentation.
+
+## Size and performance
+
+[![sugar-high bundle size](https://deno.bundlejs.com/?q=sugar-high&badge=detailed)](https://bundlejs.com/?q=sugar-high)
+[![sugar-high/core bundle size](https://deno.bundlejs.com/?q=sugar-high%2Fcore&badge=detailed)](https://bundlejs.com/?q=sugar-high%2Fcore)
+
+The badges show the minified and gzip-compressed cost of the latest published package. To measure
+the current checkout together with highlighting throughput:
+
+```sh
+pnpm --filter sugar-high benchmark
+```
+
+The benchmark runs 50,000 iterations by default. Set `BENCH_ITERATIONS` to change the count.

--- a/packages/sugar-high/README.md
+++ b/packages/sugar-high/README.md
@@ -196,22 +196,6 @@ See [`docs/API.md`](https://github.com/huozhi/sugar-high/blob/main/docs/API.md) 
 options, and lower-level functions. Upgrading from v1? Read the
 [v2 migration guide](https://github.com/huozhi/sugar-high/blob/main/docs/MIGRATION.md).
 
-## Benchmarking
-
-Measure bundle size and highlighting throughput locally:
-
-[![sugar-high bundle size](https://deno.bundlejs.com/?q=sugar-high&badge=detailed)](https://bundlejs.com/?q=sugar-high)
-[![sugar-high/core bundle size](https://deno.bundlejs.com/?q=sugar-high%2Fcore&badge=detailed)](https://bundlejs.com/?q=sugar-high%2Fcore)
-
-The badges show the minified and gzip-compressed cost of the latest published package. To measure
-the current checkout together with highlighting performance:
-
-```sh
-pnpm --filter sugar-high benchmark
-```
-
-Set `BENCH_ITERATIONS` to change the default 50,000 performance iterations.
-
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

- remove bundle-size badges and benchmark instructions from the package README
- keep published size and local throughput details in the existing API reference
- avoid adding a narrowly scoped `SIZE.md`

## Context

The README stays focused on using Sugar High. Size and performance remain documented for users evaluating the API, without adding another documentation file to maintain.

Issue #186 now contains the complete v2 release-note draft and decision record; that issue update is intentionally separate from the repository diff.

No runtime or package output changes.
