### PR TITLE
feat: add Zig and Lua highlighting

### DIFF
--- a/.changeset/fuzzy-tigers-code.md
+++ b/.changeset/fuzzy-tigers-code.md
@@ -1,0 +1,5 @@
+---
+'sugar-high': minor
+---
+
+Add built-in Zig and Lua syntax highlighting.

--- a/apps/site/app/components/install-banner.tsx
+++ b/apps/site/app/components/install-banner.tsx
@@ -198,9 +198,9 @@ ${formatPlateAsCssVars(darkPlate)}
         <div className="install-banner__block">
           <h2>Languages</h2>
           <p>
-            Sugar High includes 25 languages out of the box—no extra grammars or setup required.
+            Sugar High includes 29 languages out of the box—no extra grammars or setup required.
             JavaScript and JSX work by default; pass a canonical name to highlight TypeScript,
-            Python, CSS, Rust, Go, HTML, SQL, Markdown, and the other built-ins.
+            Python, CSS, Rust, Go, Zig, Lua, HTML, SQL, Markdown, and the other built-ins.
           </p>
           <p>
             Related dialects share the same built-in implementation, including TSX, JSONC,

--- a/docs/API.md
+++ b/docs/API.md
@@ -93,6 +93,8 @@ input map to that canonical name. Canonical names themselves are always accepted
 | `dockerfile` | `.dockerfile` | `docker` |
 | `graphql` | `.graphql` | `gql` |
 | `hcl` | `.hcl` | `terraform`, `tf` |
+| `zig` | `.zig` | — |
+| `lua` | `.lua` | — |
 
 Related dialects intentionally share one canonical language. JavaScript includes JSX, TypeScript
 includes TSX, JSON includes JSONC comments, Shell includes sh/Bash/Zsh, and HCL includes Terraform.

--- a/packages/sugar-high/README.md
+++ b/packages/sugar-high/README.md
@@ -57,7 +57,7 @@ behavior.
 
 `javascript`, `typescript`, `css`, `python`, `c`, `go`, `java`, `rust`, `json`, `diff`, `shell`,
 `cpp`, `csharp`, `sql`, `html`, `yaml`, `markdown`, `plaintext`, `ruby`, `kotlin`, `swift`, `php`,
-`toml`, `powershell`, `dockerfile`, `graphql`, and `hcl`.
+`toml`, `powershell`, `dockerfile`, `graphql`, `hcl`, `zig`, and `lua`.
 
 Related dialects share one implementation: JavaScript includes JSX, TypeScript includes TSX, JSON
 includes JSONC comments, Shell includes sh/Bash/Zsh, and HCL includes Terraform.

