### PR TITLE
fix: Preserve multiline C comments

### DIFF
--- a/.changeset/tidy-c-comments.md
+++ b/.changeset/tidy-c-comments.md
@@ -1,0 +1,5 @@
+---
+'sugar-high': patch
+---
+
+Keep multi-line comments highlighted until their closing delimiter in C-like languages.

--- a/packages/sugar-high/lib/presets/clike-base.js
+++ b/packages/sugar-high/lib/presets/clike-base.js
@@ -2,11 +2,11 @@
 export const onCommentStart = (currentChar, nextChar) => {
   const pair = currentChar + nextChar
   if (pair === '//') return 1
-  if (pair === '/*') return 1
+  if (pair === '/*') return 2
   return 0
 }
 
 export const onCommentEnd = (prevChar, currChar) => {
   if (currChar === '\n') return 1
-  return prevChar + currChar === '*/' ? 1 : 0
+  return prevChar + currChar === '*/' ? 2 : 0
 }

--- a/packages/sugar-high/test/preset/c.test.ts
+++ b/packages/sugar-high/test/preset/c.test.ts
@@ -22,10 +22,18 @@ describe('tokenize - c preset', () => {
     ])
   })
 
-  it('supports block comments with C-like rules', () => {
-    const input = '/* sum */\nstatic int total = 2;\n'
+  it('keeps multi-line block comments open until */', () => {
+    const input = `/*
+ * Copyright (c) 2009-Present, Redis Ltd.
+ * All rights reserved.
+ */
+static int total = 2;
+`
     const actual = getTokensAsString(tokenize(input, c))
-    expect(actual).toContain('/* sum */ => comment')
+    expect(actual).toContain(`/*
+ * Copyright (c) 2009-Present, Redis Ltd.
+ * All rights reserved.
+ */ => comment`)
     expect(actual).toContain('static => keyword')
     expect(actual).toContain('int => class')
   })


### PR DESCRIPTION
## Summary

- distinguish line comments from block comments in the shared C-like scanner
- keep block comments open across newlines until the closing delimiter
- add a regression test based on the Redis server.c license header
- add a patch Changeset for sugar-high

## Verification

- pnpm test
- pnpm build
- git diff --check
- loaded the Redis 8.2.1 server.c raw URL through the development site at http://localhost:3000; all 13 license-header lines rendered as comments