### PR TITLE
Avoid major bumps for compatible peer updates

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,6 +7,9 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  },
   "privatePackages": {
     "version": false,
     "tag": false


### PR DESCRIPTION
## Summary

Configure Changesets to bump peer dependents only when the new peer version falls outside their supported range. This prevents compatible `sugar-high` releases from turning an intended `@sugar-high/react` minor release into a major release.

The current release plan now resolves to:

- `sugar-high`: 2.0.3 → 2.1.0
- `@sugar-high/react`: 2.0.0 → 2.1.0

After this merges, the Changesets action will regenerate release PR #225 with the corrected versions.