### PR TITLE
fix: preserve decimal number tokens

### DIFF
--- a/.changeset/itchy-cows-fall.md
+++ b/.changeset/itchy-cows-fall.md
@@ -1,0 +1,5 @@
+---
+"sugar-high": patch
+---
+
+Keep decimal numbers together when highlighting JSON and other core languages.

--- a/packages/sugar-high/lib/core.js
+++ b/packages/sugar-high/lib/core.js
@@ -110,6 +110,10 @@ function tokenize(code, options) {
     if (isWord(curr)) {
       const start = i++
       while (i < code.length && isWord(code[i])) i++
+      if (/^\d/.test(curr) && code[i] === '.' && /\d/.test(code[i + 1] || '')) {
+        i++
+        while (i < code.length && isWord(code[i])) i++
+      }
       const value = code.slice(start, i)
       const normalized = normalize(value)
       const type = typeKeywords.has(normalized)

--- a/packages/sugar-high/test/preset/json.test.ts
+++ b/packages/sugar-high/test/preset/json.test.ts
@@ -5,6 +5,34 @@ import * as javascript from '../../lib/lang/javascript.js'
 import { getTokensAsString } from '../testing-utils'
 
 describe('tokenize - json preset', () => {
+  it('keeps decimal values together in the reported JSON example', () => {
+    const input = `// jar.json
+{
+  "title": "devjar",
+  "command": "npx devjar dev",
+  "color": "#8aa9cf",
+  "speed": 0.35,
+  "glass": 0.07
+}`
+    const tokens = tokenize(input, json)
+    const actual = getTokensAsString(tokens)
+    expect(tokens.map(([, value]) => value).join('')).toBe(input)
+    expect(actual.filter((token) => token.endsWith('=> class'))).toEqual([
+      '0.35 => class',
+      '0.07 => class',
+    ])
+    expect(actual).toContain('"speed" => property')
+    expect(actual).toContain('"#8aa9cf" => string')
+    expect(actual).toContain('// jar.json => comment')
+  })
+
+  it('preserves signs, integers, strings, and member access around decimals', () => {
+    expect(getTokensAsString(tokenize('-0.35 42 "0.07" item.value 0xff', json))).toEqual([
+      '- => sign', '0.35 => class', '42 => class', '"0.07" => string',
+      'item => identifier', '. => sign', 'value => property', '0xff => class',
+    ])
+  })
+
   it('supports JSONC comments in the canonical JSON preset', () => {
     const actual = getTokensAsString(tokenize('{\n  // note\n  "ok": true /* enabled */\n}', json))
     expect(actual).toContain('// note => comment')


### PR DESCRIPTION
Fixes #253.

Keep `0.35` and `0.07` from the reported example as single `class` tokens. Previously the decimal point was a sign and the fractional digits were properties. The shared scanner change is four lines; it reuses the existing numeric token type and adds no options or dependencies.

Regression tests cover the complete reported JSON example, source preservation, negative decimals, integers, quoted numbers, hex literals, and member access. Includes a patch Changeset.

Validation: `CI=1 pnpm test` (212 tests), `pnpm build`, `git diff --check`, and `pnpm --filter sugar-high benchmark` passed.

Bun browser ESM sizes, bytes (main → PR):

| Entry | Minified | Gzip |
| --- | ---: | ---: |
| sugar-high | 27,679 → 27,767 (+88) | 10,117 → 10,135 (+18) |
| sugar-high/core | 4,095 → 4,182 (+87) | 1,828 → 1,853 (+25) |
