### PR TITLE
Fix diff filename extension highlighting

### DIFF
--- a/packages/sugar-high/lib/presets/lang/diff.js
+++ b/packages/sugar-high/lib/presets/lang/diff.js
@@ -7,6 +7,11 @@ export const annotateLine = (line) => {
   if (line.value.startsWith('+') && !line.value.startsWith('+++')) annotation = 'diff-add'
   else if (line.value.startsWith('-') && !line.value.startsWith('---')) annotation = 'diff-remove'
   else if (line.value.startsWith('@@')) annotation = 'diff-hunk'
-  else if (/^(diff --git|index |--- |\+\+\+ )/.test(line.value)) annotation = 'diff-meta'
+  else if (/^(diff --git|index |--- |\+\+\+ )/.test(line.value)) {
+    annotation = 'diff-meta'
+    for (const token of line.tokens) {
+      if (token.type === 'property') token.type = 'identifier'
+    }
+  }
   if (annotation) line.annotations.push(annotation)
 }

--- a/packages/sugar-high/test/preset/diff.test.ts
+++ b/packages/sugar-high/test/preset/diff.test.ts
@@ -41,4 +41,23 @@ describe('diff preset', () => {
     expect(html).toContain('class="sh__line sh__line--diff-remove"')
     expect(html).toContain('class="sh__line sh__line--diff-add"')
   })
+
+  it('does not highlight filename extensions in metadata', () => {
+    const parsed = parse([
+      'diff --git a/src/index.tsx b/src/index.tsx',
+      '--- a/theme.css',
+      '+++ b/theme.css',
+      '+const value = data.name',
+    ].join('\n'), diff)
+
+    for (const line of parsed.lines.slice(0, 3)) {
+      expect(line.tokens.filter(token => ['tsx', 'css'].includes(token.value)))
+        .toEqual(expect.arrayContaining([
+          expect.objectContaining({ type: 'identifier' }),
+        ]))
+      expect(line.tokens.some(token => token.type === 'property')).toBe(false)
+    }
+
+    expect(parsed.lines[3].tokens).toContainEqual({ type: 'property', value: 'name' })
+  })
 })


### PR DESCRIPTION
## Summary

- keep filename extensions plain in diff metadata such as `index.tsx` and `theme.css`
- preserve property highlighting inside added and removed source lines
- cover git headers and old/new filename markers

## Test

- 131 tests pass

No changeset: this is a v2 bug fix and release timing remains explicit.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
