### PR TITLE
Add a selective server-safe React Code entry

### DIFF
--- a/.changeset/bright-react-code.md
+++ b/.changeset/bright-react-code.md
@@ -1,0 +1,5 @@
+---
+'@sugar-high/react': minor
+---
+
+Add a registry-free, server-compatible `@sugar-high/react/core` entry whose `Code` component accepts language configurations through `lang`.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -34,6 +34,24 @@ import { Code } from '@sugar-high/react'
 `lang` takes a canonical Sugar High language name. When omitted, `title` or the legacy
 `extension` prop is resolved through Sugar High's language aliases.
 
+### Select languages and render on the server
+
+Use `@sugar-high/react/core` when you only need a few languages or want a server-compatible static
+code block. Import each language configuration explicitly and pass it through `lang`:
+
+```tsx
+import { Code } from '@sugar-high/react/core'
+import * as python from 'sugar-high/lang/python'
+
+<Code lang={python} title="main.py" lineNumbers>
+  {'def hello():\n    return "world"'}
+</Code>
+```
+
+The core React entry does not include the complete language registry or a client directive. The
+default entry remains the convenient choice when string language names and title-based detection
+are more important than selecting the smallest bundle.
+
 Use the `data-sh-*` attributes and `--sh-*` variables for new styles. The package temporarily
 preserves Codice's existing `data-codice-*` attributes so existing structural selectors can
 migrate incrementally.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -14,6 +14,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./core": {
