### PR TITLE
Improve CSS declaration tokenization

### DIFF
--- a/.changeset/wide-tigers-read.md
+++ b/.changeset/wide-tigers-read.md
@@ -1,0 +1,5 @@
+---
+"sugar-high": patch
+---
+
+Classify CSS declaration names as property tokens.

--- a/packages/sugar-high/lib/presets/lang/css.js
+++ b/packages/sugar-high/lib/presets/lang/css.js
@@ -1,4 +1,9 @@
 // @ts-check
+import {
+  T_BREAK, T_CLASS, T_COMMENT, T_IDENTIFIER, T_PROPERTY, T_SIGN, T_SPACE,
+} from '../../shared.js'
+import { tokenize as tokenizePlain } from '../../core.js'
+
 export const keywords = new Set([
   // css keywords like @media, @import, @keyframes, etc.
   '@media', '@import', '@keyframes', '@font-face', '@supports', '@page', '@counter-style',
@@ -16,4 +21,80 @@ export const onCommentEnd = (prevChar, currChar) => {
 export const onLiteral = (curr, index, code) => {
   if (curr !== '#') return 0
   return code.slice(index).match(/^#(?:[\da-f]{8}|[\da-f]{6}|[\da-f]{4}|[\da-f]{3})(?![\w-])/i)?.[0].length || 0
+}
+
+const isIgnored = (type) => type === T_SPACE || type === T_BREAK || type === T_COMMENT
+const isPropertyPart = ([type, value]) =>
+  type === T_IDENTIFIER || type === T_CLASS || (type === T_SIGN && value === '-')
+
+/** Return true when a colon belongs to a nested selector instead of a declaration. */
+const opensBlock = (tokens, start) => {
+  let parentheses = 0
+  let brackets = 0
+  for (let index = start; index < tokens.length; index++) {
+    const [type, value] = tokens[index]
+    if (type !== T_SIGN) continue
+    if (value === '(') parentheses++
+    else if (value === ')') parentheses--
+    else if (value === '[') brackets++
+    else if (value === ']') brackets--
+    else if (!parentheses && !brackets && value === '{') return true
+    else if (!parentheses && !brackets && (value === ';' || value === '}')) return false
+  }
+  return false
+}
+
+/**
+ * Add CSS declaration context after the shared plain lexer runs.
+ * @param {string} code
+ * @param {import('../../core.js').ParseOptions} options
+ */
+export const tokenize = (code, options) => {
+  const tokens = tokenizePlain(code, { ...options, tokenize: undefined })
+  let blockDepth = 0
+  let declarationStart = false
+
+  for (let index = 0; index < tokens.length; index++) {
+    const [type, value] = tokens[index]
+
+    if (type === T_SIGN && value === '{') {
+      blockDepth++
+      declarationStart = true
+      continue
+    }
+    if (type === T_SIGN && value === '}') {
+      blockDepth--
+      declarationStart = false
+      continue
+    }
+    if (type === T_SIGN && value === ';') {
+      declarationStart = blockDepth > 0
+      continue
+    }
+    if (!declarationStart || isIgnored(type)) continue
+
+    const propertyStart = index
+    let propertyEnd = index
+    while (propertyEnd < tokens.length && isPropertyPart(tokens[propertyEnd])) {
+      propertyEnd++
+    }
+    let colon = propertyEnd
+    while (colon < tokens.length && isIgnored(tokens[colon][0])) colon++
+
+    if (
+      propertyEnd > propertyStart &&
+      tokens[colon]?.[0] === T_SIGN &&
+      tokens[colon][1] === ':' &&
+      !opensBlock(tokens, colon + 1)
+    ) {
+      const property = tokens
+        .slice(propertyStart, propertyEnd)
+        .map(([, part]) => part)
+        .join('')
+      tokens.splice(propertyStart, propertyEnd - propertyStart, [T_PROPERTY, property])
+    }
+    declarationStart = false
+  }
+
+  return tokens
 }

--- a/packages/sugar-high/test/preset/css.test.ts
+++ b/packages/sugar-high/test/preset/css.test.ts
@@ -29,4 +29,45 @@ describe('tokenize - css preset', () => {
       expect(actual).not.toContain(value)
     }
   })
+
+  it('classifies declaration names as properties', () => {
+    const input = `body {
+  background: #000;
+  display: none;
+  visibility: hidden;
+  height: calc(var(--deathDate) - var(--birthDate));
+  font-family: "Transylvania";
+  opacity: 0;
+  --accent-color: #ff79c6;
+}`
+    const actual = getTokensAsString(tokenize(input, css))
+
+    for (const property of [
+      'background',
+      'display',
+      'visibility',
+      'height',
+      'font-family',
+      'opacity',
+      '--accent-color',
+    ]) {
+      expect(actual).toContain(`${property} => property`)
+    }
+    expect(actual).toContain('#000 => string')
+    expect(actual).toContain('#ff79c6 => string')
+  })
+
+  it('does not classify selectors and custom-property references as properties', () => {
+    const input = `a:hover, #dracula {
+  color: var(--accent-color);
+  &::before { content: ""; }
+}`
+    const actual = getTokensAsString(tokenize(input, css))
+
+    expect(actual).not.toContain('hover => property')
+    expect(actual).not.toContain('dracula => property')
+    expect(actual).not.toContain('accent => property')
+    expect(actual).toContain('color => property')
+    expect(actual).toContain('content => property')
+  })
 })


### PR DESCRIPTION
Fixes #131.

## Summary

- classify CSS declaration names as `property` tokens
- combine hyphenated and custom declaration names such as `font-family` and `--accent-color`
- keep pseudo-selectors and custom-property references out of the property category
- reuse the existing core tokenizer from the CSS preset; shared lexer/core files are unchanged
- retain the complete hex-color string tokenization added in #199

## Visual verification

These screenshots were captured from the homepage `@sugar-high/react` editor with CSS selected. They live on the separate `pr-assets/131` branch and are not part of this PR's code diff.

<table>
  <thead>
    <tr>
      <th>Code</th>
      <th>Rendered CSS highlighting</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td valign="top">
        <pre><code>body {
  background: #000;
}</code></pre>
      </td>
      <td valign="top">
        <img src="https://github.com/huozhi/sugar-high/blob/5205971b6d54385bf985a237a7b9ff96a2828abe/.github/pr-assets/131/basic.png?raw=true" alt="CSS highlighting for the basic issue 131 example" width="560">
      </td>
    </tr>
    <tr>
      <td valign="top">
        <pre><code>/* Pink - White */
body {
  /* Cyan - Pink - Purple */
  background: #000;
}

/* Green - White */
#dracula {
  display: none;
  visibility: hidden;
  height: calc(var(--deathDate) - var(--birthDate));
  /* Cyan - Pink - Yellow */
  font-family: "Transylvania";
  /* Cyan - Pink - Purple */
  opacity: 0;
}</code></pre>
      </td>
      <td valign="top">
        <img src="https://github.com/huozhi/sugar-high/blob/5205971b6d54385bf985a237a7b9ff96a2828abe/.github/pr-assets/131/full.png?raw=true" alt="CSS highlighting for the full issue 131 example" width="650">
      </td>
    </tr>
  </tbody>
</table>

## Bundle size

| Entry | Base gzip | PR gzip | Change |
| --- | ---: | ---: | ---: |
| `sugar-high` | 8.59 KiB | 8.89 KiB | +309 B (+3.5%) |
| `sugar-high/core` | 1.74 KiB | 1.74 KiB | — |

_Bun browser ESM bundle, minified and gzip-compressed._

## Testing

- `pnpm test` (133 sugar-high tests; 148 workspace tests)
- `pnpm build`
- `pnpm --filter sugar-high benchmark`
- `git diff --check`
