### PR TITLE
fix: classify jsx boolean props as properties

### DIFF
--- a/.changeset/hungry-jobs-grin.md
+++ b/.changeset/hungry-jobs-grin.md
@@ -1,0 +1,5 @@
+---
+"sugar-high": patch
+---
+
+Classify JSX boolean props as properties and preserve numeric types in prop expressions.

--- a/packages/sugar-high/lib/presets/javascript-runtime.js
+++ b/packages/sugar-high/lib/presets/javascript-runtime.js
@@ -283,6 +283,7 @@ function tokenize(code, options) {
   /** @type {0 | 1 | 2} 0 = none; 1 = inside `<open`; 2 = inside `</close` */
   let __jsxTag = 0
   let __jsxExpr = false
+  let __jsxTagExpr = 0
 
   /** Nested `<open>…</open>` depth (content between tags, including nested elements). */
   let __jsxStack = 0
@@ -323,6 +324,8 @@ function tokenize(code, options) {
         // classify jsx open tag
         if ((lastToken === '<' || lastToken === '</'))
           return T_ENTITY
+        if (!__jsxTagExpr && /^\s+$/.test(tokens[tokens.length - 1]?.[1] || ''))
+          return T_PROPERTY
       }
     }
     // Then determine if they're jsx literals
@@ -343,7 +346,7 @@ function tokenize(code, options) {
     } else if (token.split('').every(isSign)) {
       return T_SIGN
     } else if (isCls(token)) {
-      return inJsxTag() ? T_IDENTIFIER : T_CLS_NUMBER
+      return inJsxTag() && !__jsxTagExpr ? T_IDENTIFIER : T_CLS_NUMBER
     } else {
       if (isIdentifier(token)) {
         const isLastPropDot = last[1] === '.' && isIdentifier(beforeLast[1])
@@ -371,6 +374,10 @@ function tokenize(code, options) {
       if (type !== T_SPACE && type !== T_BREAK) {
         beforeLast = last
         last = pair
+      }
+      if (inJsxTag() && type === T_SIGN) {
+        if (current === '{') __jsxTagExpr++
+        if (current === '}') __jsxTagExpr--
       }
       tokens.push(pair)
     }

--- a/packages/sugar-high/test/ast.test.ts
+++ b/packages/sugar-high/test/ast.test.ts
@@ -465,7 +465,7 @@ describe('jsx', () => {
         "= => sign",
         "> => sign",
         " => space",
-        "1 => identifier",
+        "1 => class",
         ") => sign",
         "} => sign",
         " => space",

--- a/packages/sugar-high/test/tokenize.test.ts
+++ b/packages/sugar-high/test/tokenize.test.ts
@@ -6,6 +6,45 @@ import { getTokensAsString } from './testing-utils'
 const tokenize = (code, options = {}) =>
   core.tokenize(code, { ...javascript, ...options })
 
+describe('tokenize - JSX boolean props', () => {
+  it('classifies the reported props without changing expression tokens', () => {
+    const input = `<Code
+  title="example.js"
+  lang="javascript"
+  theme={taffy}
+  controls
+  lineNumbers
+  highlightLines={[1, [5, 6]]}
+>`
+    const tokens = tokenize(input)
+    const actual = getTokensAsString(tokens)
+    expect(tokens.map(([, value]) => value).join('')).toBe(input)
+    expect(actual.filter((token) => token.endsWith('=> property'))).toEqual([
+      'title => property', 'lang => property', 'theme => property',
+      'controls => property', 'lineNumbers => property', 'highlightLines => property',
+    ])
+    expect(actual).toContain('Code => entity')
+    expect(actual).toContain('taffy => identifier')
+    expect(actual.filter((token) => token.endsWith('=> class'))).toEqual([
+      '1 => class', '5 => class', '6 => class',
+    ])
+  })
+
+  it.each(['<input disabled/>', '<input disabled>', '<input disabled />'])('%s', (input) => {
+    expect(getTokensAsString(tokenize(input))).toContain('disabled => property')
+  })
+
+  it('keeps nested expression identifiers and member tag names distinct from props', () => {
+    const actual = getTokensAsString(tokenize(
+      '<UI.Button options={{ value: active }} disabled>{label}</UI.Button>'
+    ))
+    expect(actual).toContain('active => identifier')
+    expect(actual).toContain('disabled => property')
+    expect(actual).not.toContain('Button => property')
+    expect(actual).toContain('label => identifier')
+  })
+})
+
 describe('tokenize - typeKeywords', () => {
   it('classifies typeKeywords as class before keywords', () => {
     const input = 'int x'


### PR DESCRIPTION
Fixes #254.

Classify standalone JSX props such as `controls` and `lineNumbers` as properties. Track brace depth in attribute expressions to preserve identifiers inside them, and classify the reported expression numbers `1`, `5`, and `6` as numbers (`class`). The fix uses a small brace counter and classification check, with no new options or dependencies.

Regression tests cover the complete reported example, source preservation, boolean props before opening/self-closing tag endings, nested object expressions, and member tag names. Update one existing snapshot where an arrow-function prop returns a number. Also verified the reported example with the TypeScript preset. Includes a patch Changeset.

Validation: `CI=1 pnpm test` (215 tests), `pnpm build`, `git diff --check`, and `pnpm --filter sugar-high benchmark` passed.

Bun browser ESM sizes, bytes (main → PR):

| Entry | Minified | Gzip |
| --- | ---: | ---: |
| sugar-high | 27,679 → 27,791 (+112) | 10,117 → 10,163 (+46) |
| sugar-high/core | 4,095 → 4,095 | 1,828 → 1,828 |
