### PR TITLE
Add a headless React highlighting API

### DIFF
--- a/.changeset/headless-react-lines.md
+++ b/.changeset/headless-react-lines.md
@@ -2,4 +2,4 @@
 '@sugar-high/react': minor
 ---
 
-Add a server-compatible headless `Highlight` render-prop API to `@sugar-high/react/core`.
+Add a server-compatible headless `Highlight` API with a `render` prop to `@sugar-high/react/core`.

--- a/.changeset/headless-react-lines.md
+++ b/.changeset/headless-react-lines.md
@@ -1,0 +1,5 @@
+---
+'@sugar-high/react': minor
+---
+
+Add a server-compatible headless `Highlight` render-prop API to `@sugar-high/react/core`.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -68,8 +68,7 @@ import * as typescript from 'sugar-high/lang/typescript'
   markLine={(line) => {
     if (line.annotations.includes('focus')) line.properties['data-focus'] = true
   }}
->
-  {({ lines }) => (
+  render={({ lines }) => (
     <pre>
       {lines.map((line, index) => (
         <div key={index} {...line.properties}>
@@ -82,15 +81,17 @@ import * as typescript from 'sugar-high/lang/typescript'
       ))}
     </pre>
   )}
-</Highlight>
+/>
 ```
 
 The result is not limited to code-block markup. For example, render each generated line as a table
 row for a diff or virtualized viewer:
 
 ```tsx
-<Highlight code={source} lang={typescript}>
-  {({ lines }) => (
+<Highlight
+  code={source}
+  lang={typescript}
+  render={({ lines }) => (
     <table>
       <tbody>
         {lines.map((line, index) => (
@@ -102,7 +103,7 @@ row for a diff or virtualized viewer:
       </tbody>
     </table>
   )}
-</Highlight>
+/>
 ```
 
 Use the `data-sh-*` attributes and `--sh-*` variables for new styles. The package temporarily

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -52,6 +52,59 @@ The core React entry does not include the complete language registry or a client
 default entry remains the convenient choice when string language names and title-based detection
 are more important than selecting the smallest bundle.
 
+### Headless highlighting
+
+`Highlight` keeps parsing and generated token properties while giving you complete control over
+the markup. It is server-compatible and accepts the same selective language imports, `cx`, `mark`,
+and `markLine` options as core `Code`.
+
+```tsx
+import { Highlight } from '@sugar-high/react/core'
+import * as typescript from 'sugar-high/lang/typescript'
+
+<Highlight
+  code={source}
+  lang={typescript}
+  markLine={(line) => {
+    if (line.annotations.includes('focus')) line.properties['data-focus'] = true
+  }}
+>
+  {({ lines }) => (
+    <pre>
+      {lines.map((line, index) => (
+        <div key={index} {...line.properties}>
+          {line.tokens.map((token, tokenIndex) => (
+            <span key={tokenIndex} {...token.properties}>
+              {token.value}
+            </span>
+          ))}
+        </div>
+      ))}
+    </pre>
+  )}
+</Highlight>
+```
+
+The result is not limited to code-block markup. For example, render each generated line as a table
+row for a diff or virtualized viewer:
+
+```tsx
+<Highlight code={source} lang={typescript}>
+  {({ lines }) => (
+    <table>
+      <tbody>
+        {lines.map((line, index) => (
+          <tr key={index}>
+            <th>{index + 1}</th>
+            <td>{line.tokens.map((token) => token.value).join('')}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )}
+</Highlight>
+```
+
 Use the `data-sh-*` attributes and `--sh-*` variables for new styles. The package temporarily
 preserves Codice's existing `data-codice-*` attributes so existing structural selectors can
 migrate incrementally.

--- a/packages/react/scripts/benchmark.mjs
+++ b/packages/react/scripts/benchmark.mjs
@@ -41,10 +41,13 @@ try {
       import * as python from 'sugar-high/lang/python'
       export const render = code => createElement(
         Highlight,
-        { code, lang: python },
-        ({ lines }) => createElement('pre', null, lines.map((line, index) =>
-          createElement('span', { key: index, ...line.properties }, line.tokens.map(token => token.value))
-        ))
+        {
+          code,
+          lang: python,
+          render: ({ lines }) => createElement('pre', null, lines.map((line, index) =>
+            createElement('span', { key: index, ...line.properties }, line.tokens.map(token => token.value))
+          )),
+        }
       )
     `),
     measure('core-python-json-css', `

--- a/packages/react/scripts/benchmark.mjs
+++ b/packages/react/scripts/benchmark.mjs
@@ -35,6 +35,18 @@ try {
       import * as python from 'sugar-high/lang/python'
       export const render = code => createElement(Code, { lang: python }, code)
     `),
+    measure('headless-python', `
+      import { createElement } from 'react'
+      import { Highlight } from '@sugar-high/react/core'
+      import * as python from 'sugar-high/lang/python'
+      export const render = code => createElement(
+        Highlight,
+        { code, lang: python },
+        ({ lines }) => createElement('pre', null, lines.map((line, index) =>
+          createElement('span', { key: index, ...line.properties }, line.tokens.map(token => token.value))
+        ))
+      )
+    `),
     measure('core-python-json-css', `
       import { createElement } from 'react'
       import { Code } from '@sugar-high/react/core'

--- a/packages/react/src/core.test.tsx
+++ b/packages/react/src/core.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { renderToString } from 'react-dom/server'
 import * as python from 'sugar-high/lang/python'
-import { Code } from './core'
+import { Code, Highlight } from './core'
 
 describe('core Code', () => {
   it('renders an imported language configuration on the server', () => {
@@ -11,5 +11,43 @@ describe('core Code', () => {
 
     expect(html).toContain('sh__token--keyword')
     expect(html).toContain('sh__token--comment')
+  })
+
+  it('provides generated lines and tokens to custom server markup', () => {
+    const html = renderToString(
+      <Highlight
+        code={'def hello(): # greeting'}
+        lang={python}
+        mark={(token) => {
+          if (token.type === 'comment') token.properties['data-note'] = 'greeting'
+        }}
+        markLine={(line) => {
+          line.properties['data-line'] = line.index + 1
+        }}
+      >
+        {({ lines }) => (
+          <ol>
+            {lines.map((line, index) => (
+              <li key={index} {...line.properties}>
+                {line.tokens.map((token, tokenIndex) => (
+                  <b
+                    key={tokenIndex}
+                    {...token.properties}
+                    data-token-type={token.tokenType}
+                  >
+                    {token.value}
+                  </b>
+                ))}
+              </li>
+            ))}
+          </ol>
+        )}
+      </Highlight>
+    )
+
+    expect(html).toContain('<ol>')
+    expect(html).toContain('data-line="1"')
+    expect(html).toContain('data-token-type="keyword"')
+    expect(html).toContain('data-note="greeting"')
   })
 })

--- a/packages/react/src/core.test.tsx
+++ b/packages/react/src/core.test.tsx
@@ -24,8 +24,7 @@ describe('core Code', () => {
         markLine={(line) => {
           line.properties['data-line'] = line.index + 1
         }}
-      >
-        {({ lines }) => (
+        render={({ lines }) => (
           <ol>
             {lines.map((line, index) => (
               <li key={index} {...line.properties}>
@@ -42,7 +41,7 @@ describe('core Code', () => {
             ))}
           </ol>
         )}
-      </Highlight>
+      />
     )
 
     expect(html).toContain('<ol>')

--- a/packages/react/src/core.ts
+++ b/packages/react/src/core.ts
@@ -1,1 +1,8 @@
 export { Code, type CodeProps } from './code/code'
+export {
+  Highlight,
+  type HighlightLine,
+  type HighlightProps,
+  type HighlightResult,
+  type HighlightToken,
+} from './highlight'

--- a/packages/react/src/core.ts
+++ b/packages/react/src/core.ts
@@ -1,8 +1,2 @@
 export { Code, type CodeProps } from './code/code'
-export {
-  Highlight,
-  type HighlightLine,
-  type HighlightProps,
-  type HighlightResult,
-  type HighlightToken,
-} from './highlight'
+export { Highlight, type HighlightProps } from './highlight'

--- a/packages/react/src/highlight.tsx
+++ b/packages/react/src/highlight.tsx
@@ -7,15 +7,15 @@ import {
   type ParseOptions,
 } from 'sugar-high/core'
 
-export type HighlightToken = Omit<GeneratedToken, 'children'> & {
+type HighlightToken = Omit<GeneratedToken, 'children'> & {
   value: string
 }
 
-export type HighlightLine = Omit<GeneratedLine, 'children'> & {
+type HighlightLine = Omit<GeneratedLine, 'children'> & {
   tokens: HighlightToken[]
 }
 
-export type HighlightResult = {
+type HighlightResult = {
   lines: HighlightLine[]
 }
 

--- a/packages/react/src/highlight.tsx
+++ b/packages/react/src/highlight.tsx
@@ -23,11 +23,11 @@ export type HighlightProps = DisplayOptions & {
   code: string
   /** Language configuration imported from `sugar-high/lang/<language>`. */
   lang?: ParseOptions
-  children: (result: HighlightResult) => React.ReactNode
+  render: (result: HighlightResult) => React.ReactNode
 }
 
 /** Parse and generate highlighted tokens while leaving all React markup to the consumer. */
-export function Highlight({ code, lang, cx, mark, markLine, children }: HighlightProps) {
+export function Highlight({ code, lang, cx, mark, markLine, render }: HighlightProps) {
   const lines = generate(parse(code, lang), { cx, mark, markLine }).map(
     ({ children: generatedTokens, ...line }): HighlightLine => ({
       ...line,
@@ -38,5 +38,5 @@ export function Highlight({ code, lang, cx, mark, markLine, children }: Highligh
     })
   )
 
-  return children({ lines })
+  return render({ lines })
 }

--- a/packages/react/src/highlight.tsx
+++ b/packages/react/src/highlight.tsx
@@ -1,0 +1,42 @@
+import {
+  generate,
+  parse,
+  type DisplayOptions,
+  type GeneratedLine,
+  type GeneratedToken,
+  type ParseOptions,
+} from 'sugar-high/core'
+
+export type HighlightToken = Omit<GeneratedToken, 'children'> & {
+  value: string
+}
+
+export type HighlightLine = Omit<GeneratedLine, 'children'> & {
+  tokens: HighlightToken[]
+}
+
+export type HighlightResult = {
+  lines: HighlightLine[]
+}
+
+export type HighlightProps = DisplayOptions & {
+  code: string
+  /** Language configuration imported from `sugar-high/lang/<language>`. */
+  lang?: ParseOptions
+  children: (result: HighlightResult) => React.ReactNode
+}
+
+/** Parse and generate highlighted tokens while leaving all React markup to the consumer. */
+export function Highlight({ code, lang, cx, mark, markLine, children }: HighlightProps) {
+  const lines = generate(parse(code, lang), { cx, mark, markLine }).map(
+    ({ children: generatedTokens, ...line }): HighlightLine => ({
+      ...line,
+      tokens: generatedTokens.map(({ children: text, ...token }) => ({
+        ...token,
+        value: text[0].value,
+      })),
+    })
+  )
+
+  return children({ lines })
+}


### PR DESCRIPTION
Closes #230

## Summary

Add a server-compatible, headless `Highlight` primitive to `@sugar-high/react/core`. Consumers retain complete control of root, line, and token markup while receiving generated properties, token types, and normalized token values. It works with selective language imports and the existing `cx`, `mark`, and `markLine` hooks.

```tsx
import { Highlight } from "@sugar-high/react/core"
import * as typescript from "sugar-high/lang/typescript"

<Highlight
  code={source}
  lang={typescript}
  render={({ lines }) => (
    <pre>
      {lines.map((line, index) => (
        <div key={index} {...line.properties}>
          {line.tokens.map((token, tokenIndex) => (
            <span key={tokenIndex} {...token.properties}>
              {token.value}
            </span>
          ))}
        </div>
      ))}
    </pre>
  )}
/>
```

## Bundle size

- Headless + Python: 5.72 KiB minified / 2.49 KiB gzip
- Core `Code` + Python: 7.96 KiB minified / 3.30 KiB gzip
- Default React entry: 30.21 KiB minified / 10.76 KiB gzip