### PR TITLE
Release React changes as a major

### DIFF
--- a/.changeset/calm-pandas-edit.md
+++ b/.changeset/calm-pandas-edit.md
@@ -1,5 +1,5 @@
 ---
-'@sugar-high/react': minor
+'@sugar-high/react': major
 ---
 
 Improve editor value synchronization and highlighting performance, add `defaultValue` for


### PR DESCRIPTION
## Summary

Change the `@sugar-high/react` Changeset from minor to major.

The merged React work replaces the public `--codice-*` styling variables with `--sh-*` names. Existing themes using the old variables will silently stop applying those customizations, so this is a breaking change and should release as `2.0.0`, not `1.1.0`.

No implementation files are changed.