### PR TITLE
Prepare Sugar High v2 release

### DIFF
--- a/.changeset/strong-candles-glow.md
+++ b/.changeset/strong-candles-glow.md
@@ -1,0 +1,8 @@
+---
+'sugar-high': major
+'@sugar-high/react': major
+---
+
+Release Sugar High v2 with canonical multi-language highlighting, a composable core, typed generated nodes, granular token and line styling, first-party React components, Remark integration, themes, and updated documentation.
+
+The default `highlight()` API stays focused on common highlighting, while `sugar-high/core` provides `parse()`, `generate()`, and `render()` for advanced composition. Language aliases are normalized through `sugar-high/lang`, and related dialects share canonical implementations.

--- a/.changeset/strong-candles-glow.md
+++ b/.changeset/strong-candles-glow.md
@@ -1,6 +1,7 @@
 ---
 'sugar-high': major
 '@sugar-high/react': major
+'@sugar-high/remark': major
 ---
 
 Release Sugar High v2 with canonical multi-language highlighting, a composable core, typed generated nodes, granular token and line styling, first-party React components, Remark integration, themes, and updated documentation.


### PR DESCRIPTION
## Summary

- add the coordinated Changeset that starts the Sugar High v2 release
- release `sugar-high@2.0.0`
- release `@sugar-high/react@1.0.0`
- release `@sugar-high/remark@1.0.0`

Merging this PR does not publish packages. It creates or updates the Changesets version PR. Publishing remains a separate manual OIDC workflow with the `publish` confirmation.

## Verified release plan

```text
sugar-high            1.3.0 → 2.0.0
@sugar-high/react     0.1.0 → 1.0.0
@sugar-high/remark    0.1.0 → 1.0.0
```

Remark's unreleased repository baseline is aligned to `0.1.0` so its major Changeset produces the intended first stable `1.0.0`. Its currently published npm placeholder is `0.0.1`.

Release notes: #186
Post-v2 release automation: #202

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
