### PR TITLE
ci: Fix package checks before publishing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,13 @@
 - Add a Changeset with `pnpm changeset` for user-facing package changes. Do not add one for
   internal-only work unless requested.
 
+# Pull requests
+
+- Prefix pull request titles by change type: `feat:` for features, `fix:` for patches and bug
+  fixes, and `ci:` for CI, workflow, and release-process fixes.
+- Follow the prefix with a concise imperative title, for example `ci: Fix package checks before
+  publishing`.
+
 # Architecture
 
 - Keep the default API focused on the common path. Put advanced composition in existing subpaths

--- a/scripts/check-packages.mjs
+++ b/scripts/check-packages.mjs
@@ -12,6 +12,8 @@ const run = (command, args, cwd = root) => execFileSync(command, args, {
   stdio: 'inherit',
 })
 
+// Package managers set npm_execpath for scripts. Reuse it so nested commands run
+// the same pnpm version.
 const runPnpm = (args, cwd = root) => process.env.npm_execpath
   ? run(process.env.npm_execpath, args, cwd)
   : run('pnpm', args, cwd)

--- a/scripts/check-packages.mjs
+++ b/scripts/check-packages.mjs
@@ -12,8 +12,12 @@ const run = (command, args, cwd = root) => execFileSync(command, args, {
   stdio: 'inherit',
 })
 
+const runPnpm = (args, cwd = root) => process.env.npm_execpath
+  ? run(process.env.npm_execpath, args, cwd)
+  : run('pnpm', args, cwd)
+
 const pack = (directory, name) => {
-  run('pnpm', ['pack', '--pack-destination', temporary], join(root, directory))
+  runPnpm(['pack', '--pack-destination', temporary], join(root, directory))
   return join(temporary, readdirSync(temporary).find(file => file.startsWith(name) && file.endsWith('.tgz')))
 }
 
@@ -32,12 +36,14 @@ try {
       react: '^19.2.0',
       'sugar-high': `file:${sugarHigh}`,
     },
-    pnpm: {
-      overrides: {
-        '@sugar-high/remark>sugar-high': `file:${sugarHigh}`,
-      },
-    },
   }, null, 2))
+
+  writeFileSync(join(temporary, 'pnpm-workspace.yaml'), `
+packages:
+  - '.'
+overrides:
+  '@sugar-high/remark>sugar-high': ${JSON.stringify(`file:${sugarHigh}`)}
+`)
 
   writeFileSync(join(temporary, 'check.mjs'), `
 import { highlight } from 'sugar-high'
@@ -84,9 +90,9 @@ remarkSugarHigh
 remarkHighlight
 `)
 
-  run('pnpm', ['install', '--prefer-offline', '--ignore-scripts'], temporary)
+  runPnpm(['install', '--prefer-offline', '--ignore-scripts'], temporary)
   run('node', ['check.mjs'], temporary)
-  run('pnpm', [
+  runPnpm([
     '--filter', 'sugar-high', 'exec', 'tsc', '--noEmit', '--strict', '--skipLibCheck',
     '--module', 'NodeNext', '--moduleResolution', 'NodeNext', '--target', 'ES2022',
     join(temporary, 'check.ts'),


### PR DESCRIPTION
## Summary

- configure the temporary package consumer through pnpm-workspace.yaml for pnpm 12
- resolve the remark integration against the freshly packed sugar-high tarball
- keep nested package commands on the pnpm version that launched the smoke test and document npm_execpath
- document feat:, fix:, and ci: pull-request title prefixes in AGENTS.md

This prevents release PR checks from querying npm for a version that has been versioned but not manually published yet.

## Verification

- corepack pnpm check:packages (passed with sugar-high@2.2.2 still unpublished)
- corepack pnpm test
- corepack pnpm build
- git diff --check

No Changeset is needed because this only changes internal CI tooling and contributor guidance.