### PR TITLE
Document React styling variables

### DIFF
--- a/apps/site/app/react/page.css
+++ b/apps/site/app/react/page.css
@@ -92,6 +92,31 @@
   color: #354150;
 }
 
+.react-style-example[data-codice-code] {
+  margin-bottom: 24px;
+  background: #f6f6f6;
+}
+
+.react-style-variables td:first-child {
+  width: 39%;
+}
+
+.react-style-variables td:nth-child(2) {
+  width: 27%;
+}
+
+.react-style-note {
+  margin: 18px 0 0;
+  color: #788592;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.react-style-note a {
+  color: #596571;
+  text-underline-offset: 3px;
+}
+
 .react-demo__status {
   display: flex;
   align-items: center;

--- a/apps/site/app/react/page.tsx
+++ b/apps/site/app/react/page.tsx
@@ -29,6 +29,34 @@ render(
   </div>
 )`
 
+const stylingExample = `const style = {
+  backgroundColor: '#f6f8fa',
+  '--codice-background-color': 'transparent',
+  '--codice-caret-color': '#24292f',
+  '--codice-title-color': '#57606a',
+  '--codice-control-color': '#afb8c1',
+  '--codice-code-line-number-color': '#8c959f',
+  '--codice-code-highlight-color': '#fff8c5',
+  '--sh-keyword': '#cf222e',
+  '--sh-string': '#0a3069',
+} as React.CSSProperties
+
+<Editor style={style} value={source} onChange={setSource} />`
+
+const styleVariables = [
+  ['--codice-text-color', 'Editor', 'transparent', 'Textarea text; transparent over highlighted code.'],
+  ['--codice-background-color', 'Editor', 'transparent', 'Textarea background.'],
+  ['--codice-caret-color', 'Both', 'inherit', 'Editor and editable-title caret.'],
+  ['--codice-font-family', 'Both', 'Editor monospace; Code inherited', 'Code, textarea, and title font.'],
+  ['--codice-font-size', 'Both', 'inherit', 'Code and textarea font size.'],
+  ['--codice-code-padding', 'Both', '1rem', 'Content and header spacing.'],
+  ['--codice-code-line-number-width', 'Both', '2.5rem / auto', 'Line-number gutter width.'],
+  ['--codice-control-color', 'Both', 'unset', 'Header control-dot color.'],
+  ['--codice-title-color', 'Both', 'unset', 'Header filename color.'],
+  ['--codice-code-line-number-color', 'Both', 'unset', 'Line-number color.'],
+  ['--codice-code-highlight-color', 'Both', 'unset', 'Highlighted-line background.'],
+] as const
+
 function Window({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <div className="product-card">
@@ -78,6 +106,35 @@ export default function ReactPage() {
               {codeBlockExample}
             </Code>
           </Window>
+        </section>
+
+        <section className="product-section react-api">
+          <div className="product-section__head">
+            <h2>Styling</h2>
+            <p>Compose frame variables with Sugar High token themes.</p>
+          </div>
+          <Code className="react-style-example" lang="typescript" title="editor-theme.tsx">
+            {stylingExample}
+          </Code>
+          <div className="react-api__table-wrap react-style-variables">
+            <table>
+              <thead><tr><th>Variable</th><th>Scope / default</th><th>Purpose</th></tr></thead>
+              <tbody>
+                {styleVariables.map(([name, scope, defaultValue, purpose]) => (
+                  <tr key={name}>
+                    <td><code>{name}</code></td>
+                    <td>{scope}<br /><code>{defaultValue}</code></td>
+                    <td>{purpose}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <p className="react-style-note">
+            Set these inline or on the component root. Use <code>--sh-*</code> variables for token
+            colors; the <a href="/theme">theme guide</a> lists copyable presets. Keep the editor
+            textarea colors transparent to preserve its highlighted overlay.
+          </p>
         </section>
 
         <section className="product-section react-api">

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -36,3 +36,47 @@ import { Code } from '@sugar-high/react'
 
 The package preserves Codice's existing `data-codice-*` attributes and CSS variables so existing
 themes can migrate without a DOM/CSS rewrite.
+
+## Styling
+
+Set Codice variables on the component itself for a self-contained theme:
+
+```tsx
+const style = {
+  backgroundColor: '#f6f8fa',
+  '--codice-background-color': 'transparent',
+  '--codice-caret-color': '#24292f',
+  '--codice-title-color': '#57606a',
+  '--codice-control-color': '#afb8c1',
+  '--codice-code-line-number-color': '#8c959f',
+  '--codice-code-highlight-color': '#fff8c5',
+  '--sh-keyword': '#cf222e',
+  '--sh-string': '#0a3069',
+} as React.CSSProperties
+
+<Editor style={style} value={source} onChange={setSource} />
+```
+
+The `--codice-*` variables control the component frame and editor. Sugar High's `--sh-*`
+variables control syntax tokens; see the [theme guide](https://sugar-high.vercel.app/theme).
+
+| Variable | Applies to | Default | Purpose |
+| --- | --- | --- | --- |
+| `--codice-text-color` | Editor | `transparent` | Textarea text color; normally transparent over highlighted code. |
+| `--codice-background-color` | Editor | `transparent` | Textarea background color. |
+| `--codice-caret-color` | Both | `inherit` | Editor caret and editable title caret. |
+| `--codice-font-family` | Both | Editor: `Consolas, Monaco, monospace`; Code: inherited | Code, textarea, and title font family. |
+| `--codice-font-size` | Both | `inherit` | Code and textarea font size. |
+| `--codice-code-padding` | Both | `1rem` | Shared content and header spacing. |
+| `--codice-code-line-number-width` | Both | `2.5rem`, expanding for 4+ digits | Line-number gutter width. Prefer `lineNumbersWidth` for an explicit override. |
+| `--codice-control-color` | Both | unset | Header control-dot color. |
+| `--codice-title-color` | Both | unset | Header filename color. |
+| `--codice-code-line-number-color` | Both | unset | Line-number color. |
+| `--codice-code-highlight-color` | Both | unset | Background for lines selected by `highlightLines`. |
+
+The editor is a textarea layered over highlighted code. Keep `--codice-text-color` and
+`--codice-background-color` transparent unless deliberately changing that overlay; set the root's
+ordinary `color` and `backgroundColor` for the visible surface.
+
+All component roots retain `data-codice`, `data-codice-code`, or `data-codice-editor` attributes
+for stylesheet selectors. Both components also accept standard `div` attributes.


### PR DESCRIPTION
## Summary

- document every supported `--codice-*` React styling variable in the package README
- add the same searchable styling reference to the `/react` website
- show frame variables composed with Sugar High `--sh-*` token colors
- explain the textarea overlay and why its text/background normally remain transparent
- retain the existing Codice DOM hooks and migration guidance

```tsx
const style = {
  backgroundColor: '#f6f8fa',
  '--codice-background-color': 'transparent',
  '--codice-caret-color': '#24292f',
  '--codice-code-line-number-color': '#8c959f',
  '--sh-keyword': '#cf222e',
} as React.CSSProperties

<Editor style={style} value={source} onChange={setSource} />
```

## Test

- `pnpm --filter site build`
- `git diff --check`

No Changeset: documentation only.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
