### PR TITLE
Automate package release notes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,9 +49,12 @@ jobs:
 
   publish:
     if: github.event_name == 'workflow_dispatch' && inputs.confirm == 'publish'
+    concurrency:
+      group: npm-publish
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
     env:
       NPM_CONFIG_PROVENANCE: "true"
@@ -71,5 +74,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Publish packages through npm trusted publishing
-        run: pnpm release
+      - name: Publish packages and create GitHub releases
+        uses: changesets/action@v1
+        with:
+          publish: pnpm release
+          createGithubReleases: true
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,3 +31,5 @@
 - Publishing is manual: Actions → Publish → Run workflow on `main`, with confirmation `publish`.
 - npm publishing uses trusted publishing through OIDC. Do not add npm tokens or publish directly
   from CI.
+- The manual publish job uses Changesets to create package tags and GitHub Releases from the
+  reviewed changelogs. Major umbrella releases may still use separately curated `vX.Y.Z` notes.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -41,6 +41,7 @@ pnpm check:packages
 2. Select the `main` branch.
 3. Enter `publish` in the confirmation field and run the workflow.
 4. Confirm that the publish job used npm provenance and completed for every intended package.
+5. Confirm that Changesets pushed a package tag and created a GitHub Release for every package published by the run.
 
 The workflow is guarded so pushes to `main` can only prepare the version PR. Publishing runs only for a manual dispatch whose confirmation is exactly `publish`.
 
@@ -64,11 +65,12 @@ import { Code, Editor } from '@sugar-high/react'
 import remarkSugarHigh from '@sugar-high/remark'
 ```
 
-For major releases, publish the curated GitHub release notes after npm verification. Routine tag and GitHub Release automation is tracked in issue #202.
+Changesets creates package-specific tags and GitHub Releases from the reviewed changelogs. For an occasional major umbrella release, a maintainer may additionally publish curated notes under the repository's `vX.Y.Z` tag after npm verification.
 
 ## Failure handling
 
 - If preparation fails, fix the Changeset or workflow in a normal PR; never edit generated versions directly on `main`.
 - If publishing fails before a package reaches npm, fix the cause and rerun the manual workflow.
 - If only some packages publish, do not change their versions. Rerun after fixing the failure; Changesets skips versions already present on npm and publishes the remaining packages.
+- If npm succeeds but GitHub release creation fails, create the missing package tag and release manually from its generated changelog; already-published versions are not recreated by a later publish run.
 - Never replace OIDC with a long-lived npm token as a workaround.


### PR DESCRIPTION
## Summary

- keep npm publishing behind the manual `publish` confirmation and OIDC
- run publishing through `changesets/action` so reviewed changelogs become package tags and GitHub Releases
- serialize manual npm publishes to prevent concurrent release races
- document automated behavior and conservative failure recovery for maintainers and agents

```yaml
- name: Publish packages and create GitHub releases
  uses: changesets/action@v1
  with:
    publish: pnpm release
    createGithubReleases: true
```

The publish job receives `contents: write` only for tags and GitHub Releases; npm continues to authenticate with `id-token: write`. Pushes to `main` still cannot publish.

No Changeset: this only changes maintainer release infrastructure.

Closes #202

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
