### PR TITLE
fix: highlight Markdown syntax signs

### DIFF
--- a/.changeset/bright-markdown-quotes.md
+++ b/.changeset/bright-markdown-quotes.md
@@ -1,0 +1,5 @@
+---
+'sugar-high': patch
+---
+
+Highlight Markdown syntax delimiters while keeping prose and fenced code contents neutral.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,9 @@
 
 # Pull requests
 
+- Use Conventional Commits for commit and pull request titles. Start the subject after the type
+  prefix with a lowercase letter, for example `fix: preserve multiline comments`, not
+  `fix: Preserve multiline comments`.
 - Prefix pull request titles by change type: `feat:` for features, `fix:` for patches and bug
   fixes, and `ci:` for CI, workflow, and release-process fixes.
 - Follow the prefix with a concise imperative title, for example `ci: Fix package checks before

--- a/apps/site/app/syntax-highlight-presets.ts
+++ b/apps/site/app/syntax-highlight-presets.ts
@@ -16,6 +16,7 @@ export const SYNTAX_PRESET_CODICE_EXTENSIONS = new Set([
   'scss',
   'sass',
   'less',
+  'md',
 ])
 
 export const SYNTAX_PRESET_SELECT_OPTIONS: readonly {

--- a/apps/site/next.config.ts
+++ b/apps/site/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  agentRules: false,
+}
+
+export default nextConfig

--- a/packages/sugar-high/lib/lang/markdown.d.ts
+++ b/packages/sugar-high/lib/lang/markdown.d.ts
@@ -1,4 +1,5 @@
 export const keywords: Set<never>;
+export function tokenize(code: string): Array<[number, string]>;
 export function annotateLine(line: any): void;
 import { onCommentEnd } from '../presets/plain-base.js';
 import { onCommentStart } from '../presets/plain-base.js';

--- a/packages/sugar-high/lib/lang/markdown.js
+++ b/packages/sugar-high/lib/lang/markdown.js
@@ -1,7 +1,90 @@
 // @ts-check
+import { T_IDENTIFIER, T_SIGN } from '../shared.js'
 import { onCommentEnd, onCommentStart } from '../presets/plain-base.js'
 
 export const keywords = new Set([])
+
+/** @param {string} code */
+export const tokenize = (code) => {
+  /** @type {Array<[number, string]>} */
+  const tokens = []
+  let fence = ''
+  let fenceQuoted = false
+
+  /** @param {number} type @param {string} value */
+  const append = (type, value) => {
+    if (!value) return
+    const previous = tokens[tokens.length - 1]
+    if (previous?.[0] === type) previous[1] += value
+    else tokens.push([type, value])
+  }
+
+  for (const part of code.match(/[^\n]*(?:\n|$)/g) || []) {
+    if (!part) continue
+    const newline = part.endsWith('\n') ? '\n' : ''
+    const line = newline ? part.slice(0, -1) : part
+    /** @type {Array<[number, number]>} */
+    const ranges = []
+    const container = line.match(/^(?: {0,3}>[ \t]?)*/)?.[0] || ''
+    if (!fence || fenceQuoted) {
+      for (const match of container.matchAll(/>/g)) {
+        ranges.push([match.index, match.index + 1])
+      }
+    }
+
+    let start = container.length
+    let spaces = 0
+    while (spaces < 3 && line[start] === ' ') {
+      start++
+      spaces++
+    }
+    const fenceMarker = line.slice(start).match(/^(`{3,}|~{3,})/)?.[1]
+
+    if (fence) {
+      if (
+        fenceMarker?.[0] === fence[0] &&
+        fenceMarker.length >= fence.length &&
+        /^\s*$/.test(line.slice(start + fenceMarker.length))
+      ) {
+        ranges.push([start, start + fenceMarker.length])
+        fence = ''
+        fenceQuoted = false
+      }
+    } else if (fenceMarker) {
+      ranges.push([start, start + fenceMarker.length])
+      fence = fenceMarker
+      fenceQuoted = container.includes('>')
+    } else {
+      const prefix = line.slice(start).match(
+        /^(#{1,6}(?=\s)|(?:[-+*]|\d+[.)])(?=\s)|(?:(?:\*\s*){3,}|(?:-\s*){3,}|(?:_\s*){3,})$)/,
+      )?.[1]
+      if (prefix) ranges.push([start, start + prefix.length])
+
+      for (const match of line.matchAll(/(`+)(.*?)\1|(\*{1,3}|_{1,3}|~{2})(?=\S)(.*?\S)\3/g)) {
+        const marker = match[1] || match[3]
+        if (
+          line[match.index - 1] === '\\' ||
+          (marker[0] === '_' && /\w/.test(line[match.index - 1] || ''))
+        ) continue
+        ranges.push(
+          [match.index, match.index + marker.length],
+          [match.index + match[0].length - marker.length, match.index + match[0].length],
+        )
+      }
+    }
+
+    let offset = 0
+    for (const [rangeStart, rangeEnd] of ranges.sort((a, b) => a[0] - b[0])) {
+      if (rangeStart < offset) continue
+      append(T_IDENTIFIER, line.slice(offset, rangeStart))
+      append(T_SIGN, line.slice(rangeStart, rangeEnd))
+      offset = rangeEnd
+    }
+    append(T_IDENTIFIER, line.slice(offset) + newline)
+  }
+
+  return tokens
+}
 
 export const annotateLine = (line) => {
   let annotation = ''

--- a/packages/sugar-high/test/preset/first-wave.test.ts
+++ b/packages/sugar-high/test/preset/first-wave.test.ts
@@ -71,4 +71,31 @@ describe('first-wave language presets', () => {
     expect(html).toContain('sh__line sh__line--markdown-list')
     expect(html).toContain('sh__line sh__line--markdown-quote')
   })
+
+  it('highlights Markdown syntax without coloring prose or fenced code', () => {
+    const input = `# Bunchee
+
+> **Zero-config** bundler with \`exports\`.
+>
+> \`\`\`sh
+> npm install --save-dev
+> \`\`\`
+
+---
+
+- Read the docs.`
+    const actual = tokenize(input, { lang: 'markdown' })
+    const signs = actual
+      .filter(([type]) => core.SugarHigh.TokenTypes[type] === 'sign')
+      .map(([, value]) => value)
+    const contentTypes = actual
+      .filter(([type]) => core.SugarHigh.TokenTypes[type] !== 'sign')
+      .map(([type]) => core.SugarHigh.TokenTypes[type])
+
+    expect(signs).toEqual([
+      '#', '>', '**', '**', '`', '`', '>', '>', '```', '>', '>', '```', '---', '-',
+    ])
+    expect(new Set(contentTypes)).toEqual(new Set(['identifier']))
+    expect(actual.map(([, value]) => value).join('')).toBe(input)
+  })
 })


### PR DESCRIPTION
## Summary

- auto-select the Markdown preset for .md files loaded in the GitHub playground
- highlight Markdown heading, blockquote, list, emphasis, inline-code, horizontal-rule, and fence delimiters as signs
- keep prose and fenced code contents in the neutral identifier color
- retain structural heading/list/quote/fence line annotations
- add regression coverage based on the Bunchee README failure
- disable Next.js agent-rule file generation in the site development server
- document lowercase Conventional Commit subjects and add a patch Changeset

## Verification

- pnpm test
- pnpm build
- pnpm --filter sugar-high benchmark
- git diff --check
- loaded the Bunchee README raw URL through the development site at http://localhost:3000 and confirmed it selects md and emits only sign and identifier tokens
- only 638 of 18,062 source characters are highlighted as Markdown signs (3.53%); prose and fenced code remain neutral
- restarted next dev and confirmed it does not regenerate AGENTS.md or CLAUDE.md

## Bundle size

- sugar-high: 25.16 KiB minified / 9.32 KiB gzip
- sugar-high/core: 4.00 KiB minified / 1.79 KiB gzip
- core + javascript: 9.86 KiB minified / 4.33 KiB gzip