### PR TITLE
Add Ruby and plaintext language support

### DIFF
--- a/.changeset/bright-rubies-highlight.md
+++ b/.changeset/bright-rubies-highlight.md
@@ -1,0 +1,5 @@
+---
+'sugar-high': minor
+---
+
+Add built-in Ruby and plaintext language configurations.

--- a/docs/API.md
+++ b/docs/API.md
@@ -83,6 +83,8 @@ input map to that canonical name. Canonical names themselves are always accepted
 | `html` | `.html` | `htm`, `xml` |
 | `yaml` | `.yaml` | `yml` |
 | `markdown` | `.md` | `md`, `mdx` |
+| `plaintext` | `.txt` | `text`, `plain` |
+| `ruby` | `.rb` | — |
 | `kotlin` | `.kt` | `kts` |
 | `swift` | `.swift` | — |
 | `php` | `.php` | — |

--- a/packages/sugar-high/README.md
+++ b/packages/sugar-high/README.md
@@ -56,8 +56,8 @@ behavior.
 ## Built-in languages
 
 `javascript`, `typescript`, `css`, `python`, `c`, `go`, `java`, `rust`, `json`, `diff`, `shell`,
-`cpp`, `csharp`, `sql`, `html`, `yaml`, `markdown`, `kotlin`, `swift`, `php`, `toml`, `powershell`,
-`dockerfile`, `graphql`, and `hcl`.
+`cpp`, `csharp`, `sql`, `html`, `yaml`, `markdown`, `plaintext`, `ruby`, `kotlin`, `swift`, `php`,
+`toml`, `powershell`, `dockerfile`, `graphql`, and `hcl`.
 
 Related dialects share one implementation: JavaScript includes JSX, TypeScript includes TSX, JSON
 includes JSONC comments, Shell includes sh/Bash/Zsh, and HCL includes Terraform.

--- a/packages/sugar-high/lib/index.d.ts
+++ b/packages/sugar-high/lib/index.d.ts
@@ -25,6 +25,8 @@ export type LanguageName =
   | 'html'
   | 'yaml'
   | 'markdown'
+  | 'plaintext'
+  | 'ruby'
   | 'kotlin'
   | 'swift'
   | 'php'

--- a/packages/sugar-high/lib/lang.js
+++ b/packages/sugar-high/lib/lang.js
@@ -16,8 +16,10 @@ import * as javascript from './lang/javascript.js'
 import * as kotlin from './lang/kotlin.js'
 import * as markdown from './lang/markdown.js'
 import * as php from './lang/php.js'
+import * as plaintext from './lang/plaintext.js'
 import * as powershell from './lang/powershell.js'
 import * as python from './lang/python.js'
+import * as ruby from './lang/ruby.js'
 import * as rust from './lang/rust.js'
 import * as shell from './lang/shell.js'
 import * as sql from './lang/sql.js'
@@ -69,6 +71,8 @@ const languages = [
   { id: 'html', extension: 'html', aliases: ['htm', 'xml'], config: html },
   { id: 'yaml', extension: 'yaml', aliases: ['yml'], config: nonJavaScript(yaml) },
   { id: 'markdown', extension: 'md', aliases: ['md', 'mdx'], config: nonJavaScript(markdown) },
+  { id: 'plaintext', extension: 'txt', aliases: ['text', 'plain'], config: nonJavaScript(plaintext) },
+  { id: 'ruby', extension: 'rb', aliases: [], config: nonJavaScript(ruby) },
   { id: 'kotlin', extension: 'kt', aliases: ['kts'], config: nonJavaScript(kotlin) },
   { id: 'swift', extension: 'swift', aliases: [], config: nonJavaScript(swift) },
   { id: 'php', extension: 'php', aliases: [], config: nonJavaScript(php) },

--- a/packages/sugar-high/lib/lang/plaintext.d.ts
+++ b/packages/sugar-high/lib/lang/plaintext.d.ts
@@ -1,0 +1,1 @@
+export function tokenize(code: string): Array<[number, string]>;

--- a/packages/sugar-high/lib/lang/plaintext.js
+++ b/packages/sugar-high/lib/lang/plaintext.js
@@ -1,0 +1,5 @@
+// @ts-check
+import { T_IDENTIFIER } from '../shared.js'
+
+/** @param {string} code */
+export const tokenize = (code) => [[T_IDENTIFIER, code]]

--- a/packages/sugar-high/lib/lang/ruby.d.ts
+++ b/packages/sugar-high/lib/lang/ruby.d.ts
@@ -1,0 +1,13 @@
+export const keywords: Set<string>;
+export function onCommentStart(
+  curr: string,
+  next: string,
+  index: number,
+  code: string,
+): 0 | 1 | 2;
+export function onCommentEnd(
+  prev: string,
+  curr: string,
+  index: number,
+  code: string,
+): 0 | 1 | 2;

--- a/packages/sugar-high/lib/lang/ruby.js
+++ b/packages/sugar-high/lib/lang/ruby.js
@@ -1,0 +1,41 @@
+// @ts-check
+
+export const keywords = new Set([
+  'BEGIN', 'END', '__ENCODING__', '__FILE__', '__LINE__', 'alias', 'and', 'begin', 'break',
+  'case', 'class', 'def', 'defined', 'do', 'else', 'elsif', 'end', 'ensure', 'false', 'for', 'if',
+  'in', 'module', 'next', 'nil', 'not', 'or', 'redo', 'rescue', 'retry', 'return', 'self', 'super',
+  'then', 'true', 'undef', 'unless', 'until', 'when', 'while', 'yield',
+])
+
+/** @param {number} index @param {string} code */
+function isBlockCommentStart(index, code) {
+  if (index > 0 && code[index - 1] !== '\n') return false
+  return /^=begin(?:\s|$)/.test(code.slice(index))
+}
+
+/**
+ * @param {string} curr
+ * @param {string} _next
+ * @param {number} index
+ * @param {string} code
+ */
+export function onCommentStart(curr, _next, index, code) {
+  if (curr === '#') return 1
+  if (curr === '=' && isBlockCommentStart(index, code)) return 2
+  return 0
+}
+
+/**
+ * @param {string} _prev
+ * @param {string} curr
+ * @param {number} index
+ * @param {string} code
+ */
+export function onCommentEnd(_prev, curr, index, code) {
+  if (curr !== '\n') return 0
+
+  const lineStart = code.lastIndexOf('\n', index - 1) + 1
+  const line = code.slice(lineStart, index)
+  if (/^=end(?:\s|$)/.test(line)) return 2
+  return 1
+}

--- a/packages/sugar-high/test/languages.test.ts
+++ b/packages/sugar-high/test/languages.test.ts
@@ -4,7 +4,9 @@ import * as core from 'sugar-high/core'
 import { lang, languages } from 'sugar-high/lang'
 import * as css from 'sugar-high/lang/css'
 import * as json from 'sugar-high/lang/json'
+import * as plaintext from 'sugar-high/lang/plaintext'
 import * as python from 'sugar-high/lang/python'
+import * as ruby from 'sugar-high/lang/ruby'
 import { getTokensAsString } from './testing-utils'
 
 const tokenize = (code, { lang }) =>
@@ -19,6 +21,10 @@ describe('language registry', () => {
     expect(core.render(core.parse('def run():', python))).toContain('sh__token--keyword')
     expect(core.render(core.parse('{"ready": true}', json))).toContain('sh__token--property')
     expect(core.render(core.parse('body { color: red; }', css))).toContain('sh__token--property')
+    expect(core.render(core.parse('class Greeter', ruby))).toContain('sh__token--keyword')
+    expect(core.parse('"plain" # text', plaintext).lines[0].tokens).toEqual([
+      { type: 'identifier', value: '"plain" # text' },
+    ])
   })
 
   it.each([
@@ -46,6 +52,9 @@ describe('language registry', () => {
     ['gql', 'graphql'],
     ['terraform', 'hcl'],
     ['tf', 'hcl'],
+    ['rb', 'ruby'],
+    ['txt', 'plaintext'],
+    ['text', 'plaintext'],
   ])('resolves %s to %s', (input, expected) => {
     expect(lang(input)).toBe(expected)
   })

--- a/packages/sugar-high/test/preset/plaintext.test.ts
+++ b/packages/sugar-high/test/preset/plaintext.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { parse } from '../../lib/core.js'
+import * as plaintext from '../../lib/lang/plaintext.js'
+
+describe('tokenize - plaintext preset', () => {
+  it('preserves lines without assigning syntax token types', () => {
+    const input = 'A "quoted" value: true # still text\nAnother line'
+    const parsed = parse(input, plaintext)
+
+    expect(parsed.lines.map(({ value }) => value)).toEqual([
+      'A "quoted" value: true # still text',
+      'Another line',
+    ])
+    expect(
+      new Set(
+        parsed.lines.flatMap(({ tokens }) => tokens.map(({ type }) => type)),
+      ),
+    ).toEqual(new Set(['identifier']))
+  })
+})

--- a/packages/sugar-high/test/preset/ruby.test.ts
+++ b/packages/sugar-high/test/preset/ruby.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { tokenize } from '../../lib/core.js'
+import * as ruby from '../../lib/lang/ruby.js'
+import { getTokensAsString } from '../testing-utils'
+
+describe('tokenize - Ruby preset', () => {
+  it('highlights keywords, strings, and line comments', () => {
+    const input = [
+      'class Greeter',
+      '  # Says hello',
+      '  def greet(name)',
+      '    puts "Hello, #{name}" if defined?(name)',
+      '  end',
+      'end',
+    ].join('\n')
+    const actual = getTokensAsString(tokenize(input, ruby))
+
+    expect(actual).toContain('class => keyword')
+    expect(actual).toContain('def => keyword')
+    expect(actual).toContain('if => keyword')
+    expect(actual).toContain('defined => keyword')
+    expect(actual).toContain('"Hello, #{name}" => string')
+    expect(actual).toContain('# Says hello => comment')
+  })
+
+  it('highlights block comments', () => {
+    const input = '=begin\nDocumentation\n=end\nclass Greeter\nend'
+    const actual = getTokensAsString(tokenize(input, ruby))
+
+    expect(actual).toContain('=begin\nDocumentation\n=end => comment')
+    expect(actual).toContain('class => keyword')
+    expect(actual).toContain('end => keyword')
+  })
+})


### PR DESCRIPTION
## Summary

Add first-class Ruby and plaintext language configurations to Sugar High.

- Highlight Ruby keywords, strings, line comments, and block comments.
- Preserve plaintext as neutral identifier tokens across multiple lines.
- Register `ruby`, `rb`, `plaintext`, `txt`, `text`, and `plain` language inputs.

## Problem

Ruby currently falls through to the general-purpose lexer without Ruby keywords or comment rules. Plaintext also uses that lexer, causing quotes, punctuation, and keyword-like values to receive syntax colors.

## Solution

Add dedicated `sugar-high/lang/ruby` and `sugar-high/lang/plaintext` configurations, expose both through the built-in registry and `LanguageName`, document their mappings, and cover direct imports, aliases, tokenization, and multiline behavior.

## Bundle size

| Entry | Base gzip | PR gzip | Change |
| --- | ---: | ---: | ---: |
| `sugar-high` | 8.95 KiB | 9.25 KiB | +308 B (+3.4%) |
| `sugar-high/core` | 1.70 KiB | 1.70 KiB | — |

Current `sugar-high` size is 25.56 KiB minified and 9.25 KiB gzip.

## Testing

- `pnpm test` — 195 tests passed across Sugar High, React, and Remark.
- `pnpm check:packages` — passed.
- `pnpm --filter sugar-high benchmark` — passed.
- `git diff --check` — passed.
- Package builds for `sugar-high`, `@sugar-high/react`, and `@sugar-high/remark` passed; the unrelated site build was not completed locally.
