### PR TITLE
Fix CSS hyphenated identifier highlighting

### DIFF
--- a/.changeset/plenty-doors-go.md
+++ b/.changeset/plenty-doors-go.md
@@ -1,0 +1,5 @@
+---
+"sugar-high": patch
+---
+
+Keep hyphenated CSS names in a single syntax token

--- a/packages/sugar-high/lib/presets/lang/css.js
+++ b/packages/sugar-high/lib/presets/lang/css.js
@@ -26,6 +26,47 @@ export const onLiteral = (curr, index, code) => {
 const isIgnored = (type) => type === T_SPACE || type === T_BREAK || type === T_COMMENT
 const isPropertyPart = ([type, value]) =>
   type === T_IDENTIFIER || type === T_CLASS || (type === T_SIGN && value === '-')
+const isNamePart = ([type]) =>
+  type === T_IDENTIFIER || type === T_CLASS || type === T_PROPERTY
+const isNameStart = (token) => isNamePart(token) && !/^\d/.test(token[1])
+const isHyphen = ([type, value]) => type === T_SIGN && value === '-'
+
+/**
+ * Rejoin CSS dashed identifiers split by the shared punctuation lexer.
+ * @param {Array<[number, string]>} tokens
+ */
+const mergeDashedNames = (tokens) => {
+  for (let index = 0; index < tokens.length; index++) {
+    let firstWord = index
+    let end = index
+
+    if (isHyphen(tokens[end])) {
+      while (isHyphen(tokens[end])) end++
+      if (!tokens[end] || !isNameStart(tokens[end])) continue
+      firstWord = end++
+    } else if (isNameStart(tokens[end])) {
+      end++
+    } else {
+      continue
+    }
+
+    let dashed = firstWord > index
+    while (tokens[end] && isHyphen(tokens[end])) {
+      const hyphenStart = end
+      while (tokens[end] && isHyphen(tokens[end])) end++
+      if (!tokens[end] || !isNamePart(tokens[end])) {
+        end = hyphenStart
+        break
+      }
+      dashed = true
+      end++
+    }
+
+    if (!dashed) continue
+    const name = tokens.slice(index, end).map(([, value]) => value).join('')
+    tokens.splice(index, end - index, [tokens[firstWord][0], name])
+  }
+}
 
 /** Return true when a colon belongs to a nested selector instead of a declaration. */
 const opensBlock = (tokens, start) => {
@@ -51,6 +92,7 @@ const opensBlock = (tokens, start) => {
  */
 export const tokenize = (code, options) => {
   const tokens = tokenizePlain(code, { ...options, tokenize: undefined })
+  mergeDashedNames(tokens)
   let blockDepth = 0
   let declarationStart = false
 

--- a/packages/sugar-high/test/preset/css.test.ts
+++ b/packages/sugar-high/test/preset/css.test.ts
@@ -70,4 +70,29 @@ describe('tokenize - css preset', () => {
     expect(actual).toContain('color => property')
     expect(actual).toContain('content => property')
   })
+
+  it('keeps dashed CSS names together outside declarations', () => {
+    const input = `.sh-theme--sugar-high, .button-2xl {
+  color: var(--theme-muted);
+  background: linear-gradient(red, blue);
+  -webkit-font-smoothing: antialiased;
+}`
+    const actual = getTokensAsString(tokenize(input, css))
+
+    expect(actual).toContain('sh-theme--sugar-high => property')
+    expect(actual).toContain('button-2xl => property')
+    expect(actual).toContain('--theme-muted => identifier')
+    expect(actual).toContain('linear-gradient => identifier')
+    expect(actual).toContain('-webkit-font-smoothing => property')
+  })
+
+  it('keeps minus signs separate from numeric CSS values', () => {
+    const input = '.offset-card { margin: -1rem; width: calc(100% - 2px); }'
+    const tokens = tokenize(input, css)
+    const actual = getTokensAsString(tokens)
+
+    expect(actual).toContain('offset-card => property')
+    expect(tokens.filter(([, value]) => value === '-')).toHaveLength(2)
+    expect(tokens.map(([, value]) => value)).not.toContain('-1rem')
+  })
 })


### PR DESCRIPTION
## Summary

- keep contiguous hyphenated CSS names in one syntax token
- cover selectors, custom properties, function names, numeric suffixes, and vendor-prefixed properties
- preserve minus signs for negative numeric values and calculations
- add a patch Changeset for `sugar-high`

## Verification

- `pnpm test` — 152 tests passed
- `pnpm --filter sugar-high benchmark`
  - `sugar-high`: 24.69 KiB minified / 8.95 KiB gzip
  - `sugar-high/core`: 3.57 KiB minified / 1.70 KiB gzip
  - `core + javascript`: 9.82 KiB minified / 4.33 KiB gzip
- verified `/theme` with the running development server: selectors and custom-property names render as single token spans
- `git diff --check`

Production build was not run because the existing development server was used for site verification.