### PR TITLE
Optimize React package rendering

### DIFF
--- a/.changeset/calm-pandas-edit.md
+++ b/.changeset/calm-pandas-edit.md
@@ -1,0 +1,8 @@
+---
+'@sugar-high/react': minor
+---
+
+Improve editor value synchronization and highlighting performance, add `defaultValue` for
+uncontrolled editors, and introduce canonical `data-sh-*` component markers while retaining the
+Codice compatibility attributes. Replace the legacy `--codice-*` styling variables with canonical
+`--sh-*` variables.

--- a/apps/site/app/carousel.tsx
+++ b/apps/site/app/carousel.tsx
@@ -273,8 +273,8 @@ export default function Carousel() {
       ...base,
       '--showcase-card-bg': previewMode === 'dark' ? '#383838' : '#f6f6f6',
       '--showcase-line-highlight': `color-mix(in srgb, ${plateColors.keyword} 14%, ${previewMode === 'dark' ? '#383838' : '#fffef6'})`,
-      '--codice-title-color': previewMode === 'dark' ? '#a8a8a8' : '#707070',
-      '--codice-control-color': previewMode === 'dark' ? '#8b8b8b' : '#a4a4a4',
+      '--sh-title-color': previewMode === 'dark' ? '#a8a8a8' : '#707070',
+      '--sh-control-color': previewMode === 'dark' ? '#8b8b8b' : '#a4a4a4',
       '--showcase-dim-bg': previewMode === 'dark' ? '#34373a' : '#e9ecee',
     } as CSSProperties
   }, [plateColors, previewMode])

