### PR TITLE
Fix CSS hex color tokenization

### DIFF
--- a/packages/sugar-high/lib/core.d.ts
+++ b/packages/sugar-high/lib/core.d.ts
@@ -90,6 +90,7 @@ export type ParseOptions = {
   typeKeywords?: Set<string>
   onCommentStart?: (curr: string, next: string, index: number, code: string) => number | boolean
   onCommentEnd?: (prev: string, curr: string, index: number, code: string) => number | boolean
+  onLiteral?: (curr: string, index: number, code: string) => number | null | undefined
   onQuote?: (curr: string, index: number, code: string) => number | null | undefined
   quotedKeys?: boolean
   jsx?: boolean

--- a/packages/sugar-high/lib/core.js
+++ b/packages/sugar-high/lib/core.js
@@ -63,6 +63,13 @@ function tokenize(code, options) {
       continue
     }
 
+    const literalLength = options?.onLiteral?.(curr, i, code)
+    if (literalLength) {
+      append(T_STRING, code.slice(i, i + literalLength))
+      i += literalLength
+      continue
+    }
+
     if (typeof options?.onQuote === 'function' && curr === "'") {
       const length = options.onQuote(curr, i, code)
       if (typeof length === 'number' && length >= 1) {
@@ -153,6 +160,7 @@ export { generate, parse, render, SugarHigh, tokenize }
  * @property {Set<string>} [typeKeywords]
  * @property {(curr: string, next: string, index: number, code: string) => number | boolean} [onCommentStart]
  * @property {(prev: string, curr: string, index: number, code: string) => number | boolean} [onCommentEnd]
+ * @property {(curr: string, index: number, code: string) => number | null | undefined} [onLiteral]
  * @property {(curr: string, index: number, code: string) => number | null | undefined} [onQuote]
  * @property {boolean} [quotedKeys]
  * @property {boolean} [caseInsensitive]

--- a/packages/sugar-high/lib/presets/lang/css.js
+++ b/packages/sugar-high/lib/presets/lang/css.js
@@ -12,3 +12,8 @@ export const onCommentStart = (currentChar, nextChar) => {
 export const onCommentEnd = (prevChar, currChar) => {
   return '*/' === (prevChar + currChar) ? 1 : 0
 }
+
+export const onLiteral = (curr, index, code) => {
+  if (curr !== '#') return 0
+  return code.slice(index).match(/^#(?:[\da-f]{8}|[\da-f]{6}|[\da-f]{4}|[\da-f]{3})(?![\w-])/i)?.[0].length || 0
+}

--- a/packages/sugar-high/test/preset/css.test.ts
+++ b/packages/sugar-high/test/preset/css.test.ts
@@ -11,4 +11,22 @@ describe('tokenize - css preset', () => {
     expect(actual).toContain('media => identifier')
     expect(actual).toContain('/* note */ => comment')
   })
+
+  it('keeps CSS hex colors together regardless of their first digit', () => {
+    const input = 'a { color: #fff; color: #abcd; color: #abcdef; color: #abcdef80; color: #12345678; }'
+    const actual = getTokensAsString(tokenize(input, css))
+
+    for (const color of ['#fff', '#abcd', '#abcdef', '#abcdef80', '#12345678']) {
+      expect(actual).toContain(`${color} => string`)
+    }
+  })
+
+  it('does not consume invalid hex lengths or identifier-like hashes', () => {
+    const input = 'a { color: #ff; color: #fffff; color: #fffffff; color: #fffffffff; } #face-value {}'
+    const actual = tokenize(input, css).map(([, value]) => value)
+
+    for (const value of ['#ff', '#fffff', '#fffffff', '#fffffffff', '#face-value']) {
+      expect(actual).not.toContain(value)
+    }
+  })
 })


### PR DESCRIPTION
## Summary

- tokenize valid CSS 3, 4, 6, and 8-digit hex colors as one `string` token
- handle values consistently whether their first hex digit is alphabetic or numeric
- keep invalid lengths and identifier-like hashes out of the CSS literal match
- scope the behavior to the CSS preset through a small core literal hook, leaving other `#` syntaxes unchanged

## Example

```css
color: #fff;
color: #abcd;
color: #abcdef;
color: #abcdef80;
color: #12345678;
```

Each color is now emitted as a single token.

## Verification

- 130 Sugar High tests pass
- benchmark: 26,532 ops/s built-in Python; 27,958 ops/s core Python
- size: `sugar-high` 23.54 KiB min / 8.56 KiB gzip
- size: `sugar-high/core` 3.63 KiB min / 1.74 KiB gzip

No Changeset included.