### PR TITLE
feat: compose file navigation with code blocks and editors

### DIFF
--- a/.changeset/friendly-files-browse.md
+++ b/.changeset/friendly-files-browse.md
@@ -1,0 +1,5 @@
+---
+"@sugar-high/react": minor
+---
+
+Add a themed FileTree with controlled file selection, folder expansion, and keyboard navigation that composes with Editor or Code.

--- a/apps/site/app/react/file-tree-demo.tsx
+++ b/apps/site/app/react/file-tree-demo.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { useState } from 'react'
+import { Code, Editor, FileTree } from '@sugar-high/react'
+import { useReactTheme } from '../components/react-themes'
+
+const initialFiles: Record<string, string> = {
+  'src/index.tsx': `import { Button } from './components/button'
+import './styles.css'
+
+export default function App() {
+  return <Button>Say hello</Button>
+}`,
+  'src/components/button.tsx': `import type { ReactNode } from 'react'
+
+export function Button({ children }: { children: ReactNode }) {
+  return <button onClick={() => alert('Hello!')}>{children}</button>
+}`,
+  'src/styles.css': `button {
+  border: 1px solid currentColor;
+  border-radius: 6px;
+  padding: 8px 16px;
+  cursor: pointer;
+}`,
+  'package.json': `{
+  "name": "hello-world",
+  "private": true
+}`,
+}
+
+export function FileTreeDemo() {
+  const { palette } = useReactTheme()
+  const [files, setFiles] = useState(initialFiles)
+  const [activeFile, setActiveFile] = useState('src/index.tsx')
+  const [readOnly, setReadOnly] = useState(false)
+  const [lineNumbers, setLineNumbers] = useState(true)
+  const code = files[activeFile]
+
+  return (
+    <div className="product-card react-demo filetree-demo" data-mode={readOnly ? 'code' : 'editor'}>
+      <div className="product-card__bar">
+        <span className="product-card__title">{activeFile}</span>
+      </div>
+      <div className="react-demo__files">
+        <FileTree paths={Object.keys(files)} activeFile={activeFile}
+          onActiveFileChange={setActiveFile} theme={palette} />
+        <div className="react-demo__document" style={{ background: palette.background, color: palette.foreground }}>
+          {readOnly ? (
+            <Code className="filetree-demo__source" extension={activeFile.split('.').pop()}
+              controls={false} fontSize={13} theme={palette} lineNumbers={lineNumbers}>{code}</Code>
+          ) : (
+            <Editor className="filetree-demo__source" title={null} extension={activeFile.split('.').pop()}
+              theme={palette} fontSize={13} fontFamily="ui-monospace, monospace" controls={false} value={code} lineNumbers={lineNumbers}
+              textareaProps={{ 'aria-label': `Edit ${activeFile}` }}
+              onChange={text => setFiles(current => ({ ...current, [activeFile]: text }))} />
+          )}
+        </div>
+      </div>
+      <div className="react-demo__status">
+        <div className="react-demo__settings">
+          <label><input type="checkbox" checked={readOnly} onChange={event => setReadOnly(event.target.checked)} />read only</label>
+          <label><input type="checkbox" checked={lineNumbers} onChange={event => setLineNumbers(event.target.checked)} />line numbers</label>
+        </div>
+        <span>{code.split('\n').length} lines · {code.length} characters</span>
+      </div>
+    </div>
+  )
+}

--- a/apps/site/app/react/page.css
+++ b/apps/site/app/react/page.css
@@ -194,6 +194,7 @@
 
 .react-product .sh__line {
   display: block;
+  min-height: 1lh;
 }
 
 .react-product [data-highlight] {
@@ -379,10 +380,33 @@
 }
 
 .react-demo__files { display: grid; grid-template-columns: minmax(150px, 210px) minmax(0, 1fr); }