--- a/packages/sugar-high/lib/core.d.ts
+++ b/packages/sugar-high/lib/core.d.ts
@@ -89,7 +89,13 @@ export type ParseOptions = {
   keywords?: Set<string>
   typeKeywords?: Set<string>
   onCommentStart?: (curr: string, next: string, index: number, code: string) => number | boolean
-  onCommentEnd?: (prev: string, curr: string, index: number, code: string) => number | boolean
+  onCommentEnd?: (
+    prev: string,
+    curr: string,
+    index: number,
+    code: string,
+    start: number,
+  ) => number | boolean
   onLiteral?: (curr: string, index: number, code: string) => number | null | undefined
   onQuote?: (curr: string, index: number, code: string) => number | null | undefined
   quotedKeys?: boolean

--- a/packages/sugar-high/lib/core.js
+++ b/packages/sugar-high/lib/core.js
@@ -53,7 +53,7 @@ function tokenize(code, options) {
     if (commentType) {
       const start = i++
       while (i < code.length) {
-        if (onCommentEnd(code[i - 1], code[i], i, code) == commentType) {
+        if (onCommentEnd(code[i - 1], code[i], i, code, start) == commentType) {
           i++
           break
         }
@@ -154,7 +154,7 @@ export { generate, parse, render, SugarHigh, tokenize }
  * @property {Set<string>} [keywords]
  * @property {Set<string>} [typeKeywords]
  * @property {(curr: string, next: string, index: number, code: string) => number | boolean} [onCommentStart]
- * @property {(prev: string, curr: string, index: number, code: string) => number | boolean} [onCommentEnd]
+ * @property {(prev: string, curr: string, index: number, code: string, start: number) => number | boolean} [onCommentEnd]
  * @property {(curr: string, index: number, code: string) => number | null | undefined} [onLiteral]
  * @property {(curr: string, index: number, code: string) => number | null | undefined} [onQuote]
  * @property {boolean} [quotedKeys]

--- a/packages/sugar-high/lib/index.d.ts
+++ b/packages/sugar-high/lib/index.d.ts
@@ -35,6 +35,8 @@ export type LanguageName =
   | 'dockerfile'
   | 'graphql'
   | 'hcl'
+  | 'zig'
+  | 'lua'
 
 export type HighlightOptions = DisplayOptions & {
   /** Canonical language name. Fence and extension aliases must be normalized first. */

--- a/packages/sugar-high/lib/lang.js
+++ b/packages/sugar-high/lib/lang.js
@@ -2,8 +2,8 @@
 
 import {
   c, cpp, csharp, css, diff, dockerfile, go, graphql, hcl, html, java, javascript, json,
-  kotlin, markdown, nonJavaScript, php, plaintext, powershell, python, ruby, rust, shell, sql,
-  swift, toml, typescript, yaml,
+  kotlin, lua, markdown, nonJavaScript, php, plaintext, powershell, python, ruby, rust, shell, sql,
+  swift, toml, typescript, yaml, zig,
 } from './presets/configs.js'
 
 /**
@@ -45,6 +45,8 @@ const languages = [
   { id: 'dockerfile', extension: 'dockerfile', aliases: ['docker'], config: nonJavaScript(dockerfile) },
   { id: 'graphql', extension: 'graphql', aliases: ['gql'], config: nonJavaScript(graphql) },
   { id: 'hcl', extension: 'hcl', aliases: ['terraform', 'tf'], config: nonJavaScript(hcl) },
+  { id: 'zig', extension: 'zig', aliases: [], config: nonJavaScript(zig) },
+  { id: 'lua', extension: 'lua', aliases: [], config: nonJavaScript(lua) },
 ]
 
 /** @param {string} value */

--- a/packages/sugar-high/lib/lang/lua.d.ts
+++ b/packages/sugar-high/lib/lang/lua.d.ts
@@ -1,0 +1,10 @@
+export const keywords: Set<string>;
+export function onCommentStart(curr: string, next: string, index: number, code: string): number;
+export function onCommentEnd(
+  prev: string,
+  curr: string,
+  index: number,
+  code: string,
+  start: number,
+): number;
+export function onLiteral(curr: string, index: number, code: string): number;

--- a/packages/sugar-high/lib/lang/lua.js
+++ b/packages/sugar-high/lib/lang/lua.js
@@ -1,0 +1,45 @@
+// @ts-check
+
+export const keywords = new Set([
+  'and', 'break', 'do', 'else', 'elseif', 'end', 'false', 'for', 'function', 'goto', 'if', 'in',
+  'local', 'nil', 'not', 'or', 'repeat', 'return', 'then', 'true', 'until', 'while',
+])
+
+/**
+ * @param {string} curr
+ * @param {string} next
+ * @param {number} index
+ * @param {string} code
+ */
+export function onCommentStart(curr, next, index, code) {
+  if (curr === '#' && index === 0 && next === '!') return 1
+  if (curr + next !== '--') return 0
+  return /^--\[=*\[/.test(code.slice(index)) ? 2 : 1
+}
+
+/**
+ * @param {string} _prev
+ * @param {string} curr
+ * @param {number} index
+ * @param {string} code
+ * @param {number} start
+ */
+export function onCommentEnd(_prev, curr, index, code, start) {
+  if (curr === '\n') return 1
+  if (curr !== ']') return 0
+  const opener = code.slice(start).match(/^--\[(=*)\[/)
+  if (!opener) return 0
+  const closing = `]${opener[1]}]`
+  if (code.slice(index - closing.length + 1, index + 1) === closing) return 2
+  return 0
+}
+
+/** @param {string} curr @param {number} index @param {string} code */
+export function onLiteral(curr, index, code) {
+  if (curr !== '[') return 0
+  const opener = code.slice(index).match(/^\[(=*)\[/)
+  if (!opener) return 0
+  const closing = `]${opener[1]}]`
+  const end = code.indexOf(closing, index + opener[0].length)
+  return end === -1 ? code.length - index : end + closing.length - index
+}

--- a/packages/sugar-high/lib/lang/zig.d.ts
+++ b/packages/sugar-high/lib/lang/zig.d.ts
@@ -1,0 +1,5 @@
+export const keywords: Set<string>;
+export const typeKeywords: Set<string>;
+export function onCommentStart(curr: string, next: string): number;
+export function onCommentEnd(prev: string, curr: string): number;
+export function onLiteral(curr: string, index: number, code: string): number;

--- a/packages/sugar-high/lib/lang/zig.js
+++ b/packages/sugar-high/lib/lang/zig.js
@@ -1,0 +1,29 @@
+// @ts-check
+
+export const keywords = new Set([
+  'addrspace', 'align', 'allowzero', 'and', 'anyframe', 'anytype', 'asm', 'async', 'await', 'break',
+  'callconv', 'catch', 'comptime', 'const', 'continue', 'defer', 'else', 'enum', 'errdefer', 'error',
+  'export', 'extern', 'false', 'fn', 'for', 'if', 'inline', 'linksection', 'noalias', 'noinline',
+  'nosuspend', 'null', 'opaque', 'or', 'orelse', 'packed', 'pub', 'resume', 'return', 'struct',
+  'suspend', 'switch', 'test', 'threadlocal', 'true', 'try', 'undefined', 'union', 'unreachable',
+  'usingnamespace', 'var', 'volatile', 'while',
+])
+
+export const typeKeywords = new Set([
+  'anyerror', 'anyopaque', 'bool', 'c_char', 'c_int', 'c_long', 'c_longdouble', 'c_longlong',
+  'c_short', 'c_uint', 'c_ulong', 'c_ulonglong', 'c_ushort', 'comptime_float', 'comptime_int',
+  'f16', 'f32', 'f64', 'f80', 'f128', 'i8', 'i16', 'i32', 'i64', 'i128', 'isize', 'noreturn',
+  'type', 'u8', 'u16', 'u32', 'u64', 'u128', 'usize', 'void',
+])
+
+export const onCommentStart = (curr, next) => curr + next === '//' ? 1 : 0
+export const onCommentEnd = (_prev, curr) => curr === '\n' ? 1 : 0
+
+/** @param {string} curr @param {number} index @param {string} code */
+export function onLiteral(curr, index, code) {
+  if (curr !== '\\' || code[index + 1] !== '\\') return 0
+  const lineStart = code.lastIndexOf('\n', index - 1) + 1
+  if (code.slice(lineStart, index).trim()) return 0
+  const lineEnd = code.indexOf('\n', index + 2)
+  return (lineEnd === -1 ? code.length : lineEnd) - index
+}

--- a/packages/sugar-high/lib/presets/configs.js
+++ b/packages/sugar-high/lib/presets/configs.js
@@ -14,6 +14,7 @@ import * as java from '../lang/java.js'
 import * as javascript from '../lang/javascript.js'
 import * as json from '../lang/json.js'
 import * as kotlin from '../lang/kotlin.js'
+import * as lua from '../lang/lua.js'
 import * as markdown from '../lang/markdown.js'
 import * as php from '../lang/php.js'
 import * as plaintext from '../lang/plaintext.js'
@@ -27,6 +28,7 @@ import * as swift from '../lang/swift.js'
 import * as toml from '../lang/toml.js'
 import * as typescript from '../lang/typescript.js'
 import * as yaml from '../lang/yaml.js'
+import * as zig from '../lang/zig.js'
 
 /**
  * Disable JavaScript-only scanner modes for a non-JavaScript language.
@@ -71,6 +73,8 @@ function createConfigs() {
     dockerfile: nonJavaScript(dockerfile),
     graphql: nonJavaScript(graphql),
     hcl: nonJavaScript(hcl),
+    zig: nonJavaScript(zig),
+    lua: nonJavaScript(lua),
   }
 }
 
@@ -83,6 +87,6 @@ function configFor(name) {
 
 export {
   c, configFor, configs, cpp, csharp, css, diff, dockerfile, go, graphql, hcl, html, java,
-  javascript, json, kotlin, markdown, nonJavaScript, php, plaintext, powershell, python, ruby,
-  rust, shell, sql, swift, toml, typescript, yaml,
+  javascript, json, kotlin, lua, markdown, nonJavaScript, php, plaintext, powershell, python, ruby,
+  rust, shell, sql, swift, toml, typescript, yaml, zig,
 }

--- a/packages/sugar-high/test/languages.test.ts
+++ b/packages/sugar-high/test/languages.test.ts
@@ -57,6 +57,8 @@ describe('language registry', () => {
     ['gql', 'graphql'],
     ['terraform', 'hcl'],
     ['tf', 'hcl'],
+    ['zig', 'zig'],
+    ['lua', 'lua'],
     ['rb', 'ruby'],
     ['txt', 'plaintext'],
     ['text', 'plaintext'],

--- a/packages/sugar-high/test/preset/second-wave.test.ts
+++ b/packages/sugar-high/test/preset/second-wave.test.ts
@@ -16,6 +16,8 @@ const cases: Array<[LanguageName, string, string, string]> = [
   ['dockerfile', 'FROM node\nRUN npm install', 'FROM => keyword', 'RUN => keyword'],
   ['graphql', 'type User { id: ID! }', 'type => keyword', 'ID => class'],
   ['hcl', 'enabled = true # rollout', 'true => keyword', '# rollout => comment'],
+  ['zig', 'const answer: u32 = 42; // result', 'const => keyword', 'u32 => class'],
+  ['lua', 'local ready = true -- status', 'local => keyword', '-- status => comment'],
 ]
 
 describe('second-wave language presets', () => {
@@ -30,5 +32,21 @@ describe('second-wave language presets', () => {
       lang: 'powershell',
     }))
     expect(actual).toContain('<# note #> => comment')
+  })
+
+  it('supports Lua long comments and strings', () => {
+    const actual = getTokensAsString(tokenize('--[=[ ignore ]] until ]=]\nlocal value = [==[text]==]', {
+      lang: 'lua',
+    }))
+    expect(actual).toContain('--[=[ ignore ]] until ]=] => comment')
+    expect(actual).toContain('[==[text]==] => string')
+  })
+
+  it('supports Zig multiline string lines', () => {
+    const actual = getTokensAsString(tokenize('const text =\n    \\\\first line\n    \\\\second line;', {
+      lang: 'zig',
+    }))
+    expect(actual).toContain('\\\\first line => string')
+    expect(actual).toContain('\\\\second line; => string')
   })
 })


### PR DESCRIPTION
## Summary

- add first-class Zig and Lua language configurations, registry entries, types, and documentation
- highlight Zig keywords, primitive types, line comments, and multiline string lines
- highlight Lua keywords, shebangs, line comments, and exact-level long comments and strings
- pass the comment start offset to custom terminators so Lua long-bracket levels close correctly
- update the site language count and add a minor Changeset

## Verification

- `pnpm test`
- `pnpm build`
- `pnpm check:packages`
- `pnpm --filter sugar-high benchmark`
- `git diff --check`
- verified through `next dev` at `http://localhost:3000` that the language selector includes `zig` and `lua` and the site reports 29 built-ins

## Bundle size

- `sugar-high`: 27.03 KiB minified / 9.88 KiB gzip
- `sugar-high/core`: 4.00 KiB minified / 1.79 KiB gzip
- isolated default-entry gzip change: +575 B (+6.0%); core gzip unchanged

_Bun browser ESM bundle, minified and gzip-compressed._
