### PR TITLE
Simplify the manual publish workflow

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -2,8 +2,8 @@
 
 Run `pnpm changeset` for every user-facing package change and commit the generated Markdown file.
 After changes land on `main`, Changesets maintains a release PR. Merging that PR updates package
-versions but does not publish anything. Publishing requires manually running the `Release` workflow
-from GitHub Actions and entering `publish` in its confirmation field.
+versions but does not publish anything. Publishing requires manually running the `Publish` workflow
+from GitHub Actions on `main`.
 
 Publishing uses npm trusted publishing through GitHub Actions OIDC; no npm access token is stored.
 Configure `sugar-high`, `@sugar-high/react`, and `@sugar-high/remark` on npm to trust this repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,11 +5,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-    inputs:
-      confirm:
-        description: Type "publish" to release packages to npm
-        required: true
-        type: string
 
 permissions: {}
 
@@ -48,7 +43,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
   publish:
-    if: github.event_name == 'workflow_dispatch' && inputs.confirm == 'publish'
+    if: github.event_name == 'workflow_dispatch'
     concurrency:
       group: npm-publish
       cancel-in-progress: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@
 
 - Pushes to `main` may create/update the Changesets version PR but must never publish packages.
 - Merge the version PR to apply versions and changelogs.
-- Publishing is manual: Actions → Publish → Run workflow on `main`, with confirmation `publish`.
+- Publishing is manual: Actions → Publish → Run workflow on `main`.
 - npm publishing uses trusted publishing through OIDC. Do not add npm tokens or publish directly
   from CI.
 - The manual publish job uses Changesets to create package tags and GitHub Releases from the


### PR DESCRIPTION
## Summary

Remove the `publish` confirmation text field from the manual Publish workflow. Publishing remains an explicit Actions → Publish → Run workflow operation on `main`, while pushes to `main` continue to update only the Changesets release PR.

The repository release instructions now match the simplified workflow.