### PR TITLE
Improve Editor indentation and textarea customization

### DIFF
--- a/.changeset/calm-editors-indent.md
+++ b/.changeset/calm-editors-indent.md
@@ -1,0 +1,5 @@
+---
+'@sugar-high/react': minor
+---
+
+Add Tab and Shift+Tab indentation to `Editor`, plus `textareaProps` for customizing the underlying textarea.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -21,6 +21,18 @@ import { Editor } from '@sugar-high/react'
 />
 ```
 
+Press Tab or Shift+Tab to indent or outdent the caret or selected lines. Customize the indentation
+string and underlying textarea attributes with `indent` and `textareaProps`:
+
+```tsx
+<Editor
+  indent="\t"
+  textareaProps={{ 'aria-label': 'Source code', autoCapitalize: 'off' }}
+  value={source}
+  onChange={setSource}
+/>
+```
+
 ## Code
 
 ```tsx

--- a/packages/react/src/editor/editor.test.tsx
+++ b/packages/react/src/editor/editor.test.tsx
@@ -1,8 +1,58 @@
 import { describe, expect, it } from 'vitest'
 import { Editor } from '.'
+import { indentCode } from './editor'
 import { renderToString } from 'react-dom/server'
 
 describe('Code', () => {
+  it('indents at the caret and preserves it', () => {
+    expect(indentCode('const value = 1', 6, 6, '  ')).toEqual({
+      value: 'const   value = 1',
+      selectionStart: 8,
+      selectionEnd: 8,
+    })
+  })
+
+  it('indents and outdents selected lines', () => {
+    const indented = indentCode('one\ntwo\nthree', 1, 7, '  ')
+    expect(indented).toEqual({
+      value: '  one\n  two\nthree',
+      selectionStart: 3,
+      selectionEnd: 11,
+    })
+    expect(
+      indentCode(
+        indented.value,
+        indented.selectionStart,
+        indented.selectionEnd,
+        '  ',
+        true
+      )
+    ).toEqual({
+      value: 'one\ntwo\nthree',
+      selectionStart: 1,
+      selectionEnd: 7,
+    })
+  })
+
+  it('passes textarea attributes without exposing value control', () => {
+    const html = renderToString(
+      <Editor
+        value="code"
+        textareaProps={{
+          'aria-label': 'Source code',
+          autoCapitalize: 'off',
+          spellCheck: true,
+        }}
+      />
+    )
+
+    expect(html).toContain('aria-label="Source code"')
+    expect(html).toContain('autoCapitalize="off"')
+    expect(html).toContain('spellCheck="true"')
+    expect(html).toContain('<textarea')
+    expect(html).toContain('>code</textarea>')
+  })
+
   it('supports controlled and uncontrolled initial values', () => {
     const controlled = renderToString(<Editor value="controlled" defaultValue="ignored" />)
     const uncontrolled = renderToString(<Editor defaultValue="initial" />)

--- a/packages/react/src/editor/editor.tsx
+++ b/packages/react/src/editor/editor.tsx
@@ -1,11 +1,85 @@
 'use client'
 
-import { useState, forwardRef } from 'react'
+import { useLayoutEffect, useRef, useState, forwardRef } from 'react'
 import { CodeHeader, getExtension, getLineNumbersWidth } from '../code/code'
 import { Code } from '../code/default'
 import { fontSizeCss, ScopedStyle } from '../style'
 import { css } from './css'
 import type { HighlightOptions, LanguageName } from 'sugar-high'
+
+type TextareaProps = Omit<
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+  'children' | 'defaultValue' | 'value'
+>
+
+export function indentCode(
+  value: string,
+  selectionStart: number,
+  selectionEnd: number,
+  indent: string,
+  outdent = false
+) {
+  if (!outdent && selectionStart === selectionEnd) {
+    return {
+      value: value.slice(0, selectionStart) + indent + value.slice(selectionEnd),
+      selectionStart: selectionStart + indent.length,
+      selectionEnd: selectionEnd + indent.length,
+    }
+  }
+
+  const firstLineStart = value.lastIndexOf('\n', selectionStart - 1) + 1
+  const lastSelectedPosition =
+    selectionEnd > selectionStart && value[selectionEnd - 1] === '\n'
+      ? selectionEnd - 1
+      : selectionEnd
+  const edits: { position: number; remove: number; insert: string }[] = []
+
+  for (
+    let position = firstLineStart;
+    position <= lastSelectedPosition;
+    position = value.indexOf('\n', position) + 1
+  ) {
+    let remove = 0
+    if (outdent) {
+      if (value.startsWith(indent, position)) remove = indent.length
+      else {
+        const whitespace = value.slice(position).match(/^[ \t]+/)?.[0] || ''
+        remove = Math.min(whitespace.length, indent.length)
+      }
+    }
+    edits.push({ position, remove, insert: outdent ? '' : indent })
+    const newline = value.indexOf('\n', position)
+    if (newline < 0 || newline >= lastSelectedPosition) break
+    position = newline
+  }
+
+  const mapOffset = (offset: number) => {
+    let mapped = offset
+    for (const edit of edits) {
+      if (offset < edit.position) break
+      if (offset <= edit.position + edit.remove) {
+        mapped = edit.position + edit.insert.length
+        break
+      }
+      mapped += edit.insert.length - edit.remove
+    }
+    return mapped
+  }
+
+  let nextValue = value
+  for (const edit of edits.slice().reverse()) {
+    nextValue =
+      nextValue.slice(0, edit.position) +
+      edit.insert +
+      nextValue.slice(edit.position + edit.remove)
+  }
+
+  return {
+    value: nextValue,
+    selectionStart: mapOffset(selectionStart),
+    selectionEnd: mapOffset(selectionEnd),
+  }
+}
 
 export const Editor = forwardRef(function Editor(
   {
@@ -25,6 +99,8 @@ export const Editor = forwardRef(function Editor(
     fontFamily,
     onChangeTitle,
     textareaRef,
+    textareaProps,
+    indent = '  ',
     style,
     ...props
   }: {
@@ -42,6 +118,8 @@ export const Editor = forwardRef(function Editor(
     onChangeTitle?: (title: string) => void
     onChange?: (code: string) => void
     textareaRef?: React.Ref<HTMLTextAreaElement>
+    textareaProps?: TextareaProps
+    indent?: string
   } & {
     fontSize?: string | number
     fontFamily?: string
@@ -49,13 +127,59 @@ export const Editor = forwardRef(function Editor(
   ref: React.Ref<HTMLDivElement>
 ) {
   const [uncontrolledCode, setUncontrolledCode] = useState(defaultValue)
+  const inputRef = useRef<HTMLTextAreaElement | null>(null)
+  const selectionRef = useRef<{ start: number; end: number } | null>(null)
+  const composingRef = useRef(false)
   const code = value ?? uncontrolledCode
   const resolvedLineNumbersWidth = getLineNumbersWidth(code, lineNumbersWidth)
 
-  function onInput(event: React.ChangeEvent<HTMLTextAreaElement>) {
-    const textContent = event.target.value || ''
+  function updateCode(textContent: string) {
     if (value === undefined) setUncontrolledCode(textContent)
     onChange?.(textContent)
+  }
+
+  function onInput(event: React.ChangeEvent<HTMLTextAreaElement>) {
+    const textContent = event.target.value || ''
+    textareaProps?.onChange?.(event)
+    updateCode(textContent)
+  }
+
+  function onKeyDown(event: React.KeyboardEvent<HTMLTextAreaElement>) {
+    textareaProps?.onKeyDown?.(event)
+    if (
+      event.defaultPrevented ||
+      event.key !== 'Tab' ||
+      composingRef.current ||
+      event.nativeEvent.isComposing
+    )
+      return
+
+    event.preventDefault()
+    const result = indentCode(
+      code,
+      event.currentTarget.selectionStart,
+      event.currentTarget.selectionEnd,
+      indent,
+      event.shiftKey
+    )
+    selectionRef.current = {
+      start: result.selectionStart,
+      end: result.selectionEnd,
+    }
+    updateCode(result.value)
+  }
+
+  useLayoutEffect(() => {
+    const selection = selectionRef.current
+    if (!selection || !inputRef.current) return
+    inputRef.current.setSelectionRange(selection.start, selection.end)
+    selectionRef.current = null
+  }, [code])
+
+  function setTextareaRef(node: HTMLTextAreaElement | null) {
+    inputRef.current = node
+    if (typeof textareaRef === 'function') textareaRef(node)
+    else if (textareaRef) textareaRef.current = node
   }
 
   return (
@@ -100,7 +224,21 @@ export const Editor = forwardRef(function Editor(
         >
           {code}
         </Code>
-        <textarea ref={textareaRef} value={code} onChange={onInput} />
+        <textarea
+          {...textareaProps}
+          ref={setTextareaRef}
+          value={code}
+          onChange={onInput}
+          onKeyDown={onKeyDown}
+          onCompositionStart={(event) => {
+            composingRef.current = true
+            textareaProps?.onCompositionStart?.(event)
+          }}
+          onCompositionEnd={(event) => {
+            composingRef.current = false
+            textareaProps?.onCompositionEnd?.(event)
+          }}
+        />
       </div>
     </div>
   )


### PR DESCRIPTION
Closes #228

## Summary
- insert or remove indentation with Tab and Shift+Tab for carets and multiline selections
- preserve selection after controlled and uncontrolled updates while avoiding Tab handling during IME composition
- add typed `textareaProps` with composed textarea event handlers
- document the new editor controls and add a changeset

## Verification
- `pnpm test`
- `pnpm build`
- `git diff --check`