--- a/apps/site/app/components/install-banner.css
+++ b/apps/site/app/components/install-banner.css
@@ -26,8 +26,8 @@
 }
 
 .install-banner__theme-pane {
-  --codice-title-color: currentColor;
-  --codice-caret-color: currentColor;
+  --sh-title-color: currentColor;
+  --sh-caret-color: currentColor;
   position: relative;
   min-width: 0;
   padding: 0 0 14px;
@@ -73,7 +73,7 @@
   padding: 0 12px;
   font-size: 0.78rem;
   font-weight: 500;
-  color: var(--codice-title-color);
+  color: var(--sh-title-color);
 }
 
 .install-banner__theme-pane pre {
@@ -153,9 +153,9 @@
 }
 
 .install-banner__code {
-  /* codice header title: color: var(--codice-title-color) */
-  --codice-title-color: #b0b0b0;
-  --codice-caret-color: #ccc;
+  /* codice header title: color: var(--sh-title-color) */
+  --sh-title-color: #b0b0b0;
+  --sh-caret-color: #ccc;
   /* --sh-* inherited from .install-banner (live theme) */
   position: relative;
   background-color: #383838;
@@ -198,8 +198,8 @@
 
 .install-banner[data-install-theme='light'] .install-banner__code {
   background-color: #f6f6f6;
-  --codice-title-color: #707070;
-  --codice-caret-color: #333;
+  --sh-title-color: #707070;
+  --sh-caret-color: #333;
 }
 
 .install-banner[data-install-theme='light'] .install-banner__code button {

--- a/apps/site/app/product-page.css
+++ b/apps/site/app/product-page.css
@@ -241,7 +241,7 @@
 }
 
 .product-code {
-  --codice-code-padding: 18px;
+  --sh-padding: 18px;
   --sh-class: #2d5e9d;
   --sh-identifier: #354150;
   --sh-sign: #8996a3;

--- a/apps/site/app/react/page.css
+++ b/apps/site/app/react/page.css
@@ -1,10 +1,10 @@
 .react-product {
   --product-accent: #f47067;
-  --codice-caret-color: #354150;
-  --codice-title-color: #6f7b86;
-  --codice-control-color: #a8b1b8;
-  --codice-code-line-number-color: #a4adb5;
-  --codice-code-highlight-color: #fff0ee;
+  --sh-caret-color: #354150;
+  --sh-title-color: #6f7b86;
+  --sh-control-color: #a8b1b8;
+  --sh-line-number-color: #a4adb5;
+  --sh-line-highlight-color: #fff0ee;
   --sh-class: #2d5e9d;
   --sh-identifier: #354150;
   --sh-sign: #8996a3;
@@ -158,8 +158,8 @@
 }
 
 .react-demo__editor {
-  --codice-caret-color: #354150;
-  --codice-code-line-number-color: #a4a4a4;
+  --sh-caret-color: #354150;
+  --sh-line-number-color: #a4a4a4;
   min-height: 330px;
   background: #f6f6f6;
   color: #354150;
@@ -179,9 +179,9 @@
 }
 
 .react-code-preview[data-codice-code] {
-  --codice-code-padding: 0px;
-  --codice-code-line-number-color: #a4a4a4;
-  --codice-code-highlight-color: #dff1ff;
+  --sh-padding: 0px;
+  --sh-line-number-color: #a4a4a4;
+  --sh-line-highlight-color: #dff1ff;
   padding: 0;
   background: #f6f6f6;
   color: #354150;

--- a/apps/site/app/react/page.tsx
+++ b/apps/site/app/react/page.tsx
@@ -31,12 +31,12 @@ render(
 
 const stylingExample = `const style = {
   backgroundColor: '#f6f8fa',
-  '--codice-background-color': 'transparent',
-  '--codice-caret-color': '#24292f',
-  '--codice-title-color': '#57606a',
-  '--codice-control-color': '#afb8c1',
-  '--codice-code-line-number-color': '#8c959f',
-  '--codice-code-highlight-color': '#fff8c5',
+  '--sh-editor-background-color': 'transparent',
+  '--sh-caret-color': '#24292f',
+  '--sh-title-color': '#57606a',
+  '--sh-control-color': '#afb8c1',
+  '--sh-line-number-color': '#8c959f',
+  '--sh-line-highlight-color': '#fff8c5',
   '--sh-keyword': '#cf222e',
   '--sh-string': '#0a3069',
 } as React.CSSProperties
@@ -44,17 +44,17 @@ const stylingExample = `const style = {
 <Editor style={style} value={source} onChange={setSource} />`
 
 const styleVariables = [
-  ['--codice-text-color', 'Editor', 'transparent', 'Textarea text; transparent over highlighted code.'],
-  ['--codice-background-color', 'Editor', 'transparent', 'Textarea background.'],
-  ['--codice-caret-color', 'Both', 'inherit', 'Editor and editable-title caret.'],
-  ['--codice-font-family', 'Both', 'Editor monospace; Code inherited', 'Code, textarea, and title font.'],
-  ['--codice-font-size', 'Both', 'inherit', 'Code and textarea font size.'],
-  ['--codice-code-padding', 'Both', '1rem', 'Content and header spacing.'],
-  ['--codice-code-line-number-width', 'Both', '2.5rem / auto', 'Line-number gutter width.'],
-  ['--codice-control-color', 'Both', 'unset', 'Header control-dot color.'],
-  ['--codice-title-color', 'Both', 'unset', 'Header filename color.'],
-  ['--codice-code-line-number-color', 'Both', 'unset', 'Line-number color.'],
-  ['--codice-code-highlight-color', 'Both', 'unset', 'Highlighted-line background.'],
+  ['--sh-editor-text-color', 'Editor', 'transparent', 'Textarea text; transparent over highlighted code.'],
+  ['--sh-editor-background-color', 'Editor', 'transparent', 'Textarea background.'],
+  ['--sh-caret-color', 'Both', 'inherit', 'Editor and editable-title caret.'],
+  ['--sh-font-family', 'Both', 'Editor monospace; Code inherited', 'Code, textarea, and title font.'],
+  ['--sh-font-size', 'Both', 'inherit', 'Code and textarea font size.'],
+  ['--sh-padding', 'Both', '1rem', 'Content and header spacing.'],
+  ['--sh-line-number-width', 'Both', '2.5rem / auto', 'Line-number gutter width.'],
+  ['--sh-control-color', 'Both', 'unset', 'Header control-dot color.'],
+  ['--sh-title-color', 'Both', 'unset', 'Header filename color.'],
+  ['--sh-line-number-color', 'Both', 'unset', 'Line-number color.'],
+  ['--sh-line-highlight-color', 'Both', 'unset', 'Highlighted-line background.'],
 ] as const
 
 function Window({ title, children }: { title: string; children: React.ReactNode }) {

--- a/apps/site/app/styles.css
+++ b/apps/site/app/styles.css
@@ -1,8 +1,8 @@
 :root {
-  --codice-caret-color: #333;
-  --codice-code-line-number-color: #a4a4a4;
-  --codice-code-highlight-color: #555555;
-  --codice-control-color: #8d8989;
+  --sh-caret-color: #333;
+  --sh-line-number-color: #a4a4a4;
+  --sh-line-highlight-color: #555555;
+  --sh-control-color: #8d8989;
 }
 
 ::selection {
@@ -250,7 +250,7 @@ input[type='checkbox']:checked {
 
 .showcase-section .code-frame,
 .showcase-section .codice.code-snippet {
-  --codice-font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+  --sh-font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
     'Liberation Mono', 'Courier New', monospace;
   background: var(--showcase-card-bg, #f6f6f6);
 }

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -34,22 +34,23 @@ import { Code } from '@sugar-high/react'
 `lang` takes a canonical Sugar High language name. When omitted, `title` or the legacy
 `extension` prop is resolved through Sugar High's language aliases.
 
-The package preserves Codice's existing `data-codice-*` attributes and CSS variables so existing
-themes can migrate without a DOM/CSS rewrite.
+Use the `data-sh-*` attributes and `--sh-*` variables for new styles. The package temporarily
+preserves Codice's existing `data-codice-*` attributes so existing structural selectors can
+migrate incrementally.
 
 ## Styling
 
-Set Codice variables on the component itself for a self-contained theme:
+Set Sugar High variables on the component itself for a self-contained theme:
 
 ```tsx
 const style = {
   backgroundColor: '#f6f8fa',
-  '--codice-background-color': 'transparent',
-  '--codice-caret-color': '#24292f',
-  '--codice-title-color': '#57606a',
-  '--codice-control-color': '#afb8c1',
-  '--codice-code-line-number-color': '#8c959f',
-  '--codice-code-highlight-color': '#fff8c5',
+  '--sh-editor-background-color': 'transparent',
+  '--sh-caret-color': '#24292f',
+  '--sh-title-color': '#57606a',
+  '--sh-control-color': '#afb8c1',
+  '--sh-line-number-color': '#8c959f',
+  '--sh-line-highlight-color': '#fff8c5',
   '--sh-keyword': '#cf222e',
   '--sh-string': '#0a3069',
 } as React.CSSProperties
@@ -57,26 +58,27 @@ const style = {
 <Editor style={style} value={source} onChange={setSource} />
 ```
 
-The `--codice-*` variables control the component frame and editor. Sugar High's `--sh-*`
-variables control syntax tokens; see the [theme guide](https://sugar-high.vercel.app/theme).
+The `--sh-*` variables control both the component frame and syntax tokens; see the
+[theme guide](https://sugar-high.vercel.app/theme).
 
 | Variable | Applies to | Default | Purpose |
 | --- | --- | --- | --- |
-| `--codice-text-color` | Editor | `transparent` | Textarea text color; normally transparent over highlighted code. |
-| `--codice-background-color` | Editor | `transparent` | Textarea background color. |
-| `--codice-caret-color` | Both | `inherit` | Editor caret and editable title caret. |
-| `--codice-font-family` | Both | Editor: `Consolas, Monaco, monospace`; Code: inherited | Code, textarea, and title font family. |
-| `--codice-font-size` | Both | `inherit` | Code and textarea font size. |
-| `--codice-code-padding` | Both | `1rem` | Shared content and header spacing. |
-| `--codice-code-line-number-width` | Both | `2.5rem`, expanding for 4+ digits | Line-number gutter width. Prefer `lineNumbersWidth` for an explicit override. |
-| `--codice-control-color` | Both | unset | Header control-dot color. |
-| `--codice-title-color` | Both | unset | Header filename color. |
-| `--codice-code-line-number-color` | Both | unset | Line-number color. |
-| `--codice-code-highlight-color` | Both | unset | Background for lines selected by `highlightLines`. |
+| `--sh-editor-text-color` | Editor | `transparent` | Textarea text color; normally transparent over highlighted code. |
+| `--sh-editor-background-color` | Editor | `transparent` | Textarea background color. |
+| `--sh-caret-color` | Both | `inherit` | Editor caret and editable title caret. |
+| `--sh-font-family` | Both | Editor: `Consolas, Monaco, monospace`; Code: inherited | Code, textarea, and title font family. |
+| `--sh-font-size` | Both | `inherit` | Code and textarea font size. |
+| `--sh-padding` | Both | `1rem` | Shared content and header spacing. |
+| `--sh-line-number-width` | Both | `2.5rem`, expanding for 4+ digits | Line-number gutter width. Prefer `lineNumbersWidth` for an explicit override. |
+| `--sh-control-color` | Both | unset | Header control-dot color. |
+| `--sh-title-color` | Both | unset | Header filename color. |
+| `--sh-line-number-color` | Both | unset | Line-number color. |
+| `--sh-line-highlight-color` | Both | unset | Background for lines selected by `highlightLines`. |
 
-The editor is a textarea layered over highlighted code. Keep `--codice-text-color` and
-`--codice-background-color` transparent unless deliberately changing that overlay; set the root's
+The editor is a textarea layered over highlighted code. Keep `--sh-editor-text-color` and
+`--sh-editor-background-color` transparent unless deliberately changing that overlay; set the root's
 ordinary `color` and `backgroundColor` for the visible surface.
 
-All component roots retain `data-codice`, `data-codice-code`, or `data-codice-editor` attributes
-for stylesheet selectors. Both components also accept standard `div` attributes.
+New styles should select component structure through the `data-sh-*` attributes. Component roots
+retain `data-codice`, `data-codice-code`, or `data-codice-editor` compatibility attributes during
+the Codice migration. Both components also accept standard `div` attributes.

--- a/packages/react/src/code/code.test.tsx
+++ b/packages/react/src/code/code.test.tsx
@@ -10,208 +10,116 @@ describe('Code', () => {
     expect(getLineNumbersWidth('line', '5rem')).toBe('5rem')
   })
 
+  it('exposes Sugar High markers and clamps highlighted ranges', () => {
+    const html = renderToString(
+      <Code highlightLines={[[1, Number.MAX_SAFE_INTEGER]]}>{'first\nsecond'}</Code>
+    )
+
+    expect(html).toContain('data-sh="code"')
+    expect(html.match(/data-highlight="true"/g)).toHaveLength(2)
+  })
+
   it('default props', () => {
     expect(renderToString(<Code>test</Code>)).toMatchInlineSnapshot(`
-      "<div data-codice="code" data-codice-code="true" data-codice-line-numbers="false"><style data-codice-style="true">@scope {
-      :scope[data-codice-code] {
-        padding: calc(var(--codice-code-padding) / 2) 0;
+      "<style data-precedence="default" data-href="sugar-high-react-code">[data-sh-code] {
+        padding: calc(var(--sh-padding) / 2) 0;
       }
-      :scope[data-codice-code] [data-codice-code-content] {
-        padding: calc(var(--codice-code-padding) * 0.25) 0;
+      [data-sh-code] [data-sh-code-content] {
+        padding: calc(var(--sh-padding) * 0.25) 0;
       }
-      :scope[data-codice-code] pre {
+      [data-sh-code] pre {
         white-space: pre-wrap;
         margin: 0;
       }
-      :scope[data-codice-code] code {
+      [data-sh-code] code {
         display: block;
         border: none;
       }
-      :scope[data-codice-code] .sh__line {
+      [data-sh-code] .sh__line {
         display: inline-block;
         width: 100%;
       }
-      :scope[data-codice-code] .sh__line[data-highlight] {
-        background-color: var(--codice-code-highlight-color);
+      [data-sh-code] .sh__line[data-highlight] {
+        background-color: var(--sh-line-highlight-color);
       }
 
-      :scope[data-codice-header] {
-        position: relative;
-        display: flex;
-        padding: calc(var(--codice-code-padding) * 0.25)
-          var(--codice-code-padding)
-          calc(var(--codice-code-padding) * 0.25);
-        align-items: center;
-      }
-      :scope[data-codice-header] [data-codice-title] {
-        display: inline-block;
-        flex: 1 0;
-        text-align: center;
-        line-height: 1;
-        background-color: transparent;
-        outline: none;
-        border: none;
-        caret-color: var(--codice-caret-color);
-        color: var(--codice-title-color);
-        font-family: var(--codice-font-family);
-      }
-      :scope[data-codice-header] [data-codice-controls] {
-        display: inline-flex;
-        align-self: center;
-        justify-self: start;
-        align-items: center;
-        justify-content: center;
-      }
-      :scope[data-codice-header] [data-codice-controls] {
-        width: 52px;
-      }
-      :scope[data-codice-header][data-codice-header-controls="true"] [data-codice-title] {
-        padding-right: 52px;
-      }
-      :scope[data-codice-header] [data-codice-control] {
-        display: flex;
-        width: 10px;
-        height: 10px;
-        margin: 3px;
-        border-radius: 50%;
-        background-color: var(--codice-control-color);
-      }
-
-      :scope[data-codice-line-numbers="true"] code {
+      [data-sh-line-numbers="true"] code {
         counter-reset: codice-code-line-number;
       }
-      :scope[data-codice-line-numbers="true"] .sh__line:has(> [data-codice-code-line-number]) {
-        padding-left: var(--codice-code-line-number-width);
+      [data-sh-line-numbers="true"] .sh__line:has(> [data-sh-code-line-number]) {
+        padding-left: var(--sh-line-number-width);
       }
-      :scope[data-codice-line-numbers="true"] [data-codice-code-line-number] {
+      [data-sh-line-numbers="true"] [data-sh-code-line-number] {
         counter-increment: codice-code-line-number 1;
         content: counter(codice-code-line-number);
         display: inline-block;
-        min-width: calc(var(--codice-code-line-number-width) - 14px);
-        margin-left: calc(var(--codice-code-line-number-width) * -1);
+        min-width: calc(var(--sh-line-number-width) - 14px);
+        margin-left: calc(var(--sh-line-number-width) * -1);
         margin-right: 14px;
         text-align: right;
         user-select: none;
-        color: var(--codice-code-line-number-color);
+        color: var(--sh-line-number-color);
       }
-      :scope[data-codice-line-numbers="false"] .sh__line {
-        padding-left: var(--codice-code-padding);
+      [data-sh-line-numbers="false"] .sh__line {
+        padding-left: var(--sh-padding);
       }
-
-      :scope[data-codice-code] {
-        --codice-font-size: inherit;
-        --codice-code-line-number-width: 2.5rem;
-        --codice-code-padding: 1rem;
-      }
-
-      }</style><pre data-codice-code-content="true"><code><span class="sh__line" data-codice-code-line="true"><span data-sh-token-type="identifier" class="sh__token--identifier" style="color:var(--sh-identifier)">test</span></span></code></pre></div>"
+      </style><div style="--sh-font-size:inherit;--sh-line-number-width:2.5rem;--sh-padding:1rem" data-codice="code" data-codice-code="true" data-sh="code" data-sh-code="true" data-codice-line-numbers="false" data-sh-line-numbers="false"><pre data-codice-code-content="true" data-sh-code-content="true"><code><span class="sh__line" data-codice-code-line="true" data-sh-code-line="true"><span data-sh-token-type="identifier" class="sh__token--identifier" style="color:var(--sh-identifier)">test</span></span></code></pre></div>"
     `)
   })
 
   it('with title', () => {
     expect(renderToString(<Code title="file.js">test</Code>)).toMatchInlineSnapshot(`
-      "<div data-codice="code" data-codice-code="true" data-codice-line-numbers="false"><style data-codice-style="true">@scope {
-      :scope[data-codice-code] {
-        padding: calc(var(--codice-code-padding) / 2) 0;
+      "<style data-precedence="default" data-href="sugar-high-react-code sugar-high-react-header">[data-sh-code] {
+        padding: calc(var(--sh-padding) / 2) 0;
       }
-      :scope[data-codice-code] [data-codice-code-content] {
-        padding: calc(var(--codice-code-padding) * 0.25) 0;
+      [data-sh-code] [data-sh-code-content] {
+        padding: calc(var(--sh-padding) * 0.25) 0;
       }
-      :scope[data-codice-code] pre {
+      [data-sh-code] pre {
         white-space: pre-wrap;
         margin: 0;
       }
-      :scope[data-codice-code] code {
+      [data-sh-code] code {
         display: block;
         border: none;
       }
-      :scope[data-codice-code] .sh__line {
+      [data-sh-code] .sh__line {
         display: inline-block;
         width: 100%;
       }
-      :scope[data-codice-code] .sh__line[data-highlight] {
-        background-color: var(--codice-code-highlight-color);
+      [data-sh-code] .sh__line[data-highlight] {
+        background-color: var(--sh-line-highlight-color);
       }
 
-      :scope[data-codice-header] {
-        position: relative;
-        display: flex;
-        padding: calc(var(--codice-code-padding) * 0.25)
-          var(--codice-code-padding)
-          calc(var(--codice-code-padding) * 0.25);
-        align-items: center;
-      }
-      :scope[data-codice-header] [data-codice-title] {
-        display: inline-block;
-        flex: 1 0;
-        text-align: center;
-        line-height: 1;
-        background-color: transparent;
-        outline: none;
-        border: none;
-        caret-color: var(--codice-caret-color);
-        color: var(--codice-title-color);
-        font-family: var(--codice-font-family);
-      }
-      :scope[data-codice-header] [data-codice-controls] {
-        display: inline-flex;
-        align-self: center;
-        justify-self: start;
-        align-items: center;
-        justify-content: center;
-      }
-      :scope[data-codice-header] [data-codice-controls] {
-        width: 52px;
-      }
-      :scope[data-codice-header][data-codice-header-controls="true"] [data-codice-title] {
-        padding-right: 52px;
-      }
-      :scope[data-codice-header] [data-codice-control] {
-        display: flex;
-        width: 10px;
-        height: 10px;
-        margin: 3px;
-        border-radius: 50%;
-        background-color: var(--codice-control-color);
-      }
-
-      :scope[data-codice-line-numbers="true"] code {
+      [data-sh-line-numbers="true"] code {
         counter-reset: codice-code-line-number;
       }
-      :scope[data-codice-line-numbers="true"] .sh__line:has(> [data-codice-code-line-number]) {
-        padding-left: var(--codice-code-line-number-width);
+      [data-sh-line-numbers="true"] .sh__line:has(> [data-sh-code-line-number]) {
+        padding-left: var(--sh-line-number-width);
       }
-      :scope[data-codice-line-numbers="true"] [data-codice-code-line-number] {
+      [data-sh-line-numbers="true"] [data-sh-code-line-number] {
         counter-increment: codice-code-line-number 1;
         content: counter(codice-code-line-number);
         display: inline-block;
-        min-width: calc(var(--codice-code-line-number-width) - 14px);
-        margin-left: calc(var(--codice-code-line-number-width) * -1);
+        min-width: calc(var(--sh-line-number-width) - 14px);
+        margin-left: calc(var(--sh-line-number-width) * -1);
         margin-right: 14px;
         text-align: right;
         user-select: none;
-        color: var(--codice-code-line-number-color);
+        color: var(--sh-line-number-color);
       }
-      :scope[data-codice-line-numbers="false"] .sh__line {
-        padding-left: var(--codice-code-padding);
+      [data-sh-line-numbers="false"] .sh__line {
+        padding-left: var(--sh-padding);
       }
-
-      :scope[data-codice-code] {
-        --codice-font-size: inherit;
-        --codice-code-line-number-width: 2.5rem;
-        --codice-code-padding: 1rem;
-      }
-
-      }</style><div data-codice-header="true" data-codice-header-controls="false"><style data-codice-style="true">@scope {
-      :scope[data-codice-header] {
+      [data-sh-header] {
         position: relative;
         display: flex;
-        padding: calc(var(--codice-code-padding) * 0.25)
-          var(--codice-code-padding)
-          calc(var(--codice-code-padding) * 0.25);
+        padding: calc(var(--sh-padding) * 0.25)
+          var(--sh-padding)
+          calc(var(--sh-padding) * 0.25);
         align-items: center;
       }
-      :scope[data-codice-header] [data-codice-title] {
+      [data-sh-header] [data-sh-title] {
         display: inline-block;
         flex: 1 0;
         text-align: center;
@@ -219,140 +127,86 @@ describe('Code', () => {
         background-color: transparent;
         outline: none;
         border: none;
-        caret-color: var(--codice-caret-color);
-        color: var(--codice-title-color);
-        font-family: var(--codice-font-family);
+        caret-color: var(--sh-caret-color);
+        color: var(--sh-title-color);
+        font-family: var(--sh-font-family);
       }
-      :scope[data-codice-header] [data-codice-controls] {
+      [data-sh-header] [data-sh-controls] {
         display: inline-flex;
         align-self: center;
         justify-self: start;
         align-items: center;
         justify-content: center;
-      }
-      :scope[data-codice-header] [data-codice-controls] {
         width: 52px;
       }
-      :scope[data-codice-header][data-codice-header-controls="true"] [data-codice-title] {
+      [data-sh-header][data-sh-header-controls="true"] [data-sh-title] {
         padding-right: 52px;
       }
-      :scope[data-codice-header] [data-codice-control] {
+      [data-sh-header] [data-sh-control] {
         display: flex;
         width: 10px;
         height: 10px;
         margin: 3px;
         border-radius: 50%;
-        background-color: var(--codice-control-color);
+        background-color: var(--sh-control-color);
       }
-
-      }</style><input data-codice-title="true" readOnly="" value="file.js"/></div><pre data-codice-code-content="true"><code><span class="sh__line" data-codice-code-line="true"><span data-sh-token-type="identifier" class="sh__token--identifier" style="color:var(--sh-identifier)">test</span></span></code></pre></div>"
+      </style><div style="--sh-font-size:inherit;--sh-line-number-width:2.5rem;--sh-padding:1rem" data-codice="code" data-codice-code="true" data-sh="code" data-sh-code="true" data-codice-line-numbers="false" data-sh-line-numbers="false"><div data-codice-header="true" data-sh-header="true" data-codice-header-controls="false" data-sh-header-controls="false"><input data-codice-title="true" data-sh-title="true" readOnly="" value="file.js"/></div><pre data-codice-code-content="true" data-sh-code-content="true"><code><span class="sh__line" data-codice-code-line="true" data-sh-code-line="true"><span data-sh-token-type="identifier" class="sh__token--identifier" style="color:var(--sh-identifier)">test</span></span></code></pre></div>"
     `)
   })
 
   it('with controls', () => {
     expect(renderToString(<Code controls>test</Code>)).toMatchInlineSnapshot(`
-      "<div data-codice="code" data-codice-code="true" data-codice-line-numbers="false"><style data-codice-style="true">@scope {
-      :scope[data-codice-code] {
-        padding: calc(var(--codice-code-padding) / 2) 0;
+      "<style data-precedence="default" data-href="sugar-high-react-code sugar-high-react-header">[data-sh-code] {
+        padding: calc(var(--sh-padding) / 2) 0;
       }
-      :scope[data-codice-code] [data-codice-code-content] {
-        padding: calc(var(--codice-code-padding) * 0.25) 0;
+      [data-sh-code] [data-sh-code-content] {
+        padding: calc(var(--sh-padding) * 0.25) 0;
       }
-      :scope[data-codice-code] pre {
+      [data-sh-code] pre {
         white-space: pre-wrap;
         margin: 0;
       }
-      :scope[data-codice-code] code {
+      [data-sh-code] code {
         display: block;
         border: none;
       }
-      :scope[data-codice-code] .sh__line {
+      [data-sh-code] .sh__line {
         display: inline-block;
         width: 100%;
       }
-      :scope[data-codice-code] .sh__line[data-highlight] {
-        background-color: var(--codice-code-highlight-color);
+      [data-sh-code] .sh__line[data-highlight] {
+        background-color: var(--sh-line-highlight-color);
       }
 
-      :scope[data-codice-header] {
-        position: relative;
-        display: flex;
-        padding: calc(var(--codice-code-padding) * 0.25)
-          var(--codice-code-padding)
-          calc(var(--codice-code-padding) * 0.25);
-        align-items: center;
-      }
-      :scope[data-codice-header] [data-codice-title] {
-        display: inline-block;
-        flex: 1 0;
-        text-align: center;
-        line-height: 1;
-        background-color: transparent;
-        outline: none;
-        border: none;
-        caret-color: var(--codice-caret-color);
-        color: var(--codice-title-color);
-        font-family: var(--codice-font-family);
-      }
-      :scope[data-codice-header] [data-codice-controls] {
-        display: inline-flex;
-        align-self: center;
-        justify-self: start;
-        align-items: center;
-        justify-content: center;
-      }
-      :scope[data-codice-header] [data-codice-controls] {
-        width: 52px;
-      }
-      :scope[data-codice-header][data-codice-header-controls="true"] [data-codice-title] {
-        padding-right: 52px;
-      }
-      :scope[data-codice-header] [data-codice-control] {
-        display: flex;
-        width: 10px;
-        height: 10px;
-        margin: 3px;
-        border-radius: 50%;
-        background-color: var(--codice-control-color);
-      }
-
-      :scope[data-codice-line-numbers="true"] code {
+      [data-sh-line-numbers="true"] code {
         counter-reset: codice-code-line-number;
       }
-      :scope[data-codice-line-numbers="true"] .sh__line:has(> [data-codice-code-line-number]) {
-        padding-left: var(--codice-code-line-number-width);
+      [data-sh-line-numbers="true"] .sh__line:has(> [data-sh-code-line-number]) {
+        padding-left: var(--sh-line-number-width);
       }
-      :scope[data-codice-line-numbers="true"] [data-codice-code-line-number] {
+      [data-sh-line-numbers="true"] [data-sh-code-line-number] {
         counter-increment: codice-code-line-number 1;
         content: counter(codice-code-line-number);
         display: inline-block;
-        min-width: calc(var(--codice-code-line-number-width) - 14px);
-        margin-left: calc(var(--codice-code-line-number-width) * -1);
+        min-width: calc(var(--sh-line-number-width) - 14px);
+        margin-left: calc(var(--sh-line-number-width) * -1);
         margin-right: 14px;
         text-align: right;
         user-select: none;
-        color: var(--codice-code-line-number-color);
+        color: var(--sh-line-number-color);
       }
-      :scope[data-codice-line-numbers="false"] .sh__line {
-        padding-left: var(--codice-code-padding);
+      [data-sh-line-numbers="false"] .sh__line {
+        padding-left: var(--sh-padding);
       }
-
-      :scope[data-codice-code] {
-        --codice-font-size: inherit;
-        --codice-code-line-number-width: 2.5rem;
-        --codice-code-padding: 1rem;
-      }
-
-      }</style><div data-codice-header="true" data-codice-header-controls="true"><style data-codice-style="true">@scope {
-      :scope[data-codice-header] {
+      [data-sh-header] {
         position: relative;
         display: flex;
-        padding: calc(var(--codice-code-padding) * 0.25)
-          var(--codice-code-padding)
-          calc(var(--codice-code-padding) * 0.25);
+        padding: calc(var(--sh-padding) * 0.25)
+          var(--sh-padding)
+          calc(var(--sh-padding) * 0.25);
         align-items: center;
       }
-      :scope[data-codice-header] [data-codice-title] {
+      [data-sh-header] [data-sh-title] {
         display: inline-block;
         flex: 1 0;
         text-align: center;
@@ -360,227 +214,124 @@ describe('Code', () => {
         background-color: transparent;
         outline: none;
         border: none;
-        caret-color: var(--codice-caret-color);
-        color: var(--codice-title-color);
-        font-family: var(--codice-font-family);
+        caret-color: var(--sh-caret-color);
+        color: var(--sh-title-color);
+        font-family: var(--sh-font-family);
       }
-      :scope[data-codice-header] [data-codice-controls] {
+      [data-sh-header] [data-sh-controls] {
         display: inline-flex;
         align-self: center;
         justify-self: start;
         align-items: center;
         justify-content: center;
-      }
-      :scope[data-codice-header] [data-codice-controls] {
         width: 52px;
       }
-      :scope[data-codice-header][data-codice-header-controls="true"] [data-codice-title] {
+      [data-sh-header][data-sh-header-controls="true"] [data-sh-title] {
         padding-right: 52px;
       }
-      :scope[data-codice-header] [data-codice-control] {
+      [data-sh-header] [data-sh-control] {
         display: flex;
         width: 10px;
         height: 10px;
         margin: 3px;
         border-radius: 50%;
-        background-color: var(--codice-control-color);
+        background-color: var(--sh-control-color);
       }
-
-      }</style><div data-codice-controls="true"><span data-codice-control="true"></span><span data-codice-control="true"></span><span data-codice-control="true"></span></div></div><pre data-codice-code-content="true"><code><span class="sh__line" data-codice-code-line="true"><span data-sh-token-type="identifier" class="sh__token--identifier" style="color:var(--sh-identifier)">test</span></span></code></pre></div>"
+      </style><div style="--sh-font-size:inherit;--sh-line-number-width:2.5rem;--sh-padding:1rem" data-codice="code" data-codice-code="true" data-sh="code" data-sh-code="true" data-codice-line-numbers="false" data-sh-line-numbers="false"><div data-codice-header="true" data-sh-header="true" data-codice-header-controls="true" data-sh-header-controls="true"><div data-codice-controls="true" data-sh-controls="true"><span data-codice-control="true" data-sh-control="true"></span><span data-codice-control="true" data-sh-control="true"></span><span data-codice-control="true" data-sh-control="true"></span></div></div><pre data-codice-code-content="true" data-sh-code-content="true"><code><span class="sh__line" data-codice-code-line="true" data-sh-code-line="true"><span data-sh-token-type="identifier" class="sh__token--identifier" style="color:var(--sh-identifier)">test</span></span></code></pre></div>"
     `)
   })
 
   it('with fontSize', () => {
     expect(renderToString(<Code fontSize={14}>test</Code>)).toMatchInlineSnapshot(`
-      "<div data-codice="code" data-codice-code="true" data-codice-line-numbers="false"><style data-codice-style="true">@scope {
-      :scope[data-codice-code] {
-        padding: calc(var(--codice-code-padding) / 2) 0;
+      "<style data-precedence="default" data-href="sugar-high-react-code">[data-sh-code] {
+        padding: calc(var(--sh-padding) / 2) 0;
       }
-      :scope[data-codice-code] [data-codice-code-content] {
-        padding: calc(var(--codice-code-padding) * 0.25) 0;
+      [data-sh-code] [data-sh-code-content] {
+        padding: calc(var(--sh-padding) * 0.25) 0;
       }
-      :scope[data-codice-code] pre {
+      [data-sh-code] pre {
         white-space: pre-wrap;
         margin: 0;
       }
-      :scope[data-codice-code] code {
+      [data-sh-code] code {
         display: block;
         border: none;
       }
-      :scope[data-codice-code] .sh__line {
+      [data-sh-code] .sh__line {
         display: inline-block;
         width: 100%;
       }
-      :scope[data-codice-code] .sh__line[data-highlight] {
-        background-color: var(--codice-code-highlight-color);
+      [data-sh-code] .sh__line[data-highlight] {
+        background-color: var(--sh-line-highlight-color);
       }
 
-      :scope[data-codice-header] {
-        position: relative;
-        display: flex;
-        padding: calc(var(--codice-code-padding) * 0.25)
-          var(--codice-code-padding)
-          calc(var(--codice-code-padding) * 0.25);
-        align-items: center;
-      }
-      :scope[data-codice-header] [data-codice-title] {
-        display: inline-block;
-        flex: 1 0;
-        text-align: center;
-        line-height: 1;
-        background-color: transparent;
-        outline: none;
-        border: none;
-        caret-color: var(--codice-caret-color);
-        color: var(--codice-title-color);
-        font-family: var(--codice-font-family);
-      }
-      :scope[data-codice-header] [data-codice-controls] {
-        display: inline-flex;
-        align-self: center;
-        justify-self: start;
-        align-items: center;
-        justify-content: center;
-      }
-      :scope[data-codice-header] [data-codice-controls] {
-        width: 52px;
-      }
-      :scope[data-codice-header][data-codice-header-controls="true"] [data-codice-title] {
-        padding-right: 52px;
-      }
-      :scope[data-codice-header] [data-codice-control] {
-        display: flex;
-        width: 10px;
-        height: 10px;
-        margin: 3px;
-        border-radius: 50%;
-        background-color: var(--codice-control-color);
-      }
-
-      :scope[data-codice-line-numbers="true"] code {
+      [data-sh-line-numbers="true"] code {
         counter-reset: codice-code-line-number;
       }
-      :scope[data-codice-line-numbers="true"] .sh__line:has(> [data-codice-code-line-number]) {
-        padding-left: var(--codice-code-line-number-width);
+      [data-sh-line-numbers="true"] .sh__line:has(> [data-sh-code-line-number]) {
+        padding-left: var(--sh-line-number-width);
       }
-      :scope[data-codice-line-numbers="true"] [data-codice-code-line-number] {
+      [data-sh-line-numbers="true"] [data-sh-code-line-number] {
         counter-increment: codice-code-line-number 1;
         content: counter(codice-code-line-number);
         display: inline-block;
-        min-width: calc(var(--codice-code-line-number-width) - 14px);
-        margin-left: calc(var(--codice-code-line-number-width) * -1);
+        min-width: calc(var(--sh-line-number-width) - 14px);
+        margin-left: calc(var(--sh-line-number-width) * -1);
         margin-right: 14px;
         text-align: right;
         user-select: none;
-        color: var(--codice-code-line-number-color);
+        color: var(--sh-line-number-color);
       }
-      :scope[data-codice-line-numbers="false"] .sh__line {
-        padding-left: var(--codice-code-padding);
+      [data-sh-line-numbers="false"] .sh__line {
+        padding-left: var(--sh-padding);
       }
-
-      :scope[data-codice-code] {
-        --codice-font-size: 14px;
-        --codice-code-line-number-width: 2.5rem;
-        --codice-code-padding: 1rem;
-      }
-
-      }</style><pre data-codice-code-content="true"><code><span class="sh__line" data-codice-code-line="true"><span data-sh-token-type="identifier" class="sh__token--identifier" style="color:var(--sh-identifier)">test</span></span></code></pre></div>"
+      </style><div style="--sh-font-size:14px;--sh-line-number-width:2.5rem;--sh-padding:1rem" data-codice="code" data-codice-code="true" data-sh="code" data-sh-code="true" data-codice-line-numbers="false" data-sh-line-numbers="false"><pre data-codice-code-content="true" data-sh-code-content="true"><code><span class="sh__line" data-codice-code-line="true" data-sh-code-line="true"><span data-sh-token-type="identifier" class="sh__token--identifier" style="color:var(--sh-identifier)">test</span></span></code></pre></div>"
     `)
 
     expect(renderToString(<Code fontSize={'1rem'}>test</Code>)).toMatchInlineSnapshot(`
-      "<div data-codice="code" data-codice-code="true" data-codice-line-numbers="false"><style data-codice-style="true">@scope {
-      :scope[data-codice-code] {
-        padding: calc(var(--codice-code-padding) / 2) 0;
+      "<style data-precedence="default" data-href="sugar-high-react-code">[data-sh-code] {
+        padding: calc(var(--sh-padding) / 2) 0;
       }
-      :scope[data-codice-code] [data-codice-code-content] {
-        padding: calc(var(--codice-code-padding) * 0.25) 0;
+      [data-sh-code] [data-sh-code-content] {
+        padding: calc(var(--sh-padding) * 0.25) 0;
       }
-      :scope[data-codice-code] pre {
+      [data-sh-code] pre {
         white-space: pre-wrap;
         margin: 0;
       }
-      :scope[data-codice-code] code {
+      [data-sh-code] code {
         display: block;
         border: none;
       }
-      :scope[data-codice-code] .sh__line {
+      [data-sh-code] .sh__line {
         display: inline-block;
         width: 100%;
       }
-      :scope[data-codice-code] .sh__line[data-highlight] {
-        background-color: var(--codice-code-highlight-color);
+      [data-sh-code] .sh__line[data-highlight] {
+        background-color: var(--sh-line-highlight-color);
       }
 
-      :scope[data-codice-header] {
-        position: relative;
-        display: flex;
-        padding: calc(var(--codice-code-padding) * 0.25)
-          var(--codice-code-padding)
-          calc(var(--codice-code-padding) * 0.25);
-        align-items: center;
-      }
-      :scope[data-codice-header] [data-codice-title] {
-        display: inline-block;
-        flex: 1 0;
-        text-align: center;
-        line-height: 1;
-        background-color: transparent;
-        outline: none;
-        border: none;
-        caret-color: var(--codice-caret-color);
-        color: var(--codice-title-color);
-        font-family: var(--codice-font-family);
-      }
-      :scope[data-codice-header] [data-codice-controls] {
-        display: inline-flex;
-        align-self: center;
-        justify-self: start;
-        align-items: center;
-        justify-content: center;
-      }
-      :scope[data-codice-header] [data-codice-controls] {
-        width: 52px;
-      }
-      :scope[data-codice-header][data-codice-header-controls="true"] [data-codice-title] {
-        padding-right: 52px;
-      }
-      :scope[data-codice-header] [data-codice-control] {
-        display: flex;
-        width: 10px;
-        height: 10px;
-        margin: 3px;
-        border-radius: 50%;
-        background-color: var(--codice-control-color);
-      }
-
-      :scope[data-codice-line-numbers="true"] code {
+      [data-sh-line-numbers="true"] code {
         counter-reset: codice-code-line-number;
       }
-      :scope[data-codice-line-numbers="true"] .sh__line:has(> [data-codice-code-line-number]) {
-        padding-left: var(--codice-code-line-number-width);
+      [data-sh-line-numbers="true"] .sh__line:has(> [data-sh-code-line-number]) {
+        padding-left: var(--sh-line-number-width);
       }
-      :scope[data-codice-line-numbers="true"] [data-codice-code-line-number] {
+      [data-sh-line-numbers="true"] [data-sh-code-line-number] {
         counter-increment: codice-code-line-number 1;
         content: counter(codice-code-line-number);
         display: inline-block;
-        min-width: calc(var(--codice-code-line-number-width) - 14px);
-        margin-left: calc(var(--codice-code-line-number-width) * -1);
+        min-width: calc(var(--sh-line-number-width) - 14px);
+        margin-left: calc(var(--sh-line-number-width) * -1);
         margin-right: 14px;
         text-align: right;
         user-select: none;
-        color: var(--codice-code-line-number-color);
+        color: var(--sh-line-number-color);
       }
-      :scope[data-codice-line-numbers="false"] .sh__line {
-        padding-left: var(--codice-code-padding);
+      [data-sh-line-numbers="false"] .sh__line {
+        padding-left: var(--sh-padding);
       }
-
-      :scope[data-codice-code] {
-        --codice-font-size: 1rem;
-        --codice-code-line-number-width: 2.5rem;
-        --codice-code-padding: 1rem;
-      }
-
-      }</style><pre data-codice-code-content="true"><code><span class="sh__line" data-codice-code-line="true"><span data-sh-token-type="identifier" class="sh__token--identifier" style="color:var(--sh-identifier)">test</span></span></code></pre></div>"
+      </style><div style="--sh-font-size:1rem;--sh-line-number-width:2.5rem;--sh-padding:1rem" data-codice="code" data-codice-code="true" data-sh="code" data-sh-code="true" data-codice-line-numbers="false" data-sh-line-numbers="false"><pre data-codice-code-content="true" data-sh-code-content="true"><code><span class="sh__line" data-codice-code-line="true" data-sh-code-line="true"><span data-sh-token-type="identifier" class="sh__token--identifier" style="color:var(--sh-identifier)">test</span></span></code></pre></div>"
     `)
   })
 })

--- a/packages/react/src/code/code.tsx
+++ b/packages/react/src/code/code.tsx
@@ -5,7 +5,7 @@ import { parse, generate } from 'sugar-high/core'
 import { css, HEADER_CSS } from './css'
 import { lang as canonicalLang, languages } from 'sugar-high/lang'
 import { useMemo } from 'react'
-import { ScopedStyle } from '../style'
+import { fontSizeCss, ScopedStyle } from '../style'
 
 /** utils */
 export function getExtension(title: string | undefined) {
@@ -14,47 +14,46 @@ export function getExtension(title: string | undefined) {
 
 export function getLineNumbersWidth(code: string, width?: string) {
   if (width) return width
-  const digits = String(code.split('\n').length).length
+  let lines = 1
+  for (let i = 0; i < code.length; i++) {
+    if (code.charCodeAt(i) === 10) lines++
+  }
+  const digits = String(lines).length
   return digits > 3 ? `calc(${digits}ch + 14px)` : undefined
 }
 
 function generateHighlightedLines(
-  codeText: string,
+  parsed: ReturnType<typeof parse>,
   highlightLines: ([number, number] | number)[],
   lineNumbers: boolean,
-  title: string | undefined,
-  extension: string | undefined,
-  language: LanguageName | undefined,
   cx: HighlightOptions['cx'],
   mark: HighlightOptions['mark'],
   markLine: HighlightOptions['markLine']
 ) {
-  const ext = extension || getExtension(title)
-  const resolvedLang = language || canonicalLang(ext)
-  const config = languages.find(({ id }) => id === (resolvedLang || 'javascript'))?.config
-  const parsed = parse(codeText, config)
   const childrenLines = generate(parsed, { cx, mark, markLine })
 
   // each line will contain class name 'sh__line',
   // if it's highlighted, it will contain [data-highlight]
-  const highlightedLines = new Set<number>()
+  const highlightedLines = highlightLines?.length ? new Set<number>() : undefined
   if (highlightLines) {
     for (const line of highlightLines) {
       if (Array.isArray(line)) {
         // Add range of lines
-        for (let i = line[0]; i <= line[1]; i++) {
-          highlightedLines.add(i)
+        const start = Math.max(1, line[0])
+        const end = Math.min(childrenLines.length, line[1])
+        for (let i = start; i <= end; i++) {
+          highlightedLines?.add(i)
         }
       } else {
         // Add single line
-        highlightedLines.add(line)
+        highlightedLines?.add(line)
       }
     }
   }
 
   const lines = (
     childrenLines.map((line, index) => {
-      const isHighlighted = highlightedLines.has(index + 1)
+      const isHighlighted = highlightedLines?.has(index + 1)
       const { tagName: Line, properties: lineProperties } = line
       const tokens = line.children
         .map((child, childIndex) => {
@@ -77,9 +76,10 @@ function generateHighlightedLines(
           // Add data-highlight attribute if line is highlighted
           {...(isHighlighted ? {'data-highlight': true} : {})}
           data-codice-code-line
+          data-sh-code-line
           key={index}
         >
-          {lineNumbers ? <span key='ln' data-codice-code-line-number>{index + 1}</span> : null}
+          {lineNumbers ? <span key='ln' data-codice-code-line-number data-sh-code-line-number>{index + 1}</span> : null}
           {tokens}
         </Line>
       )
@@ -98,6 +98,7 @@ function TitleInput({
   return (
     <input
       data-codice-title
+      data-sh-title
       value={title}
       readOnly={!onChange}
       {...(onChange && {
@@ -122,14 +123,16 @@ export function CodeHeader({
   return (
     <div
       data-codice-header
+      data-sh-header
       data-codice-header-controls={controls}
+      data-sh-header-controls={controls}
     >
-      <ScopedStyle css={HEADER_CSS} />
+      <ScopedStyle css={HEADER_CSS} href="sugar-high-react-header" />
       {controls ? (
-        <div data-codice-controls>
-          <span data-codice-control />
-          <span data-codice-control />
-          <span data-codice-control />
+        <div data-codice-controls data-sh-controls>
+          <span data-codice-control data-sh-control />
+          <span data-codice-control data-sh-control />
+          <span data-codice-control data-sh-control />
         </div>
       ) : null}
       {title ? <TitleInput title={title} onChange={onChangeTitle} /> : null}
@@ -148,11 +151,11 @@ function CodeFrame({
 }) {
   const props = asMarkup ? { dangerouslySetInnerHTML: { __html: children } } : { children }
   return preformatted ? (
-    <pre data-codice-code-content>
+    <pre data-codice-code-content data-sh-code-content>
       <code {...props} />
     </pre>
   ) : (
-    <div {...props} data-codice-code-content  />
+    <div {...props} data-codice-code-content data-sh-code-content />
   )
 }
 
@@ -172,6 +175,7 @@ export function Code({
   cx,
   mark,
   markLine,
+  style,
   ...props
 }: {
   children: string
@@ -192,22 +196,36 @@ export function Code({
   markLine?: HighlightOptions['markLine']
 } & React.HTMLAttributes<HTMLDivElement>) {
   const resolvedLineNumbersWidth = getLineNumbersWidth(code, lineNumbersWidth)
+  const config = useMemo(() => {
+    const resolvedLang = lang || canonicalLang(extension || getExtension(title)) || 'javascript'
+    return languages.find(({ id }) => id === resolvedLang)?.config
+  }, [extension, lang, title])
+  const parsed = useMemo(() => asMarkup ? null : parse(code, config), [asMarkup, code, config])
   const lineElements = useMemo(() =>
     asMarkup
       ? code
-      : generateHighlightedLines(code, highlightLines, lineNumbers, title, extension, lang, cx, mark, markLine),
-    [code, highlightLines, lineNumbers, title, extension, lang, cx, mark, markLine, asMarkup]
+      : generateHighlightedLines(parsed!, highlightLines, lineNumbers, cx, mark, markLine),
+    [code, highlightLines, lineNumbers, cx, mark, markLine, asMarkup, parsed]
   )
 
   return (
     // Add both attribute because it's both root component and child component (of editor)
     <div
       {...props}
+      style={{
+        '--sh-font-size': fontSizeCss(fontSize),
+        '--sh-line-number-width': resolvedLineNumbersWidth || '2.5rem',
+        '--sh-padding': padding ?? '1rem',
+        ...style,
+      } as React.CSSProperties}
       data-codice="code"
       data-codice-code
+      data-sh="code"
+      data-sh-code
       data-codice-line-numbers={lineNumbers}
+      data-sh-line-numbers={lineNumbers}
     >
-      <ScopedStyle css={css({ fontSize, lineNumbersWidth: resolvedLineNumbersWidth, padding })} />
+      <ScopedStyle css={css} href="sugar-high-react-code" />
       <CodeHeader title={title} controls={controls} />
       <CodeFrame preformatted={preformatted} asMarkup={asMarkup}>
         {lineElements}

--- a/packages/react/src/code/css.ts
+++ b/packages/react/src/code/css.ts
@@ -1,16 +1,14 @@
-import { fontSizeCss } from '../style'
-
-const C = `:scope[data-codice-code]`
-const H = `:scope[data-codice-header]`
-const L = `:scope[data-codice-line-numbers="true"]`
-const FL = `:scope[data-codice-line-numbers="false"]`
+const C = `[data-sh-code]`
+const H = `[data-sh-header]`
+const L = `[data-sh-line-numbers="true"]`
+const FL = `[data-sh-line-numbers="false"]`
 
 const BASE_CSS = `\
 ${C} {
-  padding: calc(var(--codice-code-padding) / 2) 0;
+  padding: calc(var(--sh-padding) / 2) 0;
 }
-${C} [data-codice-code-content] {
-  padding: calc(var(--codice-code-padding) * 0.25) 0;
+${C} [data-sh-code-content] {
+  padding: calc(var(--sh-padding) * 0.25) 0;
 }
 ${C} pre {
   white-space: pre-wrap;
@@ -25,7 +23,7 @@ ${C} .sh__line {
   width: 100%;
 }
 ${C} .sh__line[data-highlight] {
-  background-color: var(--codice-code-highlight-color);
+  background-color: var(--sh-line-highlight-color);
 }
 `
 
@@ -33,12 +31,12 @@ export const HEADER_CSS = `\
 ${H} {
   position: relative;
   display: flex;
-  padding: calc(var(--codice-code-padding) * 0.25)
-    var(--codice-code-padding)
-    calc(var(--codice-code-padding) * 0.25);
+  padding: calc(var(--sh-padding) * 0.25)
+    var(--sh-padding)
+    calc(var(--sh-padding) * 0.25);
   align-items: center;
 }
-${H} [data-codice-title] {
+${H} [data-sh-title] {
   display: inline-block;
   flex: 1 0;
   text-align: center;
@@ -46,30 +44,28 @@ ${H} [data-codice-title] {
   background-color: transparent;
   outline: none;
   border: none;
-  caret-color: var(--codice-caret-color);
-  color: var(--codice-title-color);
-  font-family: var(--codice-font-family);
+  caret-color: var(--sh-caret-color);
+  color: var(--sh-title-color);
+  font-family: var(--sh-font-family);
 }
-${H} [data-codice-controls] {
+${H} [data-sh-controls] {
   display: inline-flex;
   align-self: center;
   justify-self: start;
   align-items: center;
   justify-content: center;
-}
-${H} [data-codice-controls] {
   width: 52px;
 }
-${H}[data-codice-header-controls="true"] [data-codice-title] {
+${H}[data-sh-header-controls="true"] [data-sh-title] {
   padding-right: 52px;
 }
-${H} [data-codice-control] {
+${H} [data-sh-control] {
   display: flex;
   width: 10px;
   height: 10px;
   margin: 3px;
   border-radius: 50%;
-  background-color: var(--codice-control-color);
+  background-color: var(--sh-control-color);
 }
 `
 
@@ -77,43 +73,23 @@ const LINE_NUMBER_CSS = `\
 ${L} code {
   counter-reset: codice-code-line-number;
 }
-${L} .sh__line:has(> [data-codice-code-line-number]) {
-  padding-left: var(--codice-code-line-number-width);
+${L} .sh__line:has(> [data-sh-code-line-number]) {
+  padding-left: var(--sh-line-number-width);
 }
-${L} [data-codice-code-line-number] {
+${L} [data-sh-code-line-number] {
   counter-increment: codice-code-line-number 1;
   content: counter(codice-code-line-number);
   display: inline-block;
-  min-width: calc(var(--codice-code-line-number-width) - 14px);
-  margin-left: calc(var(--codice-code-line-number-width) * -1);
+  min-width: calc(var(--sh-line-number-width) - 14px);
+  margin-left: calc(var(--sh-line-number-width) * -1);
   margin-right: 14px;
   text-align: right;
   user-select: none;
-  color: var(--codice-code-line-number-color);
+  color: var(--sh-line-number-color);
 }
 ${FL} .sh__line {
-  padding-left: var(--codice-code-padding);
+  padding-left: var(--sh-padding);
 }
 `
 
-const CODE_CSS = `${BASE_CSS}\n${HEADER_CSS}\n${LINE_NUMBER_CSS}`
-
-export const css = ({
-  fontSize,
-  lineNumbersWidth = '2.5rem',
-  padding = '1rem',
-}: {
-  fontSize: string | number | undefined
-  lineNumbersWidth: string
-  padding: string
-}): string => {
-  const fz = fontSizeCss(fontSize)
-  return `\
-${CODE_CSS}
-${C} {
-  --codice-font-size: ${fz};
-  --codice-code-line-number-width: ${lineNumbersWidth};
-  --codice-code-padding: ${padding};
-}
-`
-}
+export const css = `${BASE_CSS}\n${LINE_NUMBER_CSS}`

--- a/packages/react/src/editor/css.ts
+++ b/packages/react/src/editor/css.ts
@@ -1,12 +1,11 @@
-import { fontSizeCss } from '../style'
-
-const R = `:scope[data-codice-editor]`
+const R = `[data-sh-editor]`
+// 2.5rem is the default line-number width.
 
 export const EDITOR_CSS = `\
 ${R} {
-  --codice-text-color: transparent;
-  --codice-background-color: transparent;
-  --codice-caret-color: inherit;
+  --sh-editor-text-color: transparent;
+  --sh-editor-background-color: transparent;
+  --sh-caret-color: inherit;
 
   position: relative;
   overflow-y: scroll;
@@ -16,17 +15,17 @@ ${R} {
   scrollbar-width: none;
 }
 ${R} textarea:not(:placeholder-shown) {
-  padding: calc(var(--codice-code-padding) * 0.75) calc(var(--codice-code-padding) * 0.5);
+  padding: calc(var(--sh-padding) * 0.75) calc(var(--sh-padding) * 0.5);
 }
 ${R} code,
 ${R} textarea {
-  font-family: var(--codice-font-family);
+  font-family: var(--sh-font-family);
   line-break: anywhere;
   overflow-wrap: break-word;
   scrollbar-width: none;
   line-height: 1.5;
-  font-size: var(--codice-font-size);
-  caret-color: var(--codice-caret-color);
+  font-size: var(--sh-font-size);
+  caret-color: var(--sh-caret-color);
   border: none;
   outline: none;
   width: 100%;
@@ -34,22 +33,22 @@ ${R} textarea {
 ${R} code {
   display: inline-block;
   width: 100%;
-  margin-left: calc(var(--codice-code-line-number-width) - 2.5rem); ${/* 2.5rem is the default line number width */''}
-  padding-right: calc(var(--codice-code-padding) * 0.5);
+  margin-left: calc(var(--sh-line-number-width) - 2.5rem);
+  padding-right: calc(var(--sh-padding) * 0.5);
 }
 ${R} textarea::-webkit-scrollbar,
 ${R} textarea:focus::-webkit-scrollbar,
 ${R} textarea:hover::-webkit-scrollbar {
   width: 0;
 }
-${R} [data-codice-content] {
+${R} [data-sh-content] {
   position: relative;
 }
 ${R} textarea {
   resize: none;
   display: block;
-  color: var(--codice-text-color);
-  background-color: var(--codice-background-color);
+  color: var(--sh-editor-text-color);
+  background-color: var(--sh-editor-background-color);
   position: absolute;
   top: 0;
   bottom: 0;
@@ -58,32 +57,13 @@ ${R} textarea {
   height: 100%;
   overflow: hidden;
 }
-${R}[data-codice-line-numbers="true"] textarea {
-  padding-left: var(--codice-code-line-number-width);
+${R}[data-sh-line-numbers="true"] textarea {
+  padding-left: var(--sh-line-number-width);
 }
-${R}[data-codice-line-numbers="false"] textarea {
-  padding-left: var(--codice-code-padding);
+${R}[data-sh-line-numbers="false"] textarea {
+  padding-left: var(--sh-padding);
 }
 `
 // line number padding-left is [[width 24px] margin-right 16px] + 15px
 
-export const css = ({
-  fontSize,
-  lineNumbersWidth = '2.5rem',
-  padding = '1rem',
-  fontFamily = 'Consolas, Monaco, monospace',
-}: {
-  fontSize?: string | number
-  lineNumbersWidth: string
-  padding: string
-  fontFamily: string
-}) => {
-  return `\
-${EDITOR_CSS}
-${R} {
-  --codice-font-size: ${fontSizeCss(fontSize)};
-  --codice-code-line-number-width: ${lineNumbersWidth};
-  --codice-code-padding: ${padding};
-  --codice-font-family: ${fontFamily};
-}`
-}
+export const css = EDITOR_CSS

--- a/packages/react/src/editor/editor.test.tsx
+++ b/packages/react/src/editor/editor.test.tsx
@@ -3,17 +3,26 @@ import { Editor } from '.'
 import { renderToString } from 'react-dom/server'
 
 describe('Code', () => {
+  it('supports controlled and uncontrolled initial values', () => {
+    const controlled = renderToString(<Editor value="controlled" defaultValue="ignored" />)
+    const uncontrolled = renderToString(<Editor defaultValue="initial" />)
+
+    expect(controlled).toContain('data-sh="editor"')
+    expect(controlled).toContain('<textarea>controlled</textarea>')
+    expect(controlled).not.toContain('ignored')
+    expect(uncontrolled).toContain('<textarea>initial</textarea>')
+  })
+
   it('default props', () => {
     expect(
       renderToString(
         <Editor>test</Editor>
       )
     ).toMatchInlineSnapshot(`
-      "<div data-codice="editor" data-codice-editor="true" data-codice-title="" data-codice-controls="true" data-codice-line-numbers="true"><style data-codice-style="true">@scope {
-      :scope[data-codice-editor] {
-        --codice-text-color: transparent;
-        --codice-background-color: transparent;
-        --codice-caret-color: inherit;
+      "<style data-precedence="default" data-href="sugar-high-react-editor sugar-high-react-header sugar-high-react-code">[data-sh-editor] {
+        --sh-editor-text-color: transparent;
+        --sh-editor-background-color: transparent;
+        --sh-caret-color: inherit;
 
         position: relative;
         overflow-y: scroll;
@@ -22,41 +31,41 @@ describe('Code', () => {
         justify-content: stretch;
         scrollbar-width: none;
       }
-      :scope[data-codice-editor] textarea:not(:placeholder-shown) {
-        padding: calc(var(--codice-code-padding) * 0.75) calc(var(--codice-code-padding) * 0.5);
+      [data-sh-editor] textarea:not(:placeholder-shown) {
+        padding: calc(var(--sh-padding) * 0.75) calc(var(--sh-padding) * 0.5);
       }
-      :scope[data-codice-editor] code,
-      :scope[data-codice-editor] textarea {
-        font-family: var(--codice-font-family);
+      [data-sh-editor] code,
+      [data-sh-editor] textarea {
+        font-family: var(--sh-font-family);
         line-break: anywhere;
         overflow-wrap: break-word;
         scrollbar-width: none;
         line-height: 1.5;
-        font-size: var(--codice-font-size);
-        caret-color: var(--codice-caret-color);
+        font-size: var(--sh-font-size);
+        caret-color: var(--sh-caret-color);
         border: none;
         outline: none;
         width: 100%;
       }
-      :scope[data-codice-editor] code {
+      [data-sh-editor] code {
         display: inline-block;
         width: 100%;
-        margin-left: calc(var(--codice-code-line-number-width) - 2.5rem); 
-        padding-right: calc(var(--codice-code-padding) * 0.5);
+        margin-left: calc(var(--sh-line-number-width) - 2.5rem);
+        padding-right: calc(var(--sh-padding) * 0.5);
       }
-      :scope[data-codice-editor] textarea::-webkit-scrollbar,
-      :scope[data-codice-editor] textarea:focus::-webkit-scrollbar,
-      :scope[data-codice-editor] textarea:hover::-webkit-scrollbar {
+      [data-sh-editor] textarea::-webkit-scrollbar,
+      [data-sh-editor] textarea:focus::-webkit-scrollbar,
+      [data-sh-editor] textarea:hover::-webkit-scrollbar {
         width: 0;
       }
-      :scope[data-codice-editor] [data-codice-content] {
+      [data-sh-editor] [data-sh-content] {
         position: relative;
       }
-      :scope[data-codice-editor] textarea {
+      [data-sh-editor] textarea {
         resize: none;
         display: block;
-        color: var(--codice-text-color);
-        background-color: var(--codice-background-color);
+        color: var(--sh-editor-text-color);
+        background-color: var(--sh-editor-background-color);
         position: absolute;
         top: 0;
         bottom: 0;
@@ -65,29 +74,21 @@ describe('Code', () => {
         height: 100%;
         overflow: hidden;
       }
-      :scope[data-codice-editor][data-codice-line-numbers="true"] textarea {
-        padding-left: var(--codice-code-line-number-width);
+      [data-sh-editor][data-sh-line-numbers="true"] textarea {
+        padding-left: var(--sh-line-number-width);
       }
-      :scope[data-codice-editor][data-codice-line-numbers="false"] textarea {
-        padding-left: var(--codice-code-padding);
+      [data-sh-editor][data-sh-line-numbers="false"] textarea {
+        padding-left: var(--sh-padding);
       }
-
-      :scope[data-codice-editor] {
-        --codice-font-size: inherit;
-        --codice-code-line-number-width: 2.5rem;
-        --codice-code-padding: 1rem;
-        --codice-font-family: Consolas, Monaco, monospace;
-      }
-      }</style><div data-codice-header="true" data-codice-header-controls="true"><style data-codice-style="true">@scope {
-      :scope[data-codice-header] {
+      [data-sh-header] {
         position: relative;
         display: flex;
-        padding: calc(var(--codice-code-padding) * 0.25)
-          var(--codice-code-padding)
-          calc(var(--codice-code-padding) * 0.25);
+        padding: calc(var(--sh-padding) * 0.25)
+          var(--sh-padding)
+          calc(var(--sh-padding) * 0.25);
         align-items: center;
       }
-      :scope[data-codice-header] [data-codice-title] {
+      [data-sh-header] [data-sh-title] {
         display: inline-block;
         flex: 1 0;
         text-align: center;
@@ -95,125 +96,72 @@ describe('Code', () => {
         background-color: transparent;
         outline: none;
         border: none;
-        caret-color: var(--codice-caret-color);
-        color: var(--codice-title-color);
-        font-family: var(--codice-font-family);
+        caret-color: var(--sh-caret-color);
+        color: var(--sh-title-color);
+        font-family: var(--sh-font-family);
       }
-      :scope[data-codice-header] [data-codice-controls] {
+      [data-sh-header] [data-sh-controls] {
         display: inline-flex;
         align-self: center;
         justify-self: start;
         align-items: center;
         justify-content: center;
-      }
-      :scope[data-codice-header] [data-codice-controls] {
         width: 52px;
       }
-      :scope[data-codice-header][data-codice-header-controls="true"] [data-codice-title] {
+      [data-sh-header][data-sh-header-controls="true"] [data-sh-title] {
         padding-right: 52px;
       }
-      :scope[data-codice-header] [data-codice-control] {
+      [data-sh-header] [data-sh-control] {
         display: flex;
         width: 10px;
         height: 10px;
         margin: 3px;
         border-radius: 50%;
-        background-color: var(--codice-control-color);
+        background-color: var(--sh-control-color);
       }
-
-      }</style><div data-codice-controls="true"><span data-codice-control="true"></span><span data-codice-control="true"></span><span data-codice-control="true"></span></div></div><div data-codice-content="true"><div data-codice="code" data-codice-code="true" data-codice-line-numbers="true"><style data-codice-style="true">@scope {
-      :scope[data-codice-code] {
-        padding: calc(var(--codice-code-padding) / 2) 0;
+      [data-sh-code] {
+        padding: calc(var(--sh-padding) / 2) 0;
       }
-      :scope[data-codice-code] [data-codice-code-content] {
-        padding: calc(var(--codice-code-padding) * 0.25) 0;
+      [data-sh-code] [data-sh-code-content] {
+        padding: calc(var(--sh-padding) * 0.25) 0;
       }
-      :scope[data-codice-code] pre {
+      [data-sh-code] pre {
         white-space: pre-wrap;
         margin: 0;
       }
-      :scope[data-codice-code] code {
+      [data-sh-code] code {
         display: block;
         border: none;
       }
-      :scope[data-codice-code] .sh__line {
+      [data-sh-code] .sh__line {
         display: inline-block;
         width: 100%;
       }
-      :scope[data-codice-code] .sh__line[data-highlight] {
-        background-color: var(--codice-code-highlight-color);
+      [data-sh-code] .sh__line[data-highlight] {
+        background-color: var(--sh-line-highlight-color);
       }
 
-      :scope[data-codice-header] {
-        position: relative;
-        display: flex;
-        padding: calc(var(--codice-code-padding) * 0.25)
-          var(--codice-code-padding)
-          calc(var(--codice-code-padding) * 0.25);
-        align-items: center;
-      }
-      :scope[data-codice-header] [data-codice-title] {
-        display: inline-block;
-        flex: 1 0;
-        text-align: center;
-        line-height: 1;
-        background-color: transparent;
-        outline: none;
-        border: none;
-        caret-color: var(--codice-caret-color);
-        color: var(--codice-title-color);
-        font-family: var(--codice-font-family);
-      }
-      :scope[data-codice-header] [data-codice-controls] {
-        display: inline-flex;
-        align-self: center;
-        justify-self: start;
-        align-items: center;
-        justify-content: center;
-      }
-      :scope[data-codice-header] [data-codice-controls] {
-        width: 52px;
-      }
-      :scope[data-codice-header][data-codice-header-controls="true"] [data-codice-title] {
-        padding-right: 52px;
-      }
-      :scope[data-codice-header] [data-codice-control] {
-        display: flex;
-        width: 10px;
-        height: 10px;
-        margin: 3px;
-        border-radius: 50%;
-        background-color: var(--codice-control-color);
-      }
-
-      :scope[data-codice-line-numbers="true"] code {
+      [data-sh-line-numbers="true"] code {
         counter-reset: codice-code-line-number;
       }
-      :scope[data-codice-line-numbers="true"] .sh__line:has(> [data-codice-code-line-number]) {
-        padding-left: var(--codice-code-line-number-width);
+      [data-sh-line-numbers="true"] .sh__line:has(> [data-sh-code-line-number]) {
+        padding-left: var(--sh-line-number-width);
       }
-      :scope[data-codice-line-numbers="true"] [data-codice-code-line-number] {
+      [data-sh-line-numbers="true"] [data-sh-code-line-number] {
         counter-increment: codice-code-line-number 1;
         content: counter(codice-code-line-number);
         display: inline-block;
-        min-width: calc(var(--codice-code-line-number-width) - 14px);
-        margin-left: calc(var(--codice-code-line-number-width) * -1);
+        min-width: calc(var(--sh-line-number-width) - 14px);
+        margin-left: calc(var(--sh-line-number-width) * -1);
         margin-right: 14px;
         text-align: right;
         user-select: none;
-        color: var(--codice-code-line-number-color);
+        color: var(--sh-line-number-color);
       }
-      :scope[data-codice-line-numbers="false"] .sh__line {
-        padding-left: var(--codice-code-padding);
+      [data-sh-line-numbers="false"] .sh__line {
+        padding-left: var(--sh-padding);
       }
-
-      :scope[data-codice-code] {
-        --codice-font-size: inherit;
-        --codice-code-line-number-width: 2.5rem;
-        --codice-code-padding: 1rem;
-      }
-
-      }</style><pre data-codice-code-content="true"><code></code></pre></div><textarea></textarea></div></div>"
+      </style><div style="--sh-font-size:inherit;--sh-line-number-width:2.5rem;--sh-padding:1rem;--sh-font-family:Consolas, Monaco, monospace" data-codice="editor" data-codice-editor="true" data-sh="editor" data-sh-editor="true" data-codice-title="" data-codice-controls="true" data-codice-line-numbers="true" data-sh-line-numbers="true"><div data-codice-header="true" data-sh-header="true" data-codice-header-controls="true" data-sh-header-controls="true"><div data-codice-controls="true" data-sh-controls="true"><span data-codice-control="true" data-sh-control="true"></span><span data-codice-control="true" data-sh-control="true"></span><span data-codice-control="true" data-sh-control="true"></span></div></div><div data-codice-content="true" data-sh-content="true"><div style="--sh-font-size:inherit;--sh-line-number-width:2.5rem;--sh-padding:1rem" data-codice="code" data-codice-code="true" data-sh="code" data-sh-code="true" data-codice-line-numbers="true" data-sh-line-numbers="true"><pre data-codice-code-content="true" data-sh-code-content="true"><code></code></pre></div><textarea></textarea></div></div>"
     `)
   })
 
@@ -223,11 +171,10 @@ describe('Code', () => {
         <Editor title="file.js">test</Editor>
       )
     ).toMatchInlineSnapshot(`
-      "<div data-codice="editor" data-codice-editor="true" data-codice-title="file.js" data-codice-controls="true" data-codice-line-numbers="true"><style data-codice-style="true">@scope {
-      :scope[data-codice-editor] {
-        --codice-text-color: transparent;
-        --codice-background-color: transparent;
-        --codice-caret-color: inherit;
+      "<style data-precedence="default" data-href="sugar-high-react-editor sugar-high-react-header sugar-high-react-code">[data-sh-editor] {
+        --sh-editor-text-color: transparent;
+        --sh-editor-background-color: transparent;
+        --sh-caret-color: inherit;
 
         position: relative;
         overflow-y: scroll;
@@ -236,41 +183,41 @@ describe('Code', () => {
         justify-content: stretch;
         scrollbar-width: none;
       }
-      :scope[data-codice-editor] textarea:not(:placeholder-shown) {
-        padding: calc(var(--codice-code-padding) * 0.75) calc(var(--codice-code-padding) * 0.5);
+      [data-sh-editor] textarea:not(:placeholder-shown) {
+        padding: calc(var(--sh-padding) * 0.75) calc(var(--sh-padding) * 0.5);
       }
-      :scope[data-codice-editor] code,
-      :scope[data-codice-editor] textarea {
-        font-family: var(--codice-font-family);
+      [data-sh-editor] code,
+      [data-sh-editor] textarea {
+        font-family: var(--sh-font-family);
         line-break: anywhere;
         overflow-wrap: break-word;
         scrollbar-width: none;
         line-height: 1.5;
-        font-size: var(--codice-font-size);
-        caret-color: var(--codice-caret-color);
+        font-size: var(--sh-font-size);
+        caret-color: var(--sh-caret-color);
         border: none;
         outline: none;
         width: 100%;
       }
-      :scope[data-codice-editor] code {
+      [data-sh-editor] code {
         display: inline-block;
         width: 100%;
-        margin-left: calc(var(--codice-code-line-number-width) - 2.5rem); 
-        padding-right: calc(var(--codice-code-padding) * 0.5);
+        margin-left: calc(var(--sh-line-number-width) - 2.5rem);
+        padding-right: calc(var(--sh-padding) * 0.5);
       }
-      :scope[data-codice-editor] textarea::-webkit-scrollbar,
-      :scope[data-codice-editor] textarea:focus::-webkit-scrollbar,
-      :scope[data-codice-editor] textarea:hover::-webkit-scrollbar {
+      [data-sh-editor] textarea::-webkit-scrollbar,
+      [data-sh-editor] textarea:focus::-webkit-scrollbar,
+      [data-sh-editor] textarea:hover::-webkit-scrollbar {
         width: 0;
       }
-      :scope[data-codice-editor] [data-codice-content] {
+      [data-sh-editor] [data-sh-content] {
         position: relative;
       }
-      :scope[data-codice-editor] textarea {
+      [data-sh-editor] textarea {
         resize: none;
         display: block;
-        color: var(--codice-text-color);
-        background-color: var(--codice-background-color);
+        color: var(--sh-editor-text-color);
+        background-color: var(--sh-editor-background-color);
         position: absolute;
         top: 0;
         bottom: 0;
@@ -279,29 +226,21 @@ describe('Code', () => {
         height: 100%;
         overflow: hidden;
       }
-      :scope[data-codice-editor][data-codice-line-numbers="true"] textarea {
-        padding-left: var(--codice-code-line-number-width);
+      [data-sh-editor][data-sh-line-numbers="true"] textarea {
+        padding-left: var(--sh-line-number-width);
       }
-      :scope[data-codice-editor][data-codice-line-numbers="false"] textarea {
-        padding-left: var(--codice-code-padding);
+      [data-sh-editor][data-sh-line-numbers="false"] textarea {
+        padding-left: var(--sh-padding);
       }
-
-      :scope[data-codice-editor] {
-        --codice-font-size: inherit;
-        --codice-code-line-number-width: 2.5rem;
-        --codice-code-padding: 1rem;
-        --codice-font-family: Consolas, Monaco, monospace;
-      }
-      }</style><div data-codice-header="true" data-codice-header-controls="true"><style data-codice-style="true">@scope {
-      :scope[data-codice-header] {
+      [data-sh-header] {
         position: relative;
         display: flex;
-        padding: calc(var(--codice-code-padding) * 0.25)
-          var(--codice-code-padding)
-          calc(var(--codice-code-padding) * 0.25);
+        padding: calc(var(--sh-padding) * 0.25)
+          var(--sh-padding)
+          calc(var(--sh-padding) * 0.25);
         align-items: center;
       }
-      :scope[data-codice-header] [data-codice-title] {
+      [data-sh-header] [data-sh-title] {
         display: inline-block;
         flex: 1 0;
         text-align: center;
@@ -309,125 +248,72 @@ describe('Code', () => {
         background-color: transparent;
         outline: none;
         border: none;
-        caret-color: var(--codice-caret-color);
-        color: var(--codice-title-color);
-        font-family: var(--codice-font-family);
+        caret-color: var(--sh-caret-color);
+        color: var(--sh-title-color);
+        font-family: var(--sh-font-family);
       }
-      :scope[data-codice-header] [data-codice-controls] {
+      [data-sh-header] [data-sh-controls] {
         display: inline-flex;
         align-self: center;
         justify-self: start;
         align-items: center;
         justify-content: center;
-      }
-      :scope[data-codice-header] [data-codice-controls] {
         width: 52px;
       }
-      :scope[data-codice-header][data-codice-header-controls="true"] [data-codice-title] {
+      [data-sh-header][data-sh-header-controls="true"] [data-sh-title] {
         padding-right: 52px;
       }
-      :scope[data-codice-header] [data-codice-control] {
+      [data-sh-header] [data-sh-control] {
         display: flex;
         width: 10px;
         height: 10px;
         margin: 3px;
         border-radius: 50%;
-        background-color: var(--codice-control-color);
+        background-color: var(--sh-control-color);
       }
-
-      }</style><div data-codice-controls="true"><span data-codice-control="true"></span><span data-codice-control="true"></span><span data-codice-control="true"></span></div><input data-codice-title="true" value="file.js"/></div><div data-codice-content="true"><div data-codice="code" data-codice-code="true" data-codice-line-numbers="true"><style data-codice-style="true">@scope {
-      :scope[data-codice-code] {
-        padding: calc(var(--codice-code-padding) / 2) 0;
+      [data-sh-code] {
+        padding: calc(var(--sh-padding) / 2) 0;
       }
-      :scope[data-codice-code] [data-codice-code-content] {
-        padding: calc(var(--codice-code-padding) * 0.25) 0;
+      [data-sh-code] [data-sh-code-content] {
+        padding: calc(var(--sh-padding) * 0.25) 0;
       }
-      :scope[data-codice-code] pre {
+      [data-sh-code] pre {
         white-space: pre-wrap;
         margin: 0;
       }
-      :scope[data-codice-code] code {
+      [data-sh-code] code {
         display: block;
         border: none;
       }
-      :scope[data-codice-code] .sh__line {
+      [data-sh-code] .sh__line {
         display: inline-block;
         width: 100%;
       }
-      :scope[data-codice-code] .sh__line[data-highlight] {
-        background-color: var(--codice-code-highlight-color);
+      [data-sh-code] .sh__line[data-highlight] {
+        background-color: var(--sh-line-highlight-color);
       }
 
-      :scope[data-codice-header] {
-        position: relative;
-        display: flex;
-        padding: calc(var(--codice-code-padding) * 0.25)
-          var(--codice-code-padding)
-          calc(var(--codice-code-padding) * 0.25);
-        align-items: center;
-      }
-      :scope[data-codice-header] [data-codice-title] {
-        display: inline-block;
-        flex: 1 0;
-        text-align: center;
-        line-height: 1;
-        background-color: transparent;
-        outline: none;
-        border: none;
-        caret-color: var(--codice-caret-color);
-        color: var(--codice-title-color);
-        font-family: var(--codice-font-family);
-      }
-      :scope[data-codice-header] [data-codice-controls] {
-        display: inline-flex;
-        align-self: center;
-        justify-self: start;
-        align-items: center;
-        justify-content: center;
-      }
-      :scope[data-codice-header] [data-codice-controls] {
-        width: 52px;
-      }
-      :scope[data-codice-header][data-codice-header-controls="true"] [data-codice-title] {
-        padding-right: 52px;
-      }
-      :scope[data-codice-header] [data-codice-control] {
-        display: flex;
-        width: 10px;
-        height: 10px;
-        margin: 3px;
-        border-radius: 50%;
-        background-color: var(--codice-control-color);
-      }
-
-      :scope[data-codice-line-numbers="true"] code {
+      [data-sh-line-numbers="true"] code {
         counter-reset: codice-code-line-number;
       }
-      :scope[data-codice-line-numbers="true"] .sh__line:has(> [data-codice-code-line-number]) {
-        padding-left: var(--codice-code-line-number-width);
+      [data-sh-line-numbers="true"] .sh__line:has(> [data-sh-code-line-number]) {
+        padding-left: var(--sh-line-number-width);
       }
-      :scope[data-codice-line-numbers="true"] [data-codice-code-line-number] {
+      [data-sh-line-numbers="true"] [data-sh-code-line-number] {
         counter-increment: codice-code-line-number 1;
         content: counter(codice-code-line-number);
         display: inline-block;
-        min-width: calc(var(--codice-code-line-number-width) - 14px);
-        margin-left: calc(var(--codice-code-line-number-width) * -1);
+        min-width: calc(var(--sh-line-number-width) - 14px);
+        margin-left: calc(var(--sh-line-number-width) * -1);
         margin-right: 14px;
         text-align: right;
         user-select: none;
-        color: var(--codice-code-line-number-color);
+        color: var(--sh-line-number-color);
       }
-      :scope[data-codice-line-numbers="false"] .sh__line {
-        padding-left: var(--codice-code-padding);
+      [data-sh-line-numbers="false"] .sh__line {
+        padding-left: var(--sh-padding);
       }
-
-      :scope[data-codice-code] {
-        --codice-font-size: inherit;
-        --codice-code-line-number-width: 2.5rem;
-        --codice-code-padding: 1rem;
-      }
-
-      }</style><pre data-codice-code-content="true"><code></code></pre></div><textarea></textarea></div></div>"
+      </style><div style="--sh-font-size:inherit;--sh-line-number-width:2.5rem;--sh-padding:1rem;--sh-font-family:Consolas, Monaco, monospace" data-codice="editor" data-codice-editor="true" data-sh="editor" data-sh-editor="true" data-codice-title="file.js" data-codice-controls="true" data-codice-line-numbers="true" data-sh-line-numbers="true"><div data-codice-header="true" data-sh-header="true" data-codice-header-controls="true" data-sh-header-controls="true"><div data-codice-controls="true" data-sh-controls="true"><span data-codice-control="true" data-sh-control="true"></span><span data-codice-control="true" data-sh-control="true"></span><span data-codice-control="true" data-sh-control="true"></span></div><input data-codice-title="true" data-sh-title="true" readOnly="" value="file.js"/></div><div data-codice-content="true" data-sh-content="true"><div style="--sh-font-size:inherit;--sh-line-number-width:2.5rem;--sh-padding:1rem" data-codice="code" data-codice-code="true" data-sh="code" data-sh-code="true" data-codice-line-numbers="true" data-sh-line-numbers="true"><pre data-codice-code-content="true" data-sh-code-content="true"><code></code></pre></div><textarea></textarea></div></div>"
     `)
   ))
 
@@ -437,11 +323,10 @@ describe('Code', () => {
         <Editor controls={false} className="editor">test</Editor>
       )
     ).toMatchInlineSnapshot(`
-      "<div class="editor" data-codice="editor" data-codice-editor="true" data-codice-title="" data-codice-controls="false" data-codice-line-numbers="true"><style data-codice-style="true">@scope {
-      :scope[data-codice-editor] {
-        --codice-text-color: transparent;
-        --codice-background-color: transparent;
-        --codice-caret-color: inherit;
+      "<style data-precedence="default" data-href="sugar-high-react-editor sugar-high-react-code">[data-sh-editor] {
+        --sh-editor-text-color: transparent;
+        --sh-editor-background-color: transparent;
+        --sh-caret-color: inherit;
 
         position: relative;
         overflow-y: scroll;
@@ -450,41 +335,41 @@ describe('Code', () => {
         justify-content: stretch;
         scrollbar-width: none;
       }
-      :scope[data-codice-editor] textarea:not(:placeholder-shown) {
-        padding: calc(var(--codice-code-padding) * 0.75) calc(var(--codice-code-padding) * 0.5);
+      [data-sh-editor] textarea:not(:placeholder-shown) {
+        padding: calc(var(--sh-padding) * 0.75) calc(var(--sh-padding) * 0.5);
       }
-      :scope[data-codice-editor] code,
-      :scope[data-codice-editor] textarea {
-        font-family: var(--codice-font-family);
+      [data-sh-editor] code,
+      [data-sh-editor] textarea {
+        font-family: var(--sh-font-family);
         line-break: anywhere;
         overflow-wrap: break-word;
         scrollbar-width: none;
         line-height: 1.5;
-        font-size: var(--codice-font-size);
-        caret-color: var(--codice-caret-color);
+        font-size: var(--sh-font-size);
+        caret-color: var(--sh-caret-color);
         border: none;
         outline: none;
         width: 100%;
       }
-      :scope[data-codice-editor] code {
+      [data-sh-editor] code {
         display: inline-block;
         width: 100%;
-        margin-left: calc(var(--codice-code-line-number-width) - 2.5rem); 
-        padding-right: calc(var(--codice-code-padding) * 0.5);
+        margin-left: calc(var(--sh-line-number-width) - 2.5rem);
+        padding-right: calc(var(--sh-padding) * 0.5);
       }
-      :scope[data-codice-editor] textarea::-webkit-scrollbar,
-      :scope[data-codice-editor] textarea:focus::-webkit-scrollbar,
-      :scope[data-codice-editor] textarea:hover::-webkit-scrollbar {
+      [data-sh-editor] textarea::-webkit-scrollbar,
+      [data-sh-editor] textarea:focus::-webkit-scrollbar,
+      [data-sh-editor] textarea:hover::-webkit-scrollbar {
         width: 0;
       }
-      :scope[data-codice-editor] [data-codice-content] {
+      [data-sh-editor] [data-sh-content] {
         position: relative;
       }
-      :scope[data-codice-editor] textarea {
+      [data-sh-editor] textarea {
         resize: none;
         display: block;
-        color: var(--codice-text-color);
-        background-color: var(--codice-background-color);
+        color: var(--sh-editor-text-color);
+        background-color: var(--sh-editor-background-color);
         position: absolute;
         top: 0;
         bottom: 0;
@@ -493,112 +378,55 @@ describe('Code', () => {
         height: 100%;
         overflow: hidden;
       }
-      :scope[data-codice-editor][data-codice-line-numbers="true"] textarea {
-        padding-left: var(--codice-code-line-number-width);
+      [data-sh-editor][data-sh-line-numbers="true"] textarea {
+        padding-left: var(--sh-line-number-width);
       }
-      :scope[data-codice-editor][data-codice-line-numbers="false"] textarea {
-        padding-left: var(--codice-code-padding);
+      [data-sh-editor][data-sh-line-numbers="false"] textarea {
+        padding-left: var(--sh-padding);
       }
-
-      :scope[data-codice-editor] {
-        --codice-font-size: inherit;
-        --codice-code-line-number-width: 2.5rem;
-        --codice-code-padding: 1rem;
-        --codice-font-family: Consolas, Monaco, monospace;
+      [data-sh-code] {
+        padding: calc(var(--sh-padding) / 2) 0;
       }
-      }</style><div data-codice-content="true"><div data-codice="code" data-codice-code="true" data-codice-line-numbers="true"><style data-codice-style="true">@scope {
-      :scope[data-codice-code] {
-        padding: calc(var(--codice-code-padding) / 2) 0;
+      [data-sh-code] [data-sh-code-content] {
+        padding: calc(var(--sh-padding) * 0.25) 0;
       }
-      :scope[data-codice-code] [data-codice-code-content] {
-        padding: calc(var(--codice-code-padding) * 0.25) 0;
-      }
-      :scope[data-codice-code] pre {
+      [data-sh-code] pre {
         white-space: pre-wrap;
         margin: 0;
       }
-      :scope[data-codice-code] code {
+      [data-sh-code] code {
         display: block;
         border: none;
       }
-      :scope[data-codice-code] .sh__line {
+      [data-sh-code] .sh__line {
         display: inline-block;
         width: 100%;
       }
-      :scope[data-codice-code] .sh__line[data-highlight] {
-        background-color: var(--codice-code-highlight-color);
+      [data-sh-code] .sh__line[data-highlight] {
+        background-color: var(--sh-line-highlight-color);
       }
 
-      :scope[data-codice-header] {
-        position: relative;
-        display: flex;
-        padding: calc(var(--codice-code-padding) * 0.25)
-          var(--codice-code-padding)
-          calc(var(--codice-code-padding) * 0.25);
-        align-items: center;
-      }
-      :scope[data-codice-header] [data-codice-title] {
-        display: inline-block;
-        flex: 1 0;
-        text-align: center;
-        line-height: 1;
-        background-color: transparent;
-        outline: none;
-        border: none;
-        caret-color: var(--codice-caret-color);
-        color: var(--codice-title-color);
-        font-family: var(--codice-font-family);
-      }
-      :scope[data-codice-header] [data-codice-controls] {
-        display: inline-flex;
-        align-self: center;
-        justify-self: start;
-        align-items: center;
-        justify-content: center;
-      }
-      :scope[data-codice-header] [data-codice-controls] {
-        width: 52px;
-      }
-      :scope[data-codice-header][data-codice-header-controls="true"] [data-codice-title] {
-        padding-right: 52px;
-      }
-      :scope[data-codice-header] [data-codice-control] {
-        display: flex;
-        width: 10px;
-        height: 10px;
-        margin: 3px;
-        border-radius: 50%;
-        background-color: var(--codice-control-color);
-      }
-
-      :scope[data-codice-line-numbers="true"] code {
+      [data-sh-line-numbers="true"] code {
         counter-reset: codice-code-line-number;
       }
-      :scope[data-codice-line-numbers="true"] .sh__line:has(> [data-codice-code-line-number]) {
-        padding-left: var(--codice-code-line-number-width);
+      [data-sh-line-numbers="true"] .sh__line:has(> [data-sh-code-line-number]) {
+        padding-left: var(--sh-line-number-width);
       }
-      :scope[data-codice-line-numbers="true"] [data-codice-code-line-number] {
+      [data-sh-line-numbers="true"] [data-sh-code-line-number] {
         counter-increment: codice-code-line-number 1;
         content: counter(codice-code-line-number);
         display: inline-block;
-        min-width: calc(var(--codice-code-line-number-width) - 14px);
-        margin-left: calc(var(--codice-code-line-number-width) * -1);
+        min-width: calc(var(--sh-line-number-width) - 14px);
+        margin-left: calc(var(--sh-line-number-width) * -1);
         margin-right: 14px;
         text-align: right;
         user-select: none;
-        color: var(--codice-code-line-number-color);
+        color: var(--sh-line-number-color);
       }
-      :scope[data-codice-line-numbers="false"] .sh__line {
-        padding-left: var(--codice-code-padding);
+      [data-sh-line-numbers="false"] .sh__line {
+        padding-left: var(--sh-padding);
       }
-
-      :scope[data-codice-code] {
-        --codice-font-size: inherit;
-        --codice-code-line-number-width: 2.5rem;
-        --codice-code-padding: 1rem;
-      }
-
-      }</style><pre data-codice-code-content="true"><code></code></pre></div><textarea></textarea></div></div>"
+      </style><div class="editor" style="--sh-font-size:inherit;--sh-line-number-width:2.5rem;--sh-padding:1rem;--sh-font-family:Consolas, Monaco, monospace" data-codice="editor" data-codice-editor="true" data-sh="editor" data-sh-editor="true" data-codice-title="" data-codice-controls="false" data-codice-line-numbers="true" data-sh-line-numbers="true"><div data-codice-content="true" data-sh-content="true"><div style="--sh-font-size:inherit;--sh-line-number-width:2.5rem;--sh-padding:1rem" data-codice="code" data-codice-code="true" data-sh="code" data-sh-code="true" data-codice-line-numbers="true" data-sh-line-numbers="true"><pre data-codice-code-content="true" data-sh-code-content="true"><code></code></pre></div><textarea></textarea></div></div>"
     `)
   ))
 })

--- a/packages/react/src/editor/editor.tsx
+++ b/packages/react/src/editor/editor.tsx
@@ -1,15 +1,16 @@
 'use client'
 
-import { useEffect, useState, forwardRef } from 'react'
+import { useState, forwardRef } from 'react'
 import { CodeHeader, getExtension, getLineNumbersWidth, Code } from '../code/code'
-import { ScopedStyle } from '../style'
+import { fontSizeCss, ScopedStyle } from '../style'
 import { css } from './css'
 import type { HighlightOptions, LanguageName } from 'sugar-high'
 
 export const Editor = forwardRef(function Editor(
   {
     title,
-    value = '',
+    value,
+    defaultValue = '',
     controls = true,
     lineNumbers = true,
     lineNumbersWidth,
@@ -18,15 +19,17 @@ export const Editor = forwardRef(function Editor(
     cx,
     mark,
     padding,
-    onChange = () => {},
+    onChange,
     fontSize,
     fontFamily,
-    onChangeTitle = () => {},
+    onChangeTitle,
     textareaRef,
+    style,
     ...props
   }: {
     title?: string | null
     value?: string
+    defaultValue?: string
     controls?: boolean
     lineNumbers?: boolean
     lineNumbersWidth?: string
@@ -44,41 +47,42 @@ export const Editor = forwardRef(function Editor(
   } & Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'>,
   ref: React.Ref<HTMLDivElement>
 ) {
-  const [code, setCode] = useState(value)
+  const [uncontrolledCode, setUncontrolledCode] = useState(defaultValue)
+  const code = value ?? uncontrolledCode
   const resolvedLineNumbersWidth = getLineNumbersWidth(code, lineNumbersWidth)
-
-  function update(textContent: string) {
-    setCode(textContent)
-    onChange(textContent)
-  }
-
-  useEffect(() => {
-    if (value !== code) {
-      update(value)
-    }
-  }, [value, code])
 
   function onInput(event: React.ChangeEvent<HTMLTextAreaElement>) {
     const textContent = event.target.value || ''
-    update(textContent)
+    if (value === undefined) setUncontrolledCode(textContent)
+    onChange?.(textContent)
   }
 
   return (
     <div
       ref={ref}
       {...props}
+      style={{
+        '--sh-font-size': fontSizeCss(fontSize),
+        '--sh-line-number-width': resolvedLineNumbersWidth || '2.5rem',
+        '--sh-padding': padding ?? '1rem',
+        '--sh-font-family': fontFamily ?? 'Consolas, Monaco, monospace',
+        ...style,
+      } as React.CSSProperties}
       data-codice="editor"
       data-codice-editor
+      data-sh="editor"
+      data-sh-editor
       // DOM attributes for selecting the stateful editor easily.
       // e.g. [data-codice-line-numbers="true"]
       data-codice-title={title || ''}
       data-codice-controls={!!controls}
       data-codice-line-numbers={!!lineNumbers}
+      data-sh-line-numbers={!!lineNumbers}
     >
-      <ScopedStyle css={css({ fontSize, padding, lineNumbersWidth: resolvedLineNumbersWidth, fontFamily })} />
+      <ScopedStyle css={css} href="sugar-high-react-editor" />
       {/* Display the header outside of the matched textarea and code, by default display controls */}
       <CodeHeader title={title} controls={controls} onChangeTitle={onChangeTitle} />
-      <div data-codice-content>
+      <div data-codice-content data-sh-content>
         {/* hide controls component inside Code to keep content matched with textarea */}
         <Code
           title={null}

--- a/packages/react/src/style.tsx
+++ b/packages/react/src/style.tsx
@@ -1,7 +1,7 @@
-export function ScopedStyle({ css }: { css: string }) {
+export function ScopedStyle({ css, href }: { css: string; href: string }) {
   return (
-    <style data-codice-style>
-      {`@scope {\n${css}\n}`}
+    <style data-codice-style data-sh-style href={href} precedence="default">
+      {css}
     </style>
   )
 }


### PR DESCRIPTION
## Summary

- deduplicate `Code`, `Editor`, and header styles through React stylesheet resources and move dynamic values to root custom properties
- fix controlled editor synchronization, add `defaultValue` for uncontrolled use, and avoid echoing external values through `onChange`
- memoize parsing separately from display generation, avoid line-count allocations, and clamp highlighted ranges to real source lines
- establish `data-sh-*` and clear `--sh-*` names while retaining `data-codice-*` structural attributes during migration
- update site consumers, documentation, snapshots, and release metadata without adding package exports

Closes #214.

## Size

Bunchee browser ESM output, minified:

| Chunk | Before | After | Before gzip | After gzip |
| --- | ---: | ---: | ---: | ---: |
| Code | 8,861 B | 9,505 B | 2,493 B | 2,635 B |
| Editor | 4,798 B | 4,620 B | 1,571 B | 1,542 B |
| Root | 100 B | 100 B | 103 B | 103 B |
| Total | 13,759 B | 14,225 B | 4,167 B | 4,280 B |

The 113 B total gzip increase adds canonical markers, controlled/uncontrolled editor behavior, and separated parsing. In exchange, React 19 hoists and combines the previously repeated per-instance CSS into one editor/code/header stylesheet resource; this was verified on the live `/react` development page.

Sugar High architecture benchmark:

- `sugar-high`: 24.30 KiB minified / 8.89 KiB gzip
- `sugar-high/core`: 3.57 KiB minified / 1.74 KiB gzip
- `core + javascript`: 9.82 KiB minified / 4.40 KiB gzip
- Python highlighting: 15,259 ops/s builtin, 15,244 ops/s core

## Verification

- `pnpm test`
- `pnpm build`
- `pnpm --filter sugar-high benchmark`
- `git diff --check`
- running development server at `http://localhost:3000/react`

The development page returned 200, rendered the combined stylesheet resource, used the clarified `--sh-editor-*` and `--sh-line-highlight-color` variables, and contained no `--codice-*` variables.