### PR TITLE
Fix Changesets version command

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Create or update release PR
         uses: changesets/action@v1
         with:
-          version: pnpm version
+          version: pnpm run version
           title: Release packages
           commit: Release packages
         env:


### PR DESCRIPTION
## Summary

- run the repository's `version` script explicitly from Changesets
- avoid pnpm interpreting `pnpm version` as its environment-version command

The failed run printed Node/npm component versions, made no files, and therefore tried to open a PR with no commits. `pnpm run version` invokes `changeset version` from `package.json` as intended.

No packages were published by the failed run. Merging this PR triggers the guarded version-preparation job again and should create the `Release packages` PR.

Failure: https://github.com/huozhi/sugar-high/actions/runs/31320467873/job/93262507752

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