+      "types": "./dist/core.d.ts",
+      "default": "./dist/core.mjs"
     }
   },
   "files": [
@@ -23,7 +27,8 @@
     "access": "public"
   },
   "scripts": {
-    "build": "bunchee",
+    "build": "bunchee && node scripts/check-core-build.mjs",
+    "benchmark": "node scripts/benchmark.mjs",
     "test": "vitest --run",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -27,7 +27,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "bunchee && node scripts/check-core-build.mjs",
+    "build": "bunchee",
     "benchmark": "node scripts/benchmark.mjs",
     "test": "vitest --run",
     "prepublishOnly": "pnpm build"

--- a/packages/react/scripts/benchmark.mjs
+++ b/packages/react/scripts/benchmark.mjs
@@ -1,0 +1,50 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { gzipSync } from 'node:zlib'
+
+const directory = mkdtempSync(join(process.cwd(), '.react-benchmark-'))
+
+function measure(name, source) {
+  const entry = join(directory, `${name}.js`)
+  const output = join(directory, `${name}.bundle.js`)
+  writeFileSync(entry, source)
+  execFileSync(process.env.BUN_BIN || 'bun', [
+    'build', entry, '--bundle', '--minify', '--target=browser',
+    '--external=react', '--external=react/jsx-runtime', `--outfile=${output}`,
+  ], { stdio: 'pipe' })
+
+  const bundled = readFileSync(output)
+  return {
+    entry: name.replaceAll('-', ' + '),
+    minified: `${(bundled.byteLength / 1024).toFixed(2)} KiB`,
+    gzip: `${(gzipSync(bundled, { level: 9 }).byteLength / 1024).toFixed(2)} KiB`,
+  }
+}
+
+try {
+  console.table([
+    measure('react', `
+      import { createElement } from 'react'
+      import { Code } from '@sugar-high/react'
+      export const render = code => createElement(Code, null, code)
+    `),
+    measure('core-python', `
+      import { createElement } from 'react'
+      import { Code } from '@sugar-high/react/core'
+      import * as python from 'sugar-high/lang/python'
+      export const render = code => createElement(Code, { lang: python }, code)
+    `),
+    measure('core-python-json-css', `
+      import { createElement } from 'react'
+      import { Code } from '@sugar-high/react/core'
+      import * as python from 'sugar-high/lang/python'
+      import * as json from 'sugar-high/lang/json'
+      import * as css from 'sugar-high/lang/css'
+      const languages = { python, json, css }
+      export const render = (code, lang) => createElement(Code, { lang: languages[lang] }, code)
+    `),
+  ])
+} finally {
+  rmSync(directory, { recursive: true, force: true })
+}

--- a/packages/react/scripts/check-core-build.mjs
+++ b/packages/react/scripts/check-core-build.mjs
@@ -1,7 +1,0 @@
-import { readFileSync } from 'node:fs'
-
-const core = readFileSync(new URL('../dist/core.mjs', import.meta.url), 'utf8')
-
-if (core.includes("'use client'") || core.includes('sugar-high/lang')) {
-  throw new Error('The core entry must remain server-safe and registry-free')
-}

--- a/packages/react/scripts/check-core-build.mjs
+++ b/packages/react/scripts/check-core-build.mjs
@@ -1,0 +1,7 @@
+import { readFileSync } from 'node:fs'
+
+const core = readFileSync(new URL('../dist/core.mjs', import.meta.url), 'utf8')
+
+if (core.includes("'use client'") || core.includes('sugar-high/lang')) {
+  throw new Error('The core entry must remain server-safe and registry-free')
+}

--- a/packages/react/src/code/code.tsx
+++ b/packages/react/src/code/code.tsx
@@ -1,10 +1,5 @@
-'use client'
-
-import { type HighlightOptions, type LanguageName } from 'sugar-high'
-import { parse, generate } from 'sugar-high/core'
+import { parse, generate, type DisplayOptions, type ParseOptions } from 'sugar-high/core'
 import { css, HEADER_CSS } from './css'
-import { lang as canonicalLang, languages } from 'sugar-high/lang'
-import { useMemo } from 'react'
 import { fontSizeCss, ScopedStyle } from '../style'
 
 /** utils */
@@ -26,9 +21,9 @@ function generateHighlightedLines(
   parsed: ReturnType<typeof parse>,
   highlightLines: ([number, number] | number)[],
   lineNumbers: boolean,
-  cx: HighlightOptions['cx'],
-  mark: HighlightOptions['mark'],
-  markLine: HighlightOptions['markLine']
+  cx: DisplayOptions['cx'],
+  mark: DisplayOptions['mark'],
+  markLine: DisplayOptions['markLine']
 ) {
   const childrenLines = generate(parsed, { cx, mark, markLine })
 
@@ -159,6 +154,25 @@ function CodeFrame({
   )
 }
 
+export type CodeProps = {
+  children: string
+  /** Language configuration imported from `sugar-high/lang/<language>`. */
+  lang?: ParseOptions
+  /** Whether to use a preformatted block <pre><code> */
+  preformatted?: boolean
+  fontSize?: string | number
+  highlightLines?: ([number, number] | number)[]
+  title?: string
+  controls?: boolean
+  lineNumbers?: boolean
+  lineNumbersWidth?: string
+  padding?: string
+  asMarkup?: boolean
+  cx?: DisplayOptions['cx']
+  mark?: DisplayOptions['mark']
+  markLine?: DisplayOptions['markLine']
+} & React.HTMLAttributes<HTMLDivElement>
+
 export function Code({
   children: code,
   title,
@@ -170,43 +184,18 @@ export function Code({
   lineNumbersWidth,
   padding,
   asMarkup = false,
-  extension,
   lang,
   cx,
   mark,
   markLine,
   style,
   ...props
-}: {
-  children: string
-  /** Whether to use a preformatted block <pre><code> */
-  preformatted?: boolean
-  fontSize?: string | number
-  highlightLines?: ([number, number] | number)[]
-  title?: string
-  controls?: boolean
-  lineNumbers?: boolean
-  lineNumbersWidth?: string
-  padding?: string
-  asMarkup?: boolean
-  extension?: string
-  lang?: LanguageName
-  cx?: HighlightOptions['cx']
-  mark?: HighlightOptions['mark']
-  markLine?: HighlightOptions['markLine']
-} & React.HTMLAttributes<HTMLDivElement>) {
+}: CodeProps) {
   const resolvedLineNumbersWidth = getLineNumbersWidth(code, lineNumbersWidth)
-  const config = useMemo(() => {
-    const resolvedLang = lang || canonicalLang(extension || getExtension(title)) || 'javascript'
-    return languages.find(({ id }) => id === resolvedLang)?.config
-  }, [extension, lang, title])
-  const parsed = useMemo(() => asMarkup ? null : parse(code, config), [asMarkup, code, config])
-  const lineElements = useMemo(() =>
-    asMarkup
-      ? code
-      : generateHighlightedLines(parsed!, highlightLines, lineNumbers, cx, mark, markLine),
-    [code, highlightLines, lineNumbers, cx, mark, markLine, asMarkup, parsed]
-  )
+  const parsed = asMarkup ? null : parse(code, lang)
+  const lineElements = asMarkup
+    ? code
+    : generateHighlightedLines(parsed!, highlightLines, lineNumbers, cx, mark, markLine)
 
   return (
     // Add both attribute because it's both root component and child component (of editor)

--- a/packages/react/src/code/default.tsx
+++ b/packages/react/src/code/default.tsx
@@ -1,0 +1,22 @@
+import { type HighlightOptions, type LanguageName } from 'sugar-high'
+import { lang as canonicalLang, languages } from 'sugar-high/lang'
+import {
+  Code as CoreCode,
+  getExtension,
+  type CodeProps as CoreCodeProps,
+} from './code'
+
+export type CodeProps = Omit<CoreCodeProps, 'lang'> & {
+  extension?: string
+  lang?: LanguageName
+  cx?: HighlightOptions['cx']
+  mark?: HighlightOptions['mark']
+  markLine?: HighlightOptions['markLine']
+}
+
+export function Code({ extension, lang, title, ...props }: CodeProps) {
+  const resolvedLang = lang || canonicalLang(extension || getExtension(title)) || 'javascript'
+  const config = languages.find(({ id }) => id === resolvedLang)?.config
+
+  return <CoreCode {...props} title={title} lang={config} />
+}

--- a/packages/react/src/code/index.ts
+++ b/packages/react/src/code/index.ts
@@ -1,1 +1,1 @@
-export { Code } from './code'
+export { Code, type CodeProps } from './default'

--- a/packages/react/src/core.test.tsx
+++ b/packages/react/src/core.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { renderToString } from 'react-dom/server'
+import * as python from 'sugar-high/lang/python'
+import { Code } from './core'
+
+describe('core Code', () => {
+  it('renders an imported language configuration on the server', () => {
+    const html = renderToString(
+      <Code lang={python}>{'def hello(): # greeting'}</Code>
+    )
+
+    expect(html).toContain('sh__token--keyword')
+    expect(html).toContain('sh__token--comment')
+  })
+})

--- a/packages/react/src/core.ts
+++ b/packages/react/src/core.ts
@@ -1,0 +1,1 @@
+export { Code, type CodeProps } from './code/code'

--- a/packages/react/src/editor/editor.tsx
+++ b/packages/react/src/editor/editor.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useState, forwardRef } from 'react'
-import { CodeHeader, getExtension, getLineNumbersWidth, Code } from '../code/code'
+import { CodeHeader, getExtension, getLineNumbersWidth } from '../code/code'
+import { Code } from '../code/default'
 import { fontSizeCss, ScopedStyle } from '../style'
 import { css } from './css'
 import type { HighlightOptions, LanguageName } from 'sugar-high'


### PR DESCRIPTION
## Summary

- add `@sugar-high/react/core` with a registry-free `Code` component
- accept imported language configurations through `<Code lang={python}>`
- remove client hooks and the client directive from the shared static Code implementation
- keep the default `@sugar-high/react` string-language API unchanged
- build the core entry as an independent server-safe module and fail the build if it gains a client directive or full registry import
- document selective language imports and add server-rendering coverage

## Bundle size

React is external in these Bun browser ESM measurements.

| Entry | Minified | Gzip |
| --- | ---: | ---: |
| `@sugar-high/react` | 30.21 KiB | 10.76 KiB |
| core + Python | 7.96 KiB | 3.30 KiB |
| core + Python + JSON + CSS | 9.91 KiB | 4.08 KiB |

## Validation

- `pnpm test`
- `pnpm build`
- `pnpm --filter @sugar-high/react benchmark`
- `git diff --check`

Closes #226
Closes #227