-.react-demo__files [data-sh-file-tree] { border-right: 1px solid var(--demo-muted); }
+.react-demo__files [data-sh-file-tree] { border-right: 1px solid color-mix(in srgb, #888 20%, transparent); }
 .react-demo__document { min-width: 0; }
-.react-demo__document > [data-sh] { min-height: 300px; }
+.filetree-demo__source { min-height: 260px; font-family: ui-monospace, monospace; font-size: 13px; }
 @media (max-width: 600px) {
   .react-demo__files { grid-template-columns: minmax(0, 1fr); }
-  .react-demo__files [data-sh-file-tree] { max-height: 180px; border-right: 0; border-bottom: 1px solid var(--demo-muted); }
+  .react-demo__files [data-sh-file-tree] { max-height: 180px; border-right: 0; border-bottom: 1px solid color-mix(in srgb, #888 20%, transparent); }
 }
+
+.react-product [data-sh] pre,
+.react-product [data-sh] code,
+.react-product [data-sh] textarea {
+  font-family: ui-monospace, monospace;
+  font-size: 13px;
+  line-height: 22px;
+  letter-spacing: normal;
+  line-break: anywhere;
+  overflow-wrap: break-word;
+}
+.filetree-demo__source code { padding-right: 8px; }
+
+.react-product .product-section > .filetree-demo { width: min(800px, 100%); }
+
+.react-product .product-card__bar { height: 28px; font: 13px/20px ui-monospace, monospace; }
+.react-product .product-card__title { line-height: 20px; }
+.filetree-demo [data-sh-file-tree] { padding-block: 12px; }
+.filetree-demo [data-sh-file-tree] [role="treeitem"] { min-height: 22px; line-height: 22px; }
+
+.react-product [data-sh="code"],
+.react-product [data-sh="editor"] { font: 13px/22px ui-monospace, monospace; }
+.react-product [data-sh-header] [data-sh-title] { font: 13px/20px ui-monospace, monospace; }

--- a/apps/site/app/react/page.css
+++ b/apps/site/app/react/page.css
@@ -194,7 +194,6 @@
 
 .react-product .sh__line {
   display: block;
-  min-height: 1lh;
 }
 
 .react-product [data-highlight] {
@@ -395,10 +394,7 @@
   font-size: 13px;
   line-height: 22px;
   letter-spacing: normal;
-  line-break: anywhere;
-  overflow-wrap: break-word;
 }
-.filetree-demo__source code { padding-right: 8px; }
 
 .react-product .product-section > .filetree-demo { width: min(800px, 100%); }
 

--- a/apps/site/app/react/page.css
+++ b/apps/site/app/react/page.css
@@ -377,3 +377,12 @@
 .react-code-languages button[aria-selected='true'] {
   font-weight: 650;
 }
+
+.react-demo__files { display: grid; grid-template-columns: minmax(150px, 210px) minmax(0, 1fr); }
+.react-demo__files [data-sh-file-tree] { border-right: 1px solid var(--demo-muted); }
+.react-demo__document { min-width: 0; }
+.react-demo__document > [data-sh] { min-height: 300px; }
+@media (max-width: 600px) {
+  .react-demo__files { grid-template-columns: minmax(0, 1fr); }
+  .react-demo__files [data-sh-file-tree] { max-height: 180px; border-right: 0; border-bottom: 1px solid var(--demo-muted); }
+}

--- a/apps/site/app/react/page.tsx
+++ b/apps/site/app/react/page.tsx
@@ -1,5 +1,6 @@
 import { ReactThemeProvider, ReactThemePicker, ThemeUsage, ThemeNames } from '../components/react-themes'
 import { ReactDemo } from './react-demo'
+import { FileTreeDemo } from './file-tree-demo'
 import { CodeDemo } from './code-demo'
 import { ProductNav } from '../product-nav'
 import { ProductStrike } from '../product-strike'
@@ -90,17 +91,52 @@ export default function ReactPage() {
 
           <section className="product-section">
             <div className="product-section__head">
-              <h2>{'<FileTree /> + <Editor />'}</h2>
-              <p>Browse files and edit their source, or switch to a read-only code block.</p>
+              <h2>{'<Editor />'}</h2>
+              <p>A controlled, highlighted editor with optional line numbers.</p>
             </div>
             <div className="react-demo-theme-picker"><ReactThemePicker label="Editor theme" /></div>
-            <Window title="Files"><ReactDemo /></Window>
+            <Window title="editor-example.tsx"><ReactDemo /></Window>
+          </section>
+
+          <section className="product-section">
+            <div className="product-section__head">
+              <h2>{'<FileTree />'}</h2>
+              <p>Compose with Editor to edit files, or Code for read-only viewing.</p>
+            </div>
+            <div className="react-demo-theme-picker"><ReactThemePicker label="FileTree theme" /></div>
+            <FileTreeDemo />
           </section>
 
           <details className="product-section react-api react-api-details">
             <summary>API details</summary>
             <div className="product-section__head">
-              <p>Props at a glance. Both components also accept standard div attributes.</p>
+              <p>Props at a glance. All three components also accept standard div attributes.</p>
+            </div>
+            <div className="react-api__component">
+              <h3>{'<Code />'}</h3>
+              <div className="react-api__table-wrap">
+                <table>
+                  <thead><tr><th>Prop</th><th>Type / default</th><th>Purpose</th></tr></thead>
+                  <tbody>
+                    <tr><td><code>children</code></td><td><code>string · required</code></td><td>Source or generated markup to render.</td></tr>
+                    <tr><td><code>lang</code></td><td><code>LanguageName</code></td><td>Canonical language; overrides the title.</td></tr>
+                    <tr><td><code>theme</code></td><td><code>Theme</code></td><td>JavaScript token and component colors.</td></tr>
+                    <tr><td><code>title</code></td><td><code>string</code></td><td>Filename shown in the header and used as a language hint.</td></tr>
+                    <tr><td><code>extension</code></td><td><code>string</code></td><td>Legacy language hint when no lang is set.</td></tr>
+                    <tr><td><code>controls</code></td><td><code>boolean · false</code></td><td>Shows header controls.</td></tr>
+                    <tr><td><code>lineNumbers</code></td><td><code>boolean · false</code></td><td>Shows one-based line numbers.</td></tr>
+                    <tr><td><code>highlightLines</code></td><td><code>(number | [number, number])[]</code></td><td>Highlights lines and inclusive ranges.</td></tr>
+                    <tr><td><code>cx</code></td><td><code>HighlightOptions['cx']</code></td><td>Maps token types to classes.</td></tr>
+                    <tr><td><code>mark</code></td><td><code>HighlightOptions['mark']</code></td><td>Mutates generated token properties.</td></tr>
+                    <tr><td><code>markLine</code></td><td><code>HighlightOptions['markLine']</code></td><td>Mutates generated line properties.</td></tr>
+                    <tr><td><code>preformatted</code></td><td><code>boolean · true</code></td><td>Uses a pre and code wrapper.</td></tr>
+                    <tr><td><code>asMarkup</code></td><td><code>boolean · false</code></td><td>Treats children as highlighted HTML.</td></tr>
+                    <tr><td><code>lineNumbersWidth</code></td><td><code>string</code></td><td>Sets the line-number gutter width.</td></tr>
+                    <tr><td><code>padding</code></td><td><code>string</code></td><td>Sets code content padding.</td></tr>
+                    <tr><td><code>fontSize</code></td><td><code>string | number</code></td><td>Sets the code font size.</td></tr>
+                  </tbody>
+                </table>
+              </div>
             </div>
             <div className="react-api__component">
               <h3>{'<Editor />'}</h3>
@@ -130,30 +166,20 @@ export default function ReactPage() {
               </div>
             </div>
             <div className="react-api__component">
-              <h3>{'<Code />'}</h3>
+              <h3>{'<FileTree />'}</h3>
               <div className="react-api__table-wrap">
                 <table>
                   <thead><tr><th>Prop</th><th>Type / default</th><th>Purpose</th></tr></thead>
                   <tbody>
-                    <tr><td><code>children</code></td><td><code>string · required</code></td><td>Source or generated markup to render.</td></tr>
-                    <tr><td><code>lang</code></td><td><code>LanguageName</code></td><td>Canonical language; overrides the title.</td></tr>
-                    <tr><td><code>theme</code></td><td><code>Theme</code></td><td>JavaScript token and component colors.</td></tr>
-                    <tr><td><code>title</code></td><td><code>string</code></td><td>Filename shown in the header and used as a language hint.</td></tr>
-                    <tr><td><code>extension</code></td><td><code>string</code></td><td>Legacy language hint when no lang is set.</td></tr>
-                    <tr><td><code>controls</code></td><td><code>boolean · false</code></td><td>Shows header controls.</td></tr>
-                    <tr><td><code>lineNumbers</code></td><td><code>boolean · false</code></td><td>Shows one-based line numbers.</td></tr>
-                    <tr><td><code>highlightLines</code></td><td><code>(number | [number, number])[]</code></td><td>Highlights lines and inclusive ranges.</td></tr>
-                    <tr><td><code>cx</code></td><td><code>HighlightOptions['cx']</code></td><td>Maps token types to classes.</td></tr>
-                    <tr><td><code>mark</code></td><td><code>HighlightOptions['mark']</code></td><td>Mutates generated token properties.</td></tr>
-                    <tr><td><code>markLine</code></td><td><code>HighlightOptions['markLine']</code></td><td>Mutates generated line properties.</td></tr>
-                    <tr><td><code>preformatted</code></td><td><code>boolean · true</code></td><td>Uses a pre and code wrapper.</td></tr>
-                    <tr><td><code>asMarkup</code></td><td><code>boolean · false</code></td><td>Treats children as highlighted HTML.</td></tr>
-                    <tr><td><code>lineNumbersWidth</code></td><td><code>string</code></td><td>Sets the line-number gutter width.</td></tr>
-                    <tr><td><code>padding</code></td><td><code>string</code></td><td>Sets code content padding.</td></tr>
-                    <tr><td><code>fontSize</code></td><td><code>string | number</code></td><td>Sets the code font size.</td></tr>
+                    <tr><td><code>paths</code></td><td><code>readonly string[] · required</code></td><td>Relative file paths. Folders are inferred and initially expanded.</td></tr>
+                    <tr><td><code>activeFile</code></td><td><code>string | null · required</code></td><td>Selected file path, or null for no selection.</td></tr>
+                    <tr><td><code>onActiveFileChange</code></td><td><code>(path: string) =&gt; void · required</code></td><td>Runs when a file is selected. Use the path to update Editor or Code.</td></tr>
+                    <tr><td><code>theme</code></td><td><code>Theme · optional</code></td><td>Pass the same theme as the adjacent Editor or Code.</td></tr>
+                    <tr><td><code>aria-label</code></td><td><code>string · 'Files'</code></td><td>Accessible name for the tree.</td></tr>
                   </tbody>
                 </table>
               </div>
+              <p>The tree manages folder expansion and keyboard focus. Your component owns the files and selected path.</p>
             </div>
             <div className="react-api__component">
               <h3>CSS variables</h3>

--- a/apps/site/app/react/page.tsx
+++ b/apps/site/app/react/page.tsx
@@ -90,11 +90,11 @@ export default function ReactPage() {
 
           <section className="product-section">
             <div className="product-section__head">
-              <h2>{'<Editor />'}</h2>
-              <p>A controlled, highlighted editor with optional line numbers.</p>
+              <h2>{'<FileTree /> + <Editor />'}</h2>
+              <p>Browse files and edit their source, or switch to a read-only code block.</p>
             </div>
             <div className="react-demo-theme-picker"><ReactThemePicker label="Editor theme" /></div>
-            <Window title="editor-example.tsx"><ReactDemo /></Window>
+            <Window title="Files"><ReactDemo /></Window>
           </section>
 
           <details className="product-section react-api react-api-details">

--- a/apps/site/app/react/react-demo.tsx
+++ b/apps/site/app/react/react-demo.tsx
@@ -1,61 +1,69 @@
 'use client'
 
 import { useState } from 'react'
-import { Code, Editor, FileTree } from '@sugar-high/react'
+import { Editor } from '@sugar-high/react'
+import type { LanguageName } from 'sugar-high'
+import { languages } from 'sugar-high/lang'
 import { useReactTheme } from '../components/react-themes'
 
-const initialFiles: Record<string, string> = {
-  'src/index.tsx': `import { Button } from './components/button'
-import './styles.css'
+const initialCode = `import { useState } from 'react'
+import { Editor } from '@sugar-high/react'
 
-export default function App() {
-  return <Button>Say hello</Button>
-}`,
-  'src/components/button.tsx': `import type { ReactNode } from 'react'
+const defaultText = 'console.log("hello world")'
 
-export function Button({ children }: { children: ReactNode }) {
-  return <button onClick={() => alert('Hello!')}>{children}</button>
-}`,
-  'src/styles.css': `button {
-  border: 1px solid currentColor;
-  border-radius: 6px;
-  padding: 8px 16px;
-  cursor: pointer;
-}`,
-  'package.json': `{
-  "name": "hello-world",
-  "private": true
-}`,
-}
+export default function Page() {
+  const [code, setCode] = useState(defaultText)
+  const [title, setTitle] = useState('index.js')
+
+  return (
+    <Editor
+      value={code}
+      title={title}
+      onChange={(text) => setCode(text)}
+      onChangeTitle={(title) => setTitle(title)}
+    />
+  )
+}`
 
 export function ReactDemo() {
   const { palette } = useReactTheme()
-  const [files, setFiles] = useState(initialFiles)
-  const [activeFile, setActiveFile] = useState('src/index.tsx')
-  const [readOnly, setReadOnly] = useState(false)
+  const [code, setCode] = useState(initialCode)
+  const [language, setLanguage] = useState<LanguageName>('typescript')
   const [lineNumbers, setLineNumbers] = useState(true)
-  const code = files[activeFile]
 
   return (
     <div className="react-demo">
-      <div className="react-demo__files">
-        <FileTree paths={Object.keys(files)} activeFile={activeFile}
-          onActiveFileChange={setActiveFile} theme={palette} />
-        <div className="react-demo__document">
-          {readOnly ? (
-            <Code title={activeFile} theme={palette} lineNumbers={lineNumbers}>{code}</Code>
-          ) : (
-            <Editor className="react-demo__editor" title={activeFile}
-              theme={palette} controls={false} value={code} lineNumbers={lineNumbers}
-              textareaProps={{ 'aria-label': `Edit ${activeFile}` }}
-              onChange={text => setFiles(current => ({ ...current, [activeFile]: text }))} />
-          )}
-        </div>
-      </div>
+      <Editor
+        className="react-demo__editor"
+        theme={palette}
+        lang={language}
+        title={null}
+        controls={false}
+        value={code}
+        lineNumbers={lineNumbers}
+        onChange={setCode}
+      />
       <div className="react-demo__status">
         <div className="react-demo__settings">
-          <label><input type="checkbox" checked={readOnly} onChange={event => setReadOnly(event.target.checked)} />read only</label>
-          <label><input type="checkbox" checked={lineNumbers} onChange={event => setLineNumbers(event.target.checked)} />line numbers</label>
+          <label>
+            <select
+              aria-label="Language"
+              value={language}
+              onChange={(event) => setLanguage(event.target.value as LanguageName)}
+            >
+              {languages.map(({ id }) => (
+                <option key={id} value={id}>{id}</option>
+              ))}
+            </select>
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={lineNumbers}
+              onChange={(event) => setLineNumbers(event.target.checked)}
+            />
+            line numbers
+          </label>
         </div>
         <span>{code.split('\n').length} lines · {code.length} characters</span>
       </div>

--- a/apps/site/app/react/react-demo.tsx
+++ b/apps/site/app/react/react-demo.tsx
@@ -1,70 +1,61 @@
 'use client'
 
 import { useState } from 'react'
-import { Editor } from '@sugar-high/react'
-import type { LanguageName } from 'sugar-high'
-import { languages } from 'sugar-high/lang'
+import { Code, Editor, FileTree } from '@sugar-high/react'
 import { useReactTheme } from '../components/react-themes'
 
-const initialCode = `import { useState } from 'react'
-import { Editor } from '@sugar-high/react'
+const initialFiles: Record<string, string> = {
+  'src/index.tsx': `import { Button } from './components/button'
+import './styles.css'
 
-const defaultText = 'console.log("hello world")'
+export default function App() {
+  return <Button>Say hello</Button>
+}`,
+  'src/components/button.tsx': `import type { ReactNode } from 'react'
 
-export default function Page() {
-  const [code, setCode] = useState(defaultText)
-  const [title, setTitle] = useState('index.js')
-
-  return (
-    <Editor
-      value={code}
-      title={title}
-      onChange={(text) => setCode(text)}
-      onChangeTitle={(title) => setTitle(title)}
-    />
-  )
-}`
+export function Button({ children }: { children: ReactNode }) {
+  return <button onClick={() => alert('Hello!')}>{children}</button>
+}`,
+  'src/styles.css': `button {
+  border: 1px solid currentColor;
+  border-radius: 6px;
+  padding: 8px 16px;
+  cursor: pointer;
+}`,
+  'package.json': `{
+  "name": "hello-world",
+  "private": true
+}`,
+}
 
 export function ReactDemo() {
   const { palette } = useReactTheme()
-  const [code, setCode] = useState(initialCode)
-  const [language, setLanguage] = useState<LanguageName>('typescript')
+  const [files, setFiles] = useState(initialFiles)
+  const [activeFile, setActiveFile] = useState('src/index.tsx')
+  const [readOnly, setReadOnly] = useState(false)
   const [lineNumbers, setLineNumbers] = useState(true)
+  const code = files[activeFile]
 
   return (
     <div className="react-demo">
-      <Editor
-        className="react-demo__editor"
-        theme={palette}
-        lang={language}
-        title={null}
-        controls={false}
-        value={code}
-        lineNumbers={lineNumbers}
-        onChange={setCode}
-      />
+      <div className="react-demo__files">
+        <FileTree paths={Object.keys(files)} activeFile={activeFile}
+          onActiveFileChange={setActiveFile} theme={palette} />
+        <div className="react-demo__document">
+          {readOnly ? (
+            <Code title={activeFile} theme={palette} lineNumbers={lineNumbers}>{code}</Code>
+          ) : (
+            <Editor className="react-demo__editor" title={activeFile}
+              theme={palette} controls={false} value={code} lineNumbers={lineNumbers}
+              textareaProps={{ 'aria-label': `Edit ${activeFile}` }}
+              onChange={text => setFiles(current => ({ ...current, [activeFile]: text }))} />
+          )}
+        </div>
+      </div>
       <div className="react-demo__status">
         <div className="react-demo__settings">
-          <label>
-            <span className="sr-only">Language</span>
-            <select
-              aria-label="Language"
-              value={language}
-              onChange={(event) => setLanguage(event.target.value as LanguageName)}
-            >
-              {languages.map(({ id }) => (
-                <option key={id} value={id}>{id}</option>
-              ))}
-            </select>
-          </label>
-          <label>
-            <input
-              type="checkbox"
-              checked={lineNumbers}
-              onChange={(event) => setLineNumbers(event.target.checked)}
-            />
-            line numbers
-          </label>
+          <label><input type="checkbox" checked={readOnly} onChange={event => setReadOnly(event.target.checked)} />read only</label>
+          <label><input type="checkbox" checked={lineNumbers} onChange={event => setLineNumbers(event.target.checked)} />line numbers</label>
         </div>
         <span>{code.split('\n').length} lines · {code.length} characters</span>
       </div>

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -33,6 +33,47 @@ string and underlying textarea attributes with `indent` and `textareaProps`:
 />
 ```
 
+## FileTree
+
+Compose file navigation with `Editor` or `Code`. The parent owns the files and selected path;
+the tree owns folder expansion and keyboard focus.
+
+```tsx
+import { useState } from 'react'
+import { Editor, FileTree } from '@sugar-high/react'
+
+export function FilesExample() {
+  const [files, setFiles] = useState<Record<string, string>>({
+    'src/index.ts': 'export const greeting = "Hello"',
+    'src/styles.css': 'body { margin: 0; }',
+  })
+  const [activeFile, setActiveFile] = useState('src/index.ts')
+
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: '180px minmax(0, 1fr)' }}>
+      <FileTree paths={Object.keys(files)} activeFile={activeFile} onActiveFileChange={setActiveFile} />
+      <Editor title={activeFile} value={files[activeFile]}
+        onChange={code => setFiles(current => ({ ...current, [activeFile]: code }))} />
+    </div>
+  )
+}
+```
+
+Replace `Editor` with `<Code title={activeFile}>{files[activeFile]}</Code>` for read-only viewing.
+Pass the same `theme` to the tree and document for matching colors. Layout is ordinary CSS.
+
+`paths`, `activeFile` (`string | null`), and `onActiveFileChange(path)` are required.
+Paths are relative, slash-separated file names; folders are inferred and initially expanded.
+Duplicates are removed. Empty paths, leading/trailing slashes, empty segments, and `.` / `..`
+segments are ignored. Callbacks preserve the supplied file path. Folders sort before files.
+If files are removed, the parent should update its selection; the tree does not select another file automatically.
+
+Arrow keys navigate and expand/collapse folders; Home/End move to the first/last visible item.
+Enter or Space selects a file or toggles a folder. Typing a name moves focus to a matching item.
+`FileTree` accepts standard div attributes, an accessible label (default “Files”), and `theme`.
+Style it through `data-sh-file-tree` and the existing `--sh-*` theme variables.
+Document cursor, scroll, and undo history are not managed by the tree.
+
 ## Code
 
 ```tsx

--- a/packages/react/scripts/benchmark.mjs
+++ b/packages/react/scripts/benchmark.mjs
@@ -24,6 +24,9 @@ function measure(name, source) {
 
 try {
   console.table([
+    measure('file-tree', `import { FileTree } from '@sugar-high/react'; export { FileTree }`),
+    measure('editor', `import { Editor } from '@sugar-high/react'; export { Editor }`),
+    measure('editor-tree', `import { Editor, FileTree } from '@sugar-high/react'; export { Editor, FileTree }`),
     measure('react', `
       import { createElement } from 'react'
       import { Code } from '@sugar-high/react'

--- a/packages/react/src/file-tree/index.tsx
+++ b/packages/react/src/file-tree/index.tsx
@@ -13,10 +13,10 @@ export type FileTreeProps = {
 } & Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'onChange'>
 
 const css = `[data-sh-file-tree]{padding:8px;overflow:auto;font-family:var(--sh-font-family,ui-monospace,monospace);font-size:var(--sh-font-size,13px)}
-[data-sh-file-tree] [role=treeitem]{display:flex;align-items:center;gap:6px;min-height:30px;padding-right:8px;border-radius:4px;cursor:pointer;white-space:nowrap;outline:none}
-[data-sh-file-tree] [role=treeitem]:hover{background:color-mix(in srgb,currentColor 6%,transparent)}
-[data-sh-file-tree] [aria-selected=true]{background:var(--sh-line-highlight-color,color-mix(in srgb,currentColor 10%,transparent))}
-[data-sh-file-tree] [role=treeitem]:focus-visible{outline:2px solid currentColor;outline-offset:-2px}
+[data-sh-file-tree] [role=treeitem]{display:flex;align-items:center;gap:6px;min-height:30px;padding-right:8px;border-radius:4px;cursor:pointer;white-space:nowrap;outline:none;user-select:none}
+[data-sh-file-tree] [role=treeitem]:hover{background:color-mix(in srgb,#888 7%,transparent)}
+[data-sh-file-tree] [aria-selected=true]{background:color-mix(in srgb,#888 13%,transparent)}
+[data-sh-file-tree] [role=treeitem]:focus-visible{outline:1px solid color-mix(in srgb,currentColor 45%,transparent);outline-offset:-1px}
 [data-sh-file-tree] svg{width:16px;height:16px;flex:none}
 [data-sh-file-tree] [data-sh-chevron]{width:10px}`
 

--- a/packages/react/src/file-tree/index.tsx
+++ b/packages/react/src/file-tree/index.tsx
@@ -1,0 +1,105 @@
+'use client'
+
+import { useId, useMemo, useRef, useState, type HTMLAttributes } from 'react'
+import { ScopedStyle } from '../style'
+import { themeStyle, type Theme } from '../theme'
+import { treeItems, visibleItems, type TreeItem } from './model'
+
+export type FileTreeProps = {
+  paths: readonly string[]
+  activeFile: string | null
+  onActiveFileChange: (path: string) => void
+  theme?: Theme
+} & Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'onChange'>
+
+const css = `[data-sh-file-tree]{padding:8px;overflow:auto;font-family:var(--sh-font-family,ui-monospace,monospace);font-size:var(--sh-font-size,13px)}
+[data-sh-file-tree] [role=treeitem]{display:flex;align-items:center;gap:6px;min-height:30px;padding-right:8px;border-radius:4px;cursor:pointer;white-space:nowrap;outline:none}
+[data-sh-file-tree] [role=treeitem]:hover{background:color-mix(in srgb,currentColor 6%,transparent)}
+[data-sh-file-tree] [aria-selected=true]{background:var(--sh-line-highlight-color,color-mix(in srgb,currentColor 10%,transparent))}
+[data-sh-file-tree] [role=treeitem]:focus-visible{outline:2px solid currentColor;outline-offset:-2px}
+[data-sh-file-tree] svg{width:16px;height:16px;flex:none}
+[data-sh-file-tree] [data-sh-chevron]{width:10px}`
+
+export function FileTree({ paths, activeFile, onActiveFileChange, theme, style, ...props }: FileTreeProps) {
+  const items = useMemo(() => treeItems(paths), [paths])
+  const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set())
+  const [focused, setFocused] = useState<string | null>(null)
+  const visible = visibleItems(items, collapsed)
+  const current = visible.find(item => item.path === focused)
+    ?? visible.find(item => item.path === activeFile) ?? visible[0]
+  const refs = useRef(new Map<string, HTMLDivElement>())
+  const search = useRef({ value: '', time: 0 })
+  const id = useId()
+
+  function focus(item: TreeItem | undefined) {
+    if (!item) return
+    setFocused(item.path)
+    refs.current.get(item.path)?.focus()
+  }
+  function toggle(path: string) {
+    setCollapsed(previous => {
+      const next = new Set(previous)
+      if (next.has(path)) next.delete(path)
+      else next.add(path)
+      return next
+    })
+  }
+  function activate(item: TreeItem) {
+    if (item.directory) toggle(item.path)
+    else onActiveFileChange(item.path)
+  }
+
+  return (
+    <div {...props} role="tree" aria-label={props['aria-label'] ?? 'Files'}
+      style={{ ...themeStyle(theme), ...style }} data-sh-file-tree>
+      <ScopedStyle css={css} href="sugar-high-file-tree" />
+      {visible.map((item, index) => {
+        const siblings = items.filter(other => other.parent === item.parent)
+        const expanded = !collapsed.has(item.path)
+        return (
+          <div key={item.path} id={`${id}-${items.indexOf(item)}`} role="treeitem"
+            aria-label={item.name} aria-level={item.depth + 1}
+            aria-setsize={siblings.length} aria-posinset={siblings.indexOf(item) + 1}
+            aria-expanded={item.directory ? expanded : undefined}
+            aria-selected={!item.directory && item.path === activeFile}
+            tabIndex={current === item ? 0 : -1}
+            style={{ paddingLeft: 6 + item.depth * 16 }}
+            ref={node => { if (node) refs.current.set(item.path, node); else refs.current.delete(item.path) }}
+            onFocus={() => setFocused(item.path)}
+            onClick={() => { focus(item); activate(item) }}
+            onKeyDown={event => {
+              if (event.altKey || event.ctrlKey || event.metaKey) return
+              const key = event.key
+              if (['ArrowDown', 'ArrowUp', 'ArrowRight', 'ArrowLeft', 'Home', 'End', 'Enter', ' '].includes(key)) event.preventDefault()
+              if (key === 'ArrowDown') focus(visible[index + 1])
+              else if (key === 'ArrowUp') focus(visible[index - 1])
+              else if (key === 'Home') focus(visible[0])
+              else if (key === 'End') focus(visible[visible.length - 1])
+              else if (key === 'ArrowRight' && item.directory) {
+                if (!expanded) toggle(item.path)
+                else if (visible[index + 1]?.parent === item.path) focus(visible[index + 1])
+              } else if (key === 'ArrowLeft') {
+                if (item.directory && expanded) toggle(item.path)
+                else focus(visible.find(other => other.path === item.parent))
+              } else if (key === 'Enter' || key === ' ') activate(item)
+              else if (key.length === 1) {
+                const now = Date.now()
+                const value = (now - search.current.time < 500 ? search.current.value : '') + key.toLowerCase()
+                search.current = { value, time: now }
+                const ordered = [...visible.slice(index + 1), ...visible.slice(0, index + 1)]
+                focus(ordered.find(other => other.name.toLowerCase().startsWith(value)))
+              }
+            }}>
+            <svg data-sh-chevron aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor">
+              {item.directory && <path d={expanded ? 'm4 6 4 4 4-4' : 'm6 4 4 4-4 4'} />}
+            </svg>
+            <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeLinejoin="round">
+              <path d={item.directory ? 'M2 4h4l2 2h6v7H2Z' : 'M4 2h5l3 3v9H4Z M9 2v4h3'} />
+            </svg>
+            <span>{item.name}</span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/packages/react/src/file-tree/model.test.ts
+++ b/packages/react/src/file-tree/model.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { treeItems, visibleItems } from './model'
+
+describe('file navigation', () => {
+  it('deduplicates paths and sorts nested folders before files while preserving file identities', () => {
+    const paths = ['z.ts', 'src/z.ts', 'src/ui/button.tsx', 'src/a.ts', 'z.ts']
+    const items = treeItems(paths)
+    expect(items.map(item => item.path)).toEqual(['src/', 'src/ui/', 'src/ui/button.tsx', 'src/a.ts', 'src/z.ts', 'z.ts'])
+    expect(items[2]).toMatchObject({ name: 'button.tsx', parent: 'src/ui/', depth: 2, directory: false })
+    expect(treeItems([...paths].reverse())).toEqual(items)
+  })
+  it('hides all descendants of collapsed folders and retains nested expansion state', () => {
+    const items = treeItems(['src/ui/button.tsx', 'src/index.ts', 'readme.md'])
+    expect(visibleItems(items, new Set(['src/'])).map(item => item.path)).toEqual(['src/', 'readme.md'])
+    expect(visibleItems(items, new Set(['src/ui/'])).map(item => item.path)).toEqual(['src/', 'src/ui/', 'src/index.ts', 'readme.md'])
+    expect(visibleItems(treeItems(['other.ts']), new Set(['src/']))).toHaveLength(1)
+  })
+  it('handles empty inputs and ignores non-relative or ambiguous paths', () => {
+    expect(treeItems([])).toEqual([])
+    expect(treeItems(['', '/root.ts', './a.ts', '../a.ts', 'a//b.ts', 'a/', 'valid.ts']).map(item => item.path)).toEqual(['valid.ts'])
+  })
+})

--- a/packages/react/src/file-tree/model.ts
+++ b/packages/react/src/file-tree/model.ts
@@ -1,0 +1,42 @@
+export type TreeItem = { path: string; name: string; parent: string | null; depth: number; directory: boolean }
+
+// Preserve caller file paths in callbacks; directory keys end in a slash.
+export function treeItems(paths: readonly string[]): TreeItem[] {
+  const items = new Map<string, TreeItem>()
+  for (const path of paths) {
+    const parts = path.split('/')
+    if (!path || parts.some(part => !part || part === '.' || part === '..')) continue
+    let parent: string | null = null
+    parts.forEach((name, depth) => {
+      const directory = depth < parts.length - 1
+      const key = parts.slice(0, depth + 1).join('/') + (directory ? '/' : '')
+      items.set(key, { path: key, name, parent, depth, directory })
+      parent = key
+    })
+  }
+  const children = new Map<string | null, TreeItem[]>()
+  for (const item of items.values()) {
+    const siblings = children.get(item.parent) ?? []
+    siblings.push(item)
+    children.set(item.parent, siblings)
+  }
+  const result: TreeItem[] = []
+  function visit(parent: string | null) {
+    const siblings = children.get(parent) ?? []
+    siblings.sort((a, b) => Number(b.directory) - Number(a.directory) || (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
+    for (const item of siblings) { result.push(item); visit(item.path) }
+  }
+  visit(null)
+  return result
+}
+
+export function visibleItems(items: TreeItem[], collapsed: ReadonlySet<string>) {
+  const hidden = new Set<string>()
+  return items.filter(item => {
+    if (item.parent && (hidden.has(item.parent) || collapsed.has(item.parent))) {
+      hidden.add(item.path)
+      return false
+    }
+    return true
+  })
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,3 +1,5 @@
 export { Editor } from './editor'
 export { Code } from './code'
 export type { Theme, ThemePalette } from './theme'
+export { FileTree } from './file-tree'
+export type { FileTreeProps } from './file-tree'


### PR DESCRIPTION
Adds `FileTree` to `@sugar-high/react` so callers can browse multiple files beside the existing `Editor` or `Code`. The tree handles folder expansion and keyboard focus; callers own file contents and selection.

```tsx
<FileTree
  paths={Object.keys(files)}
  activeFile={activeFile}
  onActiveFileChange={setActiveFile}
/>
<Editor
  title={activeFile}
  value={files[activeFile]}
  onChange={code => setFiles(current => ({ ...current, [activeFile]: code }))}
/>
```

For read-only viewing, replace `Editor` with `<Code title={activeFile}>{files[activeFile]}</Code>`.

Includes neutral file/folder icons, nested paths, folder-first sorting, controlled selection, arrow/Home/End navigation, Enter/Space activation, typeahead, and existing Sugar High themes. File mutation and per-document cursor/scroll/undo management remain outside the tree.

The `/react` page preserves the standalone Code and Editor examples and adds a separate FileTree demo with a read-only checkbox. The selected filename appears in the card header. Examples share 13px monospace text, 22px rows, and compact filename bars. The tree uses a muted divider and neutral selection in an 800px responsive layout. Includes API documentation and a minor Changeset.

Rebased onto current `main`, which already contains #257, #259, and #260. This PR does not change the existing Code/Editor implementation, parser, dependencies, lockfile, or CI. The demo uses the shared layout fixes without temporary wrapping, padding, or empty-line workarounds.

Validation:
- `pnpm test`: 220 tests passed.
- Package builds (`pnpm -r --filter '!site' run build`), site TypeScript, and `git diff --check` passed.
- All 6 optional agent-browser layout checks passed.
- Local `/react` verification confirmed matching 22px tree/code rows, including blank rows in editable and read-only modes, after removing the temporary workarounds. Prior browser checks covered file editing persistence, keyboard navigation, and mobile layout.

React bundle measurements after rebasing (React external):

| Import | Minified | Gzip |
| --- | ---: | ---: |
| Code | 35.85 KiB | 12.52 KiB |
| Editor | 38.55 KiB | 13.47 KiB |
| Editor + FileTree | 42.33 KiB | 14.98 KiB |
| FileTree from the default entry | 35.41 KiB | 12.49 KiB |

Adding FileTree to Editor costs 3.78 KiB minified / 1.51 KiB gzip. Standalone FileTree imports retain shared editor/language dependencies from the default entry; no separate subpath is introduced here.
