### PR TITLE
Add starting line numbers and long-line wrapping controls

### DIFF
--- a/.changeset/bright-lines-scroll.md
+++ b/.changeset/bright-lines-scroll.md
@@ -1,0 +1,5 @@
+---
+'@sugar-high/react': minor
+---
+
+Add starting line numbers and configurable long-line wrapping to `Code` and `Editor`.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -43,6 +43,15 @@ import { Code } from '@sugar-high/react'
 </Code>
 ```
 
+For excerpts from larger files, set the first displayed line number. Long lines wrap by default;
+disable wrapping to use horizontal scrolling instead. Both options also work with `Editor`.
+
+```tsx
+<Code lineNumbers startingLineNumber={40} wrapLongLines={false}>
+  {source}
+</Code>
+```
+
 `lang` takes a canonical Sugar High language name. When omitted, `title` or the legacy
 `extension` prop is resolved through Sugar High's language aliases.
 

--- a/packages/react/src/code/code.test.tsx
+++ b/packages/react/src/code/code.test.tsx
@@ -8,6 +8,32 @@ describe('Code', () => {
     expect(getLineNumbersWidth('line\n'.repeat(998))).toBeUndefined()
     expect(getLineNumbersWidth('line\n'.repeat(999))).toBe('calc(4ch + 14px)')
     expect(getLineNumbersWidth('line', '5rem')).toBe('5rem')
+    expect(getLineNumbersWidth('first\nsecond', undefined, 999)).toBe(
+      'calc(4ch + 14px)'
+    )
+  })
+
+  it('starts displayed line numbers at a custom value without changing highlights', () => {
+    const html = renderToString(
+      <Code lineNumbers startingLineNumber={40} highlightLines={[1]}>
+        {'first\nsecond'}
+      </Code>
+    )
+
+    expect(html).toContain('>40</span>')
+    expect(html).toContain('>41</span>')
+    expect(html.match(/data-highlight="true"/g)).toHaveLength(1)
+  })
+
+  it('can disable long-line wrapping', () => {
+    const html = renderToString(<Code wrapLongLines={false}>long line</Code>)
+
+    expect(html).toContain('data-sh-wrap-long-lines="false"')
+    expect(html).toContain('white-space: pre;')
+    expect(html.match(/data-sh-wrap-long-lines="false"/g)).toHaveLength(3)
+    expect(
+      renderToString(<Code>long line</Code>).match(/data-sh-wrap-long-lines="false"/g)
+    ).toHaveLength(2)
   })
 
   it('exposes Sugar High markers and clamps highlighted ranges', () => {
@@ -30,6 +56,14 @@ describe('Code', () => {
       [data-sh-code] pre {
         white-space: pre-wrap;
         margin: 0;
+      }
+      [data-sh-code][data-sh-wrap-long-lines="false"] pre {
+        overflow-x: auto;
+        white-space: pre;
+      }
+      [data-sh-code][data-sh-wrap-long-lines="false"] .sh__line {
+        width: max-content;
+        min-width: 100%;
       }
       [data-sh-code] code {
         display: block;
@@ -78,6 +112,14 @@ describe('Code', () => {
       [data-sh-code] pre {
         white-space: pre-wrap;
         margin: 0;
+      }
+      [data-sh-code][data-sh-wrap-long-lines="false"] pre {
+        overflow-x: auto;
+        white-space: pre;
+      }
+      [data-sh-code][data-sh-wrap-long-lines="false"] .sh__line {
+        width: max-content;
+        min-width: 100%;
       }
       [data-sh-code] code {
         display: block;
@@ -166,6 +208,14 @@ describe('Code', () => {
         white-space: pre-wrap;
         margin: 0;
       }
+      [data-sh-code][data-sh-wrap-long-lines="false"] pre {
+        overflow-x: auto;
+        white-space: pre;
+      }
+      [data-sh-code][data-sh-wrap-long-lines="false"] .sh__line {
+        width: max-content;
+        min-width: 100%;
+      }
       [data-sh-code] code {
         display: block;
         border: none;
@@ -253,6 +303,14 @@ describe('Code', () => {
         white-space: pre-wrap;
         margin: 0;
       }
+      [data-sh-code][data-sh-wrap-long-lines="false"] pre {
+        overflow-x: auto;
+        white-space: pre;
+      }
+      [data-sh-code][data-sh-wrap-long-lines="false"] .sh__line {
+        width: max-content;
+        min-width: 100%;
+      }
       [data-sh-code] code {
         display: block;
         border: none;
@@ -298,6 +356,14 @@ describe('Code', () => {
       [data-sh-code] pre {
         white-space: pre-wrap;
         margin: 0;
+      }
+      [data-sh-code][data-sh-wrap-long-lines="false"] pre {
+        overflow-x: auto;
+        white-space: pre;
+      }
+      [data-sh-code][data-sh-wrap-long-lines="false"] .sh__line {
+        width: max-content;
+        min-width: 100%;
       }
       [data-sh-code] code {
         display: block;

--- a/packages/react/src/code/code.tsx
+++ b/packages/react/src/code/code.tsx
@@ -7,13 +7,13 @@ export function getExtension(title: string | undefined) {
   return (title || '').split('.').pop() || ''
 }
 
-export function getLineNumbersWidth(code: string, width?: string) {
+export function getLineNumbersWidth(code: string, width?: string, startingLineNumber = 1) {
   if (width) return width
   let lines = 1
   for (let i = 0; i < code.length; i++) {
     if (code.charCodeAt(i) === 10) lines++
   }
-  const digits = String(lines).length
+  const digits = String(startingLineNumber + lines - 1).length
   return digits > 3 ? `calc(${digits}ch + 14px)` : undefined
 }
 
@@ -23,7 +23,8 @@ function generateHighlightedLines(
   lineNumbers: boolean,
   cx: DisplayOptions['cx'],
   mark: DisplayOptions['mark'],
-  markLine: DisplayOptions['markLine']
+  markLine: DisplayOptions['markLine'],
+  startingLineNumber: number
 ) {
   const childrenLines = generate(parsed, { cx, mark, markLine })
 
@@ -74,7 +75,11 @@ function generateHighlightedLines(
           data-sh-code-line
           key={index}
         >
-          {lineNumbers ? <span key='ln' data-codice-code-line-number data-sh-code-line-number>{index + 1}</span> : null}
+          {lineNumbers ? (
+            <span key="ln" data-codice-code-line-number data-sh-code-line-number>
+              {startingLineNumber + index}
+            </span>
+          ) : null}
           {tokens}
         </Line>
       )
@@ -166,6 +171,8 @@ export type CodeProps = {
   controls?: boolean
   lineNumbers?: boolean
   lineNumbersWidth?: string
+  startingLineNumber?: number
+  wrapLongLines?: boolean
   padding?: string
   asMarkup?: boolean
   cx?: DisplayOptions['cx']
@@ -182,6 +189,8 @@ export function Code({
   preformatted = true,
   lineNumbers = false,
   lineNumbersWidth,
+  startingLineNumber = 1,
+  wrapLongLines = true,
   padding,
   asMarkup = false,
   lang,
@@ -191,11 +200,23 @@ export function Code({
   style,
   ...props
 }: CodeProps) {
-  const resolvedLineNumbersWidth = getLineNumbersWidth(code, lineNumbersWidth)
+  const resolvedLineNumbersWidth = getLineNumbersWidth(
+    code,
+    lineNumbersWidth,
+    startingLineNumber
+  )
   const parsed = asMarkup ? null : parse(code, lang)
   const lineElements = asMarkup
     ? code
-    : generateHighlightedLines(parsed!, highlightLines, lineNumbers, cx, mark, markLine)
+    : generateHighlightedLines(
+        parsed!,
+        highlightLines,
+        lineNumbers,
+        cx,
+        mark,
+        markLine,
+        startingLineNumber
+      )
 
   return (
     // Add both attribute because it's both root component and child component (of editor)
@@ -213,6 +234,7 @@ export function Code({
       data-sh-code
       data-codice-line-numbers={lineNumbers}
       data-sh-line-numbers={lineNumbers}
+      data-sh-wrap-long-lines={wrapLongLines ? undefined : false}
     >
       <ScopedStyle css={css} href="sugar-high-react-code" />
       <CodeHeader title={title} controls={controls} />

--- a/packages/react/src/code/css.ts
+++ b/packages/react/src/code/css.ts
@@ -14,6 +14,14 @@ ${C} pre {
   white-space: pre-wrap;
   margin: 0;
 }
+${C}[data-sh-wrap-long-lines="false"] pre {
+  overflow-x: auto;
+  white-space: pre;
+}
+${C}[data-sh-wrap-long-lines="false"] .sh__line {
+  width: max-content;
+  min-width: 100%;
+}
 ${C} code {
   display: block;
   border: none;

--- a/packages/react/src/editor/editor.test.tsx
+++ b/packages/react/src/editor/editor.test.tsx
@@ -53,6 +53,17 @@ describe('Code', () => {
     expect(html).toContain('>code</textarea>')
   })
 
+  it('supports starting line numbers and non-wrapping input', () => {
+    const html = renderToString(
+      <Editor value={'first\nsecond'} startingLineNumber={40} wrapLongLines={false} />
+    )
+
+    expect(html).toContain('>40</span>')
+    expect(html).toContain('>41</span>')
+    expect(html).toContain('data-sh-wrap-long-lines="false"')
+    expect(html).toContain('<textarea wrap="off">')
+  })
+
   it('supports controlled and uncontrolled initial values', () => {
     const controlled = renderToString(<Editor value="controlled" defaultValue="ignored" />)
     const uncontrolled = renderToString(<Editor defaultValue="initial" />)
@@ -178,6 +189,14 @@ describe('Code', () => {
       [data-sh-code] pre {
         white-space: pre-wrap;
         margin: 0;
+      }
+      [data-sh-code][data-sh-wrap-long-lines="false"] pre {
+        overflow-x: auto;
+        white-space: pre;
+      }
+      [data-sh-code][data-sh-wrap-long-lines="false"] .sh__line {
+        width: max-content;
+        min-width: 100%;
       }
       [data-sh-code] code {
         display: block;
@@ -331,6 +350,14 @@ describe('Code', () => {
         white-space: pre-wrap;
         margin: 0;
       }
+      [data-sh-code][data-sh-wrap-long-lines="false"] pre {
+        overflow-x: auto;
+        white-space: pre;
+      }
+      [data-sh-code][data-sh-wrap-long-lines="false"] .sh__line {
+        width: max-content;
+        min-width: 100%;
+      }
       [data-sh-code] code {
         display: block;
         border: none;
@@ -443,6 +470,14 @@ describe('Code', () => {
       [data-sh-code] pre {
         white-space: pre-wrap;
         margin: 0;
+      }
+      [data-sh-code][data-sh-wrap-long-lines="false"] pre {
+        overflow-x: auto;
+        white-space: pre;
+      }
+      [data-sh-code][data-sh-wrap-long-lines="false"] .sh__line {
+        width: max-content;
+        min-width: 100%;
       }
       [data-sh-code] code {
         display: block;

--- a/packages/react/src/editor/editor.tsx
+++ b/packages/react/src/editor/editor.tsx
@@ -89,6 +89,8 @@ export const Editor = forwardRef(function Editor(
     controls = true,
     lineNumbers = true,
     lineNumbersWidth,
+    startingLineNumber = 1,
+    wrapLongLines = true,
     extension,
     lang,
     cx,
@@ -110,6 +112,8 @@ export const Editor = forwardRef(function Editor(
     controls?: boolean
     lineNumbers?: boolean
     lineNumbersWidth?: string
+    startingLineNumber?: number
+    wrapLongLines?: boolean
     padding?: string
     extension?: string
     lang?: LanguageName
@@ -131,7 +135,11 @@ export const Editor = forwardRef(function Editor(
   const selectionRef = useRef<{ start: number; end: number } | null>(null)
   const composingRef = useRef(false)
   const code = value ?? uncontrolledCode
-  const resolvedLineNumbersWidth = getLineNumbersWidth(code, lineNumbersWidth)
+  const resolvedLineNumbersWidth = getLineNumbersWidth(
+    code,
+    lineNumbersWidth,
+    startingLineNumber
+  )
 
   function updateCode(textContent: string) {
     if (value === undefined) setUncontrolledCode(textContent)
@@ -218,6 +226,8 @@ export const Editor = forwardRef(function Editor(
           controls={false}
           lineNumbers={lineNumbers}
           lineNumbersWidth={resolvedLineNumbersWidth}
+          startingLineNumber={startingLineNumber}
+          wrapLongLines={wrapLongLines}
           padding={padding}
           // Do not pass fontSize to Code in Editor.
           // It will control both the textarea and code font size.
@@ -228,6 +238,7 @@ export const Editor = forwardRef(function Editor(
           {...textareaProps}
           ref={setTextareaRef}
           value={code}
+          wrap={wrapLongLines ? undefined : 'off'}
           onChange={onInput}
           onKeyDown={onKeyDown}
           onCompositionStart={(event) => {
@@ -237,6 +248,13 @@ export const Editor = forwardRef(function Editor(
           onCompositionEnd={(event) => {
             composingRef.current = false
             textareaProps?.onCompositionEnd?.(event)
+          }}
+          onScroll={(event) => {
+            textareaProps?.onScroll?.(event)
+            const codeContent = event.currentTarget.previousElementSibling?.querySelector(
+              '[data-sh-code-content]'
+            )
+            if (codeContent) codeContent.scrollLeft = event.currentTarget.scrollLeft
           }}
         />
       </div>


### PR DESCRIPTION
Closes #229

## Summary

Add excerpt-friendly line numbering and explicit long-line behavior to both `Code` and `Editor`. Displayed numbers can begin at any value without changing the source-relative indexes used by `highlightLines` or `markLine`. Disabling wrapping enables horizontal scrolling; Editor keeps its textarea and highlighted layer synchronized.

```tsx
<Code lineNumbers startingLineNumber={40} wrapLongLines={false}>
  {source}
</Code>
```

The line-number gutter now sizes itself using the largest displayed number.

## Bundle size

- `@sugar-high/react`: 30.51 KiB minified / 10.87 KiB gzip
- `@sugar-high/react/core` + Python: 8.23 KiB minified / 3.39 KiB gzip