### PR TITLE
Auto-size line number gutters

### DIFF
--- a/apps/docs/app/live-editor.tsx
+++ b/apps/docs/app/live-editor.tsx
@@ -343,7 +343,6 @@ export default function LiveEditor({
               controls={false}
               value={displayCode}
               fontSize={15}
-              lineNumbersWidth='2rem'
               extension={fileExtension}
               onChange={handleEditorChange}
             />

--- a/packages/react/src/code/code.test.tsx
+++ b/packages/react/src/code/code.test.tsx
@@ -1,8 +1,15 @@
 import { describe, expect, it } from 'vitest'
 import { Code } from '.'
+import { getLineNumbersWidth } from './code'
 import { renderToString } from 'react-dom/server'
 
 describe('Code', () => {
+  it('expands the line number gutter for long files', () => {
+    expect(getLineNumbersWidth('line\n'.repeat(998))).toBeUndefined()
+    expect(getLineNumbersWidth('line\n'.repeat(999))).toBe('calc(4ch + 14px)')
+    expect(getLineNumbersWidth('line', '5rem')).toBe('5rem')
+  })
+
   it('default props', () => {
     expect(renderToString(<Code>test</Code>)).toMatchInlineSnapshot(`
       "<div data-codice="code" data-codice-code="true" data-codice-line-numbers="false"><style data-codice-style="true">@scope {
@@ -80,7 +87,7 @@ describe('Code', () => {
         counter-increment: codice-code-line-number 1;
         content: counter(codice-code-line-number);
         display: inline-block;
-        min-width: calc(2rem - 6px);
+        min-width: calc(var(--codice-code-line-number-width) - 14px);
         margin-left: calc(var(--codice-code-line-number-width) * -1);
         margin-right: 14px;
         text-align: right;
@@ -178,7 +185,7 @@ describe('Code', () => {
         counter-increment: codice-code-line-number 1;
         content: counter(codice-code-line-number);
         display: inline-block;
-        min-width: calc(2rem - 6px);
+        min-width: calc(var(--codice-code-line-number-width) - 14px);
         margin-left: calc(var(--codice-code-line-number-width) * -1);
         margin-right: 14px;
         text-align: right;
@@ -319,7 +326,7 @@ describe('Code', () => {
         counter-increment: codice-code-line-number 1;
         content: counter(codice-code-line-number);
         display: inline-block;
-        min-width: calc(2rem - 6px);
+        min-width: calc(var(--codice-code-line-number-width) - 14px);
         margin-left: calc(var(--codice-code-line-number-width) * -1);
         margin-right: 14px;
         text-align: right;
@@ -460,7 +467,7 @@ describe('Code', () => {
         counter-increment: codice-code-line-number 1;
         content: counter(codice-code-line-number);
         display: inline-block;
-        min-width: calc(2rem - 6px);
+        min-width: calc(var(--codice-code-line-number-width) - 14px);
         margin-left: calc(var(--codice-code-line-number-width) * -1);
         margin-right: 14px;
         text-align: right;
@@ -556,7 +563,7 @@ describe('Code', () => {
         counter-increment: codice-code-line-number 1;
         content: counter(codice-code-line-number);
         display: inline-block;
-        min-width: calc(2rem - 6px);
+        min-width: calc(var(--codice-code-line-number-width) - 14px);
         margin-left: calc(var(--codice-code-line-number-width) * -1);
         margin-right: 14px;
         text-align: right;

--- a/packages/react/src/code/code.tsx
+++ b/packages/react/src/code/code.tsx
@@ -12,6 +12,12 @@ export function getExtension(title: string | undefined) {
   return (title || '').split('.').pop() || ''
 }
 
+export function getLineNumbersWidth(code: string, width?: string) {
+  if (width) return width
+  const digits = String(code.split('\n').length).length
+  return digits > 3 ? `calc(${digits}ch + 14px)` : undefined
+}
+
 function generateHighlightedLines(
   codeText: string,
   highlightLines: ([number, number] | number)[],
@@ -185,6 +191,7 @@ export function Code({
   mark?: HighlightOptions['mark']
   markLine?: HighlightOptions['markLine']
 } & React.HTMLAttributes<HTMLDivElement>) {
+  const resolvedLineNumbersWidth = getLineNumbersWidth(code, lineNumbersWidth)
   const lineElements = useMemo(() =>
     asMarkup
       ? code
@@ -200,7 +207,7 @@ export function Code({
       data-codice-code
       data-codice-line-numbers={lineNumbers}
     >
-      <ScopedStyle css={css({ fontSize, lineNumbersWidth, padding })} />
+      <ScopedStyle css={css({ fontSize, lineNumbersWidth: resolvedLineNumbersWidth, padding })} />
       <CodeHeader title={title} controls={controls} />
       <CodeFrame preformatted={preformatted} asMarkup={asMarkup}>
         {lineElements}

--- a/packages/react/src/code/css.ts
+++ b/packages/react/src/code/css.ts
@@ -84,7 +84,7 @@ ${L} [data-codice-code-line-number] {
   counter-increment: codice-code-line-number 1;
   content: counter(codice-code-line-number);
   display: inline-block;
-  min-width: calc(2rem - 6px);
+  min-width: calc(var(--codice-code-line-number-width) - 14px);
   margin-left: calc(var(--codice-code-line-number-width) * -1);
   margin-right: 14px;
   text-align: right;

--- a/packages/react/src/editor/editor.test.tsx
+++ b/packages/react/src/editor/editor.test.tsx
@@ -196,7 +196,7 @@ describe('Code', () => {
         counter-increment: codice-code-line-number 1;
         content: counter(codice-code-line-number);
         display: inline-block;
-        min-width: calc(2rem - 6px);
+        min-width: calc(var(--codice-code-line-number-width) - 14px);
         margin-left: calc(var(--codice-code-line-number-width) * -1);
         margin-right: 14px;
         text-align: right;
@@ -410,7 +410,7 @@ describe('Code', () => {
         counter-increment: codice-code-line-number 1;
         content: counter(codice-code-line-number);
         display: inline-block;
-        min-width: calc(2rem - 6px);
+        min-width: calc(var(--codice-code-line-number-width) - 14px);
         margin-left: calc(var(--codice-code-line-number-width) * -1);
         margin-right: 14px;
         text-align: right;
@@ -581,7 +581,7 @@ describe('Code', () => {
         counter-increment: codice-code-line-number 1;
         content: counter(codice-code-line-number);
         display: inline-block;
-        min-width: calc(2rem - 6px);
+        min-width: calc(var(--codice-code-line-number-width) - 14px);
         margin-left: calc(var(--codice-code-line-number-width) * -1);
         margin-right: 14px;
         text-align: right;

--- a/packages/react/src/editor/editor.tsx
+++ b/packages/react/src/editor/editor.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState, forwardRef } from 'react'
-import { CodeHeader, getExtension, Code } from '../code/code'
+import { CodeHeader, getExtension, getLineNumbersWidth, Code } from '../code/code'
 import { ScopedStyle } from '../style'
 import { css } from './css'
 import type { HighlightOptions, LanguageName } from 'sugar-high'
@@ -45,6 +45,7 @@ export const Editor = forwardRef(function Editor(
   ref: React.Ref<HTMLDivElement>
 ) {
   const [code, setCode] = useState(value)
+  const resolvedLineNumbersWidth = getLineNumbersWidth(code, lineNumbersWidth)
 
   function update(textContent: string) {
     setCode(textContent)
@@ -74,7 +75,7 @@ export const Editor = forwardRef(function Editor(
       data-codice-controls={!!controls}
       data-codice-line-numbers={!!lineNumbers}
     >
-      <ScopedStyle css={css({ fontSize, padding, lineNumbersWidth, fontFamily })} />
+      <ScopedStyle css={css({ fontSize, padding, lineNumbersWidth: resolvedLineNumbersWidth, fontFamily })} />
       {/* Display the header outside of the matched textarea and code, by default display controls */}
       <CodeHeader title={title} controls={controls} onChangeTitle={onChangeTitle} />
       <div data-codice-content>
@@ -87,7 +88,7 @@ export const Editor = forwardRef(function Editor(
           mark={mark}
           controls={false}
           lineNumbers={lineNumbers}
-          lineNumbersWidth={lineNumbersWidth}
+          lineNumbersWidth={resolvedLineNumbersWidth}
           padding={padding}
           // Do not pass fontSize to Code in Editor.
           // It will control both the textarea and code font size.


### PR DESCRIPTION
## Summary

- automatically expand line-number gutters once a file reaches four digits
- size the gutter with `ch` so `<Code>` and `<Editor>` remain aligned
- keep `lineNumbersWidth` as an explicit override

```tsx
const digits = String(code.split('\n').length).length
const width = digits > 3 ? `calc(${digits}ch + 14px)` : undefined
```

## Test

- `pnpm test`
- `pnpm build`
- `git diff --check`

No changeset until the v2 release is approved.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
