### PR TITLE
fix: Keep the default editor caret visible

### DIFF
--- a/.changeset/fix-visible-editor-caret.md
+++ b/.changeset/fix-visible-editor-caret.md
@@ -1,0 +1,5 @@
+---
+'@sugar-high/react': patch
+---
+
+Keep the default editor and editable-title caret visible when their text layer is transparent.

--- a/apps/site/app/react/page.tsx
+++ b/apps/site/app/react/page.tsx
@@ -38,7 +38,7 @@ import { taffy } from '@sugar-high/react/themes'
 const styleVariables = [
   ['--sh-editor-text-color', 'Editor', 'transparent', 'Textarea text; transparent over highlighted code.'],
   ['--sh-editor-background-color', 'Editor', 'transparent', 'Textarea background.'],
-  ['--sh-caret-color', 'Both', 'inherit', 'Editor and editable-title caret.'],
+  ['--sh-caret-color', 'Both', 'CanvasText', 'Editor and editable-title caret.'],
   ['--sh-font-family', 'Both', 'Editor monospace; Code inherited', 'Code, textarea, and title font.'],
   ['--sh-font-size', 'Both', 'inherit', 'Code and textarea font size.'],
   ['--sh-padding', 'Both', '1rem', 'Content and header spacing.'],

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -215,7 +215,7 @@ The `--sh-*` variables control both the component frame and syntax tokens; see t
 | --- | --- | --- | --- |
 | `--sh-editor-text-color` | Editor | `transparent` | Textarea text color; normally transparent over highlighted code. |
 | `--sh-editor-background-color` | Editor | `transparent` | Textarea background color. |
-| `--sh-caret-color` | Both | `inherit` | Editor caret and editable title caret. |
+| `--sh-caret-color` | Both | `CanvasText` | Editor caret and editable title caret. |
 | `--sh-font-family` | Both | Editor: `Consolas, Monaco, monospace`; Code: inherited | Code, textarea, and title font family. |
 | `--sh-font-size` | Both | `inherit` | Code and textarea font size. |
 | `--sh-padding` | Both | `1rem` | Shared content and header spacing. |

--- a/packages/react/src/code/code.test.tsx
+++ b/packages/react/src/code/code.test.tsx
@@ -169,7 +169,7 @@ describe('Code', () => {
         background-color: transparent;
         outline: none;
         border: none;
-        caret-color: var(--sh-caret-color);
+        caret-color: var(--sh-caret-color, CanvasText);
         color: var(--sh-title-color);
         font-family: var(--sh-font-family);
       }
@@ -264,7 +264,7 @@ describe('Code', () => {
         background-color: transparent;
         outline: none;
         border: none;
-        caret-color: var(--sh-caret-color);
+        caret-color: var(--sh-caret-color, CanvasText);
         color: var(--sh-title-color);
         font-family: var(--sh-font-family);
       }

--- a/packages/react/src/code/css.ts
+++ b/packages/react/src/code/css.ts
@@ -52,7 +52,7 @@ ${H} [data-sh-title] {
   background-color: transparent;
   outline: none;
   border: none;
-  caret-color: var(--sh-caret-color);
+  caret-color: var(--sh-caret-color, CanvasText);
   color: var(--sh-title-color);
   font-family: var(--sh-font-family);
 }

--- a/packages/react/src/editor/css.ts
+++ b/packages/react/src/editor/css.ts
@@ -5,7 +5,6 @@ export const EDITOR_CSS = `\
 ${R} {
   --sh-editor-text-color: transparent;
   --sh-editor-background-color: transparent;
-  --sh-caret-color: inherit;
 
   position: relative;
   overflow-y: scroll;
@@ -25,7 +24,7 @@ ${R} textarea {
   scrollbar-width: none;
   line-height: 1.5;
   font-size: var(--sh-font-size);
-  caret-color: var(--sh-caret-color);
+  caret-color: var(--sh-caret-color, CanvasText);
   border: none;
   outline: none;
   width: 100%;

--- a/packages/react/src/editor/editor.test.tsx
+++ b/packages/react/src/editor/editor.test.tsx
@@ -83,7 +83,6 @@ describe('Code', () => {
       "<style data-precedence="default" data-href="sugar-high-react-editor sugar-high-react-header sugar-high-react-code">[data-sh-editor] {
         --sh-editor-text-color: transparent;
         --sh-editor-background-color: transparent;
-        --sh-caret-color: inherit;
 
         position: relative;
         overflow-y: scroll;
@@ -103,7 +102,7 @@ describe('Code', () => {
         scrollbar-width: none;
         line-height: 1.5;
         font-size: var(--sh-font-size);
-        caret-color: var(--sh-caret-color);
+        caret-color: var(--sh-caret-color, CanvasText);
         border: none;
         outline: none;
         width: 100%;
@@ -157,7 +156,7 @@ describe('Code', () => {
         background-color: transparent;
         outline: none;
         border: none;
-        caret-color: var(--sh-caret-color);
+        caret-color: var(--sh-caret-color, CanvasText);
         color: var(--sh-title-color);
         font-family: var(--sh-font-family);
       }
@@ -243,7 +242,6 @@ describe('Code', () => {
       "<style data-precedence="default" data-href="sugar-high-react-editor sugar-high-react-header sugar-high-react-code">[data-sh-editor] {
         --sh-editor-text-color: transparent;
         --sh-editor-background-color: transparent;
-        --sh-caret-color: inherit;
 
         position: relative;
         overflow-y: scroll;
@@ -263,7 +261,7 @@ describe('Code', () => {
         scrollbar-width: none;
         line-height: 1.5;
         font-size: var(--sh-font-size);
-        caret-color: var(--sh-caret-color);
+        caret-color: var(--sh-caret-color, CanvasText);
         border: none;
         outline: none;
         width: 100%;
@@ -317,7 +315,7 @@ describe('Code', () => {
         background-color: transparent;
         outline: none;
         border: none;
-        caret-color: var(--sh-caret-color);
+        caret-color: var(--sh-caret-color, CanvasText);
         color: var(--sh-title-color);
         font-family: var(--sh-font-family);
       }
@@ -403,7 +401,6 @@ describe('Code', () => {
       "<style data-precedence="default" data-href="sugar-high-react-editor sugar-high-react-code">[data-sh-editor] {
         --sh-editor-text-color: transparent;
         --sh-editor-background-color: transparent;
-        --sh-caret-color: inherit;
 
         position: relative;
         overflow-y: scroll;
@@ -423,7 +420,7 @@ describe('Code', () => {
         scrollbar-width: none;
         line-height: 1.5;
         font-size: var(--sh-font-size);
-        caret-color: var(--sh-caret-color);
+        caret-color: var(--sh-caret-color, CanvasText);
         border: none;
         outline: none;
         width: 100%;


### PR DESCRIPTION
## Summary

- remove the internal `--sh-caret-color: inherit` assignment that can override consumer styles and resolve through transparent textarea text
- fall back to the system `CanvasText` color for editor and editable-title carets
- preserve custom CSS variable and theme palette overrides
- update React docs, site reference, snapshots, and add a patch changeset

## Verification

- `pnpm test`
- `pnpm build`
- `git diff --check`
- verified `/react` on the local development server: themed caret `rgb(53, 65, 80)`, zero-theme fallback `rgb(0, 0, 0)`, while textarea text remains transparent