### PR TITLE
Fix CSS tokenizer crash on trailing hyphens

### DIFF
--- a/.changeset/calm-hyphens-smile.md
+++ b/.changeset/calm-hyphens-smile.md
@@ -1,0 +1,5 @@
+---
+'sugar-high': patch
+---
+
+Prevent the CSS tokenizer from crashing on input that ends with hyphens.

--- a/packages/sugar-high/lib/presets/lang/css.js
+++ b/packages/sugar-high/lib/presets/lang/css.js
@@ -41,7 +41,7 @@ const mergeDashedNames = (tokens) => {
     let end = index
 
     if (isHyphen(tokens[end])) {
-      while (isHyphen(tokens[end])) end++
+      while (tokens[end] && isHyphen(tokens[end])) end++
       if (!tokens[end] || !isNameStart(tokens[end])) continue
       firstWord = end++
     } else if (isNameStart(tokens[end])) {

--- a/packages/sugar-high/test/preset/css.test.ts
+++ b/packages/sugar-high/test/preset/css.test.ts
@@ -95,4 +95,10 @@ describe('tokenize - css preset', () => {
     expect(tokens.filter(([, value]) => value === '-')).toHaveLength(2)
     expect(tokens.map(([, value]) => value)).not.toContain('-1rem')
   })
+
+  it('handles trailing hyphens', () => {
+    for (const input of ['-', '--', '.button-']) {
+      expect(() => tokenize(input, css)).not.toThrow()
+    }
+  })
 })


### PR DESCRIPTION
## Summary

- guard the dashed-name scan at the end of the token stream
- cover trailing single and repeated hyphens with regression tests
- add a patch changeset for `sugar-high`

## Validation

- `pnpm test`
- `pnpm build`
- `git diff --check`