### PR TITLE
Shrink the default language registry bundle

### DIFF
--- a/.changeset/tidy-bags-smile.md
+++ b/.changeset/tidy-bags-smile.md
@@ -1,0 +1,6 @@
+---
+'sugar-high': patch
+---
+
+Reduce the default bundle size by keeping language aliases and extension metadata out of the
+canonical highlighting path.

--- a/packages/sugar-high/lib/index.js
+++ b/packages/sugar-high/lib/index.js
@@ -4,11 +4,11 @@ import {
   parse,
   render,
 } from './core.js'
-import { languages } from './lang.js'
+import { configs } from './presets/configs.js'
 
 /** @param {string | undefined} name */
 function configFor(name) {
-  return languages.find(({ id }) => id === (name || 'javascript'))?.config
+  return configs[name || 'javascript']
 }
 
 /** @param {string} code @param {HighlightOptions | undefined} options */

--- a/packages/sugar-high/lib/index.js
+++ b/packages/sugar-high/lib/index.js
@@ -4,12 +4,7 @@ import {
   parse,
   render,
 } from './core.js'
-import { configs } from './presets/configs.js'
-
-/** @param {string | undefined} name */
-function configFor(name) {
-  return configs[name || 'javascript']
-}
+import { configFor } from './presets/configs.js'
 
 /** @param {string} code @param {HighlightOptions | undefined} options */
 function highlight(code, options) {

--- a/packages/sugar-high/lib/lang.js
+++ b/packages/sugar-high/lib/lang.js
@@ -1,32 +1,10 @@
 // @ts-check
 
-import * as c from './lang/c.js'
-import * as cpp from './lang/cpp.js'
-import * as csharp from './lang/csharp.js'
-import * as css from './lang/css.js'
-import * as diff from './lang/diff.js'
-import * as dockerfile from './lang/dockerfile.js'
-import * as go from './lang/go.js'
-import * as html from './lang/html.js'
-import * as graphql from './lang/graphql.js'
-import * as hcl from './lang/hcl.js'
-import * as java from './lang/java.js'
-import * as json from './lang/json.js'
-import * as javascript from './lang/javascript.js'
-import * as kotlin from './lang/kotlin.js'
-import * as markdown from './lang/markdown.js'
-import * as php from './lang/php.js'
-import * as plaintext from './lang/plaintext.js'
-import * as powershell from './lang/powershell.js'
-import * as python from './lang/python.js'
-import * as ruby from './lang/ruby.js'
-import * as rust from './lang/rust.js'
-import * as shell from './lang/shell.js'
-import * as sql from './lang/sql.js'
-import * as swift from './lang/swift.js'
-import * as toml from './lang/toml.js'
-import * as typescript from './lang/typescript.js'
-import * as yaml from './lang/yaml.js'
+import {
+  c, cpp, csharp, css, diff, dockerfile, go, graphql, hcl, html, java, javascript, json,
+  kotlin, markdown, nonJavaScript, php, plaintext, powershell, python, ruby, rust, shell, sql,
+  swift, toml, typescript, yaml,
+} from './presets/configs.js'
 
 /**
  * @typedef {import('./core.js').ParseOptions} ParseOptions
@@ -37,20 +15,6 @@ import * as yaml from './lang/yaml.js'
  *   config?: ParseOptions
  * }} Language
  */
-
-/**
- * Disable JavaScript-only scanner modes for a non-JavaScript language.
- * @param {ParseOptions} config
- * @returns {ParseOptions}
- */
-function nonJavaScript(config) {
-  return {
-    ...config,
-    jsx: false,
-    regex: false,
-    templateStrings: false,
-  }
-}
 
 /** @type {readonly Language[]} */
 const languages = [

--- a/packages/sugar-high/lib/presets/configs.js
+++ b/packages/sugar-high/lib/presets/configs.js
@@ -1,0 +1,76 @@
+// @ts-check
+
+import * as c from '../lang/c.js'
+import * as cpp from '../lang/cpp.js'
+import * as csharp from '../lang/csharp.js'
+import * as css from '../lang/css.js'
+import * as diff from '../lang/diff.js'
+import * as dockerfile from '../lang/dockerfile.js'
+import * as go from '../lang/go.js'
+import * as graphql from '../lang/graphql.js'
+import * as hcl from '../lang/hcl.js'
+import * as html from '../lang/html.js'
+import * as java from '../lang/java.js'
+import * as javascript from '../lang/javascript.js'
+import * as json from '../lang/json.js'
+import * as kotlin from '../lang/kotlin.js'
+import * as markdown from '../lang/markdown.js'
+import * as php from '../lang/php.js'
+import * as plaintext from '../lang/plaintext.js'
+import * as powershell from '../lang/powershell.js'
+import * as python from '../lang/python.js'
+import * as ruby from '../lang/ruby.js'
+import * as rust from '../lang/rust.js'
+import * as shell from '../lang/shell.js'
+import * as sql from '../lang/sql.js'
+import * as swift from '../lang/swift.js'
+import * as toml from '../lang/toml.js'
+import * as typescript from '../lang/typescript.js'
+import * as yaml from '../lang/yaml.js'
+
+/**
+ * Disable JavaScript-only scanner modes for a non-JavaScript language.
+ * @param {import('../core.js').ParseOptions} config
+ * @returns {import('../core.js').ParseOptions}
+ */
+function nonJavaScript(config) {
+  return {
+    ...config,
+    jsx: false,
+    regex: false,
+    templateStrings: false,
+  }
+}
+
+/** @type {Record<string, import('../core.js').ParseOptions>} */
+const configs = {
+  javascript,
+  typescript,
+  css: nonJavaScript(css),
+  python: nonJavaScript(python),
+  c: nonJavaScript(c),
+  go: nonJavaScript(go),
+  java: nonJavaScript(java),
+  rust: nonJavaScript(rust),
+  json: nonJavaScript(json),
+  diff: nonJavaScript(diff),
+  shell: nonJavaScript(shell),
+  cpp: nonJavaScript(cpp),
+  csharp: nonJavaScript(csharp),
+  sql: nonJavaScript(sql),
+  html,
+  yaml: nonJavaScript(yaml),
+  markdown: nonJavaScript(markdown),
+  plaintext: nonJavaScript(plaintext),
+  ruby: nonJavaScript(ruby),
+  kotlin: nonJavaScript(kotlin),
+  swift: nonJavaScript(swift),
+  php: nonJavaScript(php),
+  toml: nonJavaScript(toml),
+  powershell: nonJavaScript(powershell),
+  dockerfile: nonJavaScript(dockerfile),
+  graphql: nonJavaScript(graphql),
+  hcl: nonJavaScript(hcl),
+}
+
+export { configs }

--- a/packages/sugar-high/lib/presets/configs.js
+++ b/packages/sugar-high/lib/presets/configs.js
@@ -42,35 +42,47 @@ function nonJavaScript(config) {
   }
 }
 
-/** @type {Record<string, import('../core.js').ParseOptions>} */
-const configs = {
-  javascript,
-  typescript,
-  css: nonJavaScript(css),
-  python: nonJavaScript(python),
-  c: nonJavaScript(c),
-  go: nonJavaScript(go),
-  java: nonJavaScript(java),
-  rust: nonJavaScript(rust),
-  json: nonJavaScript(json),
-  diff: nonJavaScript(diff),
-  shell: nonJavaScript(shell),
-  cpp: nonJavaScript(cpp),
-  csharp: nonJavaScript(csharp),
-  sql: nonJavaScript(sql),
-  html,
-  yaml: nonJavaScript(yaml),
-  markdown: nonJavaScript(markdown),
-  plaintext: nonJavaScript(plaintext),
-  ruby: nonJavaScript(ruby),
-  kotlin: nonJavaScript(kotlin),
-  swift: nonJavaScript(swift),
-  php: nonJavaScript(php),
-  toml: nonJavaScript(toml),
-  powershell: nonJavaScript(powershell),
-  dockerfile: nonJavaScript(dockerfile),
-  graphql: nonJavaScript(graphql),
-  hcl: nonJavaScript(hcl),
+function createConfigs() {
+  return {
+    javascript,
+    typescript,
+    css: nonJavaScript(css),
+    python: nonJavaScript(python),
+    c: nonJavaScript(c),
+    go: nonJavaScript(go),
+    java: nonJavaScript(java),
+    rust: nonJavaScript(rust),
+    json: nonJavaScript(json),
+    diff: nonJavaScript(diff),
+    shell: nonJavaScript(shell),
+    cpp: nonJavaScript(cpp),
+    csharp: nonJavaScript(csharp),
+    sql: nonJavaScript(sql),
+    html,
+    yaml: nonJavaScript(yaml),
+    markdown: nonJavaScript(markdown),
+    plaintext: nonJavaScript(plaintext),
+    ruby: nonJavaScript(ruby),
+    kotlin: nonJavaScript(kotlin),
+    swift: nonJavaScript(swift),
+    php: nonJavaScript(php),
+    toml: nonJavaScript(toml),
+    powershell: nonJavaScript(powershell),
+    dockerfile: nonJavaScript(dockerfile),
+    graphql: nonJavaScript(graphql),
+    hcl: nonJavaScript(hcl),
+  }
 }
 
-export { configs }
+const configs = /* @__PURE__ */ createConfigs()
+
+/** @param {string | undefined} name */
+function configFor(name) {
+  return configs[name || 'javascript']
+}
+
+export {
+  c, configFor, configs, cpp, csharp, css, diff, dockerfile, go, graphql, hcl, html, java,
+  javascript, json, kotlin, markdown, nonJavaScript, php, plaintext, powershell, python, ruby,
+  rust, shell, sql, swift, toml, typescript, yaml,
+}

--- a/packages/sugar-high/test/languages.test.ts
+++ b/packages/sugar-high/test/languages.test.ts
@@ -7,12 +7,17 @@ import * as json from 'sugar-high/lang/json'
 import * as plaintext from 'sugar-high/lang/plaintext'
 import * as python from 'sugar-high/lang/python'
 import * as ruby from 'sugar-high/lang/ruby'
+import { configs } from '../lib/presets/configs.js'
 import { getTokensAsString } from './testing-utils'
 
 const tokenize = (code, { lang }) =>
   core.tokenize(code, languages.find(({ id }) => id === lang)?.config)
 
 describe('language registry', () => {
+  it('keeps canonical configs aligned with public language metadata', () => {
+    expect(Object.keys(configs)).toEqual(languages.map(({ id }) => id))
+  })
+
   it.each(languages.map(({ id }) => id))('exports %s as an individual configuration', async (id) => {
     expect(Object.keys(await import(`sugar-high/lang/${id}`))).not.toHaveLength(0)
   })


### PR DESCRIPTION
## Summary

- use a focused internal canonical configuration map for the default `highlight()` entry
- keep alias normalization, extension metadata, and duplicate validation isolated to `sugar-high/lang`
- add a test that keeps the canonical configs aligned with public language metadata

The public API and all 27 built-in language configurations remain unchanged.

## Bundle size

| Entry | Base min/gzip/Brotli | PR min/gzip/Brotli | Gzip change |
| --- | ---: | ---: | ---: |
| `sugar-high` | 25.61 / 9.24 / 8.37 KiB | 24.04 / 8.83 / 7.94 KiB | -0.41 KiB (-4.4%) |
| `sugar-high/core` | 4.00 / 1.79 / 1.60 KiB | 4.00 / 1.79 / 1.60 KiB | unchanged |
| core + JavaScript | 9.86 / 4.33 / 3.95 KiB | 9.86 / 4.33 / 3.95 KiB | unchanged |

The separate `sugar-high/lang` metadata entry keeps the same minified size. Both entries share the language imports and the non-JavaScript configuration helper; a pure factory lets bundlers remove the root-only lookup from the metadata entry.

## Validation

- `pnpm test` — 201 tests passed
- `pnpm build`
- `pnpm --filter sugar-high benchmark`
- `pnpm check:packages`
- `git diff --check`
