### PR TITLE
fix: inherit editor typography across text layers

### DIFF
--- a/.changeset/loud-donuts-appear.md
+++ b/.changeset/loud-donuts-appear.md
@@ -2,4 +2,4 @@
 "@sugar-high/react": patch
 ---
 
-Keep editor text and highlighting aligned by inheriting font size, line height, and letter spacing from the root.
+Keep editor text and highlighting aligned by inheriting font size, line height, and letter spacing from the root, and prevent later global code styles from changing the highlighted layer's typography independently.

--- a/.changeset/loud-donuts-appear.md
+++ b/.changeset/loud-donuts-appear.md
@@ -1,0 +1,5 @@
+---
+"@sugar-high/react": patch
+---
+
+Keep editor text and highlighting aligned by inheriting font size, line height, and letter spacing from the root.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,27 @@ on:
   pull_request:
 
 jobs:
+  react-layout:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          package-manager-cache: false
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @sugar-high/react build
+      - name: Install browser tooling
+        run: |
+          pnpm add --global agent-browser@0.36.0
+          agent-browser install --with-deps
+      - run: pnpm --filter @sugar-high/react test:browser
+
   test:
     runs-on: ubuntu-latest
     permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,9 @@
 - For React layout changes, build the React package and optionally run
   `pnpm --filter @sugar-high/react test:browser`. This uses an existing `agent-browser` installation
   to verify the built components without a site server. It skips successfully when the CLI is
-  absent; do not install browser tooling just to run it. It is not part of the default tests or CI.
+  absent locally; do not install browser tooling just to run it locally. CI installs a pinned CLI
+  and runs it in the separate `react-layout` job on pushes to `main` (including merged PRs).
+  It is not part of PR checks or the default unit tests.
 - Keep internal package dependencies on `workspace:^` (or `workspace:*` for private apps); pnpm
   rewrites them to normal semver ranges when publishing.
 - Add a Changeset with `pnpm changeset` for user-facing package changes. Do not add one for

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -48,6 +48,23 @@ disable wrapping to use horizontal scrolling instead. Both options also work wit
 At the same font and width, `Code` and `Editor` use the same wrapping rules. Empty lines retain
 a full line height. `fontSize` applies to source text and filename headers in both components.
 
+Set editor typography once on the root; the textarea and highlighted code inherit it together:
+
+```jsx
+<Editor value={code} onChange={setCode} style={{ fontSize: 14, lineHeight: 1.6 }} />
+```
+
+You can also set these styles through `className`, or use the existing `fontSize` and
+`fontFamily` props. The default editor line height is `1.5`.
+
+The browser layout suite runs with `pnpm --filter @sugar-high/react test:browser` after
+building the package. It uses Node's test runner and an installed `agent-browser` CLI,
+without a site server. It checks typography, blank lines, wrapping, horizontal overflow,
+and highlighted character positions against a plain-text mirror of the textarea at
+multiple widths. CI installs a pinned CLI and runs the suite in a separate job on
+pushes to `main`, including merged PRs. PR checks skip this job; locally the suite
+skips if the CLI is absent.
+
 ```tsx
 <Code lineNumbers startingLineNumber={40} wrapLongLines={false}>
   {source}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -35,7 +35,7 @@
     "benchmark": "node scripts/benchmark.mjs",
     "test": "vitest --run",
     "prepublishOnly": "pnpm build",
-    "test:browser": "node scripts/test-layout.mjs"
+    "test:browser": "node --test scripts/test-layout.mjs"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",

--- a/packages/react/scripts/test-layout.mjs
+++ b/packages/react/scripts/test-layout.mjs
@@ -114,6 +114,10 @@ test('built React components preserve layout', { skip: missingBrowser && 'agent-
           assert.deepEqual(positions[0], positions[1], `Wrapping must match at width=${width}, lineNumbers=${lineNumbers}`)
 
           const overlayPositions = read(() => {
+            // Site styles can load after component styles in a deployed page.
+            const siteStyle = document.createElement('style')
+            siteStyle.textContent = '[data-codice-code] code { font-family: serif; font-size: 12px; line-height: 2; letter-spacing: 1px }'
+            document.head.append(siteStyle)
             const editor = document.querySelector('[data-sh-editor]')
             const textarea = editor.querySelector('textarea')
             // Textarea text has no DOM ranges. Mirror its computed styles in a plain

--- a/packages/react/scripts/test-layout.mjs
+++ b/packages/react/scripts/test-layout.mjs
@@ -1,19 +1,18 @@
 import assert from 'node:assert/strict'
+import { test } from 'node:test'
 import { execFileSync, spawnSync } from 'node:child_process'
 
 const detected = spawnSync('agent-browser', ['--version'], { encoding: 'utf8', timeout: 10000 })
-if (detected.error?.code === 'ENOENT') {
-  console.log('Skipped layout verification: agent-browser is not installed.')
-  process.exit(0)
-}
-if (detected.error || detected.status !== 0) {
+const missingBrowser = detected.error?.code === 'ENOENT'
+if (missingBrowser && process.env.CI) throw new Error('agent-browser must be installed in CI')
+if (!missingBrowser && (detected.error || detected.status !== 0)) {
   throw detected.error ?? new Error(detected.stderr || 'agent-browser failed to start')
 }
 
 // Use the built package, so verification also exercises its emitted styles.
 const { createElement: h } = await import('react')
 const { renderToString } = await import('react-dom/server')
-const { Code, Editor } = await import('../dist/index.js')
+let Code, Editor
 const session = `sugar-layout-${process.pid}`
 const source = "import { Button } from './components/button'\n\nexport default Button\n"
 
@@ -41,61 +40,136 @@ function read(fn) {
   return browser(['eval', '--stdin'], `(${fn.toString()})()`).result
 }
 
-try {
-  browser(['open', 'about:blank'], undefined)
-  render({ fontFamily: 'monospace', fontSize: 18 },
-    { title: 'index.tsx', fontSize: 13 }, { title: 'index.tsx', fontSize: 13 }, '')
-  const sizes = read(() => [...document.querySelectorAll('code, textarea, [data-sh-title]')]
-    .map(element => getComputedStyle(element).fontSize))
-  assert(sizes.length > 0 && sizes.every(size => size === '13px'), 'Source and filenames must respect fontSize')
+test('built React components preserve layout', { skip: missingBrowser && 'agent-browser is not installed' }, async t => {
+  const components = await import('../dist/index.js')
+  Code = components.Code
+  Editor = components.Editor
+  try {
+    browser(['open', 'about:blank'], undefined)
+    await t.test('fontSize applies to source and headers', () => {
+      render({ fontFamily: 'monospace', fontSize: 18 },
+        { title: 'index.tsx', fontSize: 13 }, { title: 'index.tsx', fontSize: 13 }, '')
+      const sizes = read(() => [...document.querySelectorAll('code, textarea, [data-sh-title]')]
+        .map(element => getComputedStyle(element).fontSize))
+      assert(sizes.length > 0 && sizes.every(size => size === '13px'), 'Source and filenames must respect fontSize')
+    })
 
-  for (const lineNumbers of [true, false]) {
-    render({ fontFamily: 'monospace', fontSize: 13, lineHeight: '22px' },
-      { lineNumbers }, { lineNumbers },
-      '.sh__line { display: block; min-height: 1em } [data-sh-code-line-number] { position: absolute }')
-    const rows = read(() => [...document.querySelectorAll('code')].map(block =>
-      [...block.querySelectorAll('.sh__line')].map(element => ({
-        height: element.getBoundingClientRect().height,
-        lineHeight: parseFloat(getComputedStyle(element).lineHeight),
-      }))))
-    for (const block of rows) {
-      assert(block.length >= 3)
-      assert(block.every(row => row.height >= row.lineHeight), `Empty rows must retain line height (lineNumbers=${lineNumbers})`)
-    }
+    await t.test('editor layers inherit root typography', () => {
+      for (const editorProps of [
+        { style: { fontSize: 17, lineHeight: '31px', letterSpacing: '0.5px' } },
+        { fontSize: '1.25em', style: { lineHeight: 1.8 } },
+      ]) {
+        render({ fontSize: 16 }, {}, editorProps,
+          'code { font-size: .95em; letter-spacing: 0 } textarea { font: inherit }')
+        const typography = read(() => {
+          const editor = document.querySelector('[data-sh-editor]')
+          return [editor, ...editor.querySelectorAll('[data-sh-code], pre, code, textarea, .sh__line')]
+            .map(element => {
+              const style = getComputedStyle(element)
+              return [style.fontSize, style.lineHeight, style.letterSpacing]
+            })
+        })
+        for (const layer of typography.slice(1)) {
+          assert.deepEqual(layer, typography[0], 'Editor layers must inherit root typography without scaling it again')
+        }
+      }
+    })
 
-    for (const width of [240, 390, 600]) {
-      render({ width, fontFamily: 'monospace', fontSize: 13, lineHeight: 1.5 },
-        { lineNumbers }, { lineNumbers }, '* { box-sizing: border-box }')
-      const positions = read(() => [...document.querySelectorAll('code > .sh__line:first-child')].map(line => {
-        const origin = line.getBoundingClientRect()
-        const walker = document.createTreeWalker(line, NodeFilter.SHOW_TEXT)
-        const positions = []
-        while (walker.nextNode()) {
-          const node = walker.currentNode
-          if (node.parentElement?.closest('[data-sh-code-line-number]')) continue
-          for (let index = 0; index < (node.textContent?.length ?? 0); index++) {
-            const range = document.createRange()
-            range.setStart(node, index)
-            range.setEnd(node, index + 1)
-            const rect = range.getBoundingClientRect()
-            positions.push([rect.x - origin.x, rect.y - origin.y])
+    await t.test('empty lines and wrapped text retain matching geometry', () => {
+      for (const lineNumbers of [true, false]) {
+        render({ fontFamily: 'monospace', fontSize: 13, lineHeight: '22px' },
+          { lineNumbers }, { lineNumbers },
+          '.sh__line { display: block; min-height: 1em } [data-sh-code-line-number] { position: absolute }')
+        const rows = read(() => [...document.querySelectorAll('code')].map(block =>
+          [...block.querySelectorAll('.sh__line')].map(element => ({
+            height: element.getBoundingClientRect().height,
+            lineHeight: parseFloat(getComputedStyle(element).lineHeight),
+          }))))
+        for (const block of rows) {
+          assert(block.length >= 3)
+          assert(block.every(row => row.height >= row.lineHeight), `Empty rows must retain line height (lineNumbers=${lineNumbers})`)
+        }
+
+        for (const width of [240, 390, 600]) {
+          render({ width, fontFamily: 'monospace', fontSize: 13, lineHeight: 1.5 },
+            { lineNumbers }, { lineNumbers }, '* { box-sizing: border-box }')
+          const positions = read(() => [...document.querySelectorAll('code > .sh__line:first-child')].map(line => {
+            const origin = line.getBoundingClientRect()
+            const walker = document.createTreeWalker(line, NodeFilter.SHOW_TEXT)
+            const positions = []
+            while (walker.nextNode()) {
+              const node = walker.currentNode
+              if (node.parentElement?.closest('[data-sh-code-line-number]')) continue
+              for (let index = 0; index < (node.textContent?.length ?? 0); index++) {
+                const range = document.createRange()
+                range.setStart(node, index)
+                range.setEnd(node, index + 1)
+                const rect = range.getBoundingClientRect()
+                positions.push([rect.x - origin.x, rect.y - origin.y])
+              }
+            }
+            return positions
+          }))
+          assert.equal(positions.length, 2)
+          assert.deepEqual(positions[0], positions[1], `Wrapping must match at width=${width}, lineNumbers=${lineNumbers}`)
+
+          const overlayPositions = read(() => {
+            const editor = document.querySelector('[data-sh-editor]')
+            const textarea = editor.querySelector('textarea')
+            // Textarea text has no DOM ranges. Mirror its computed styles in a plain
+            // text box so ranges expose wrapping and glyph positions for comparison.
+            const mirror = document.createElement('div')
+            const style = getComputedStyle(textarea)
+            for (const property of style) mirror.style.setProperty(property, style.getPropertyValue(property))
+            const rect = textarea.getBoundingClientRect()
+            Object.assign(mirror.style, {
+              position: 'absolute', left: `${rect.x + scrollX}px`, top: `${rect.y + scrollY}px`,
+              right: 'auto', bottom: 'auto', visibility: 'hidden',
+            })
+            mirror.textContent = textarea.value
+            document.body.append(mirror)
+            const positions = [editor.querySelector('code'), mirror].map(element => {
+              const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
+              const result = []
+              while (walker.nextNode()) {
+                const node = walker.currentNode
+                if (node.parentElement.closest('[data-sh-code-line-number]')) continue
+                for (let index = 0; index < node.length; index++) {
+                  if (node.textContent[index] === '\n') continue
+                  const range = document.createRange()
+                  range.setStart(node, index)
+                  range.setEnd(node, index + 1)
+                  const rect = range.getBoundingClientRect()
+                  result.push([rect.x, rect.y])
+                }
+              }
+              return result
+            })
+            mirror.remove()
+            return positions
+          })
+          assert.equal(overlayPositions[0].length, overlayPositions[1].length)
+          for (let index = 0; index < overlayPositions[0].length; index++) {
+            for (const axis of [0, 1]) {
+              assert(Math.abs(overlayPositions[0][index][axis] - overlayPositions[1][index][axis]) < 0.5,
+                `Textarea and highlight differ at character ${index}, axis=${axis}, width=${width}, lineNumbers=${lineNumbers}`)
+            }
           }
         }
-        return positions
-      }))
-      assert.equal(positions.length, 2)
-      assert.deepEqual(positions[0], positions[1], `Wrapping must match at width=${width}, lineNumbers=${lineNumbers}`)
-    }
+      }
+    })
+
+    await t.test('non-wrapping code scrolls horizontally', () => {
+      render({ width: 180, fontFamily: 'monospace', fontSize: 13 },
+        { wrapLongLines: false }, { wrapLongLines: false }, '')
+      const frames = read(() => [...document.querySelectorAll('pre')].map(element => ({
+        whiteSpace: getComputedStyle(element).whiteSpace,
+        overflow: element.scrollWidth > element.clientWidth,
+      })))
+      assert.deepEqual(frames, [{ whiteSpace: 'pre', overflow: true }, { whiteSpace: 'pre', overflow: true }])
+    })
+  } finally {
+    browser(['close'], undefined)
   }
 
-  render({ width: 180, fontFamily: 'monospace', fontSize: 13 },
-    { wrapLongLines: false }, { wrapLongLines: false }, '')
-  const frames = read(() => [...document.querySelectorAll('pre')].map(element => ({
-    whiteSpace: getComputedStyle(element).whiteSpace,
-    overflow: element.scrollWidth > element.clientWidth,
-  })))
-  assert.deepEqual(frames, [{ whiteSpace: 'pre', overflow: true }, { whiteSpace: 'pre', overflow: true }])
-  console.log('Passed 6 layout checks: font sizing, empty rows and matching wrapping with/without line numbers, and horizontal scrolling.')
-} finally {
-  browser(['close'], undefined)
-}
+})

--- a/packages/react/src/editor/css.ts
+++ b/packages/react/src/editor/css.ts
@@ -13,9 +13,19 @@ ${R} {
   justify-content: stretch;
   scrollbar-width: none;
   font-size: var(--sh-font-size);
+  line-height: 1.5;
+  letter-spacing: 0;
 }
 ${R} textarea:not(:placeholder-shown) {
   padding: calc(var(--sh-padding) * 0.75) calc(var(--sh-padding) * 0.5);
+}
+${R} [data-sh-code],
+${R} pre,
+${R} code,
+${R} textarea {
+  font-size: inherit;
+  line-height: inherit;
+  letter-spacing: inherit;
 }
 ${R} code,
 ${R} textarea {
@@ -23,8 +33,6 @@ ${R} textarea {
   line-break: anywhere;
   overflow-wrap: break-word;
   scrollbar-width: none;
-  line-height: 1.5;
-  font-size: var(--sh-font-size);
   caret-color: var(--sh-caret-color, CanvasText);
   border: none;
   outline: none;

--- a/packages/react/src/editor/css.ts
+++ b/packages/react/src/editor/css.ts
@@ -21,13 +21,13 @@ ${R} textarea:not(:placeholder-shown) {
 }
 ${R} [data-sh-code],
 ${R} pre,
-${R} code,
+${R} [data-sh-code] code,
 ${R} textarea {
   font-size: inherit;
   line-height: inherit;
   letter-spacing: inherit;
 }
-${R} code,
+${R} [data-sh-code] code,
 ${R} textarea {
   font-family: var(--sh-font-family);
   line-break: anywhere;

--- a/packages/react/src/editor/editor.test.tsx
+++ b/packages/react/src/editor/editor.test.tsx
@@ -91,9 +91,19 @@ describe('Code', () => {
         justify-content: stretch;
         scrollbar-width: none;
         font-size: var(--sh-font-size);
+        line-height: 1.5;
+        letter-spacing: 0;
       }
       [data-sh-editor] textarea:not(:placeholder-shown) {
         padding: calc(var(--sh-padding) * 0.75) calc(var(--sh-padding) * 0.5);
+      }
+      [data-sh-editor] [data-sh-code],
+      [data-sh-editor] pre,
+      [data-sh-editor] code,
+      [data-sh-editor] textarea {
+        font-size: inherit;
+        line-height: inherit;
+        letter-spacing: inherit;
       }
       [data-sh-editor] code,
       [data-sh-editor] textarea {
@@ -101,8 +111,6 @@ describe('Code', () => {
         line-break: anywhere;
         overflow-wrap: break-word;
         scrollbar-width: none;
-        line-height: 1.5;
-        font-size: var(--sh-font-size);
         caret-color: var(--sh-caret-color, CanvasText);
         border: none;
         outline: none;
@@ -262,9 +270,19 @@ describe('Code', () => {
         justify-content: stretch;
         scrollbar-width: none;
         font-size: var(--sh-font-size);
+        line-height: 1.5;
+        letter-spacing: 0;
       }
       [data-sh-editor] textarea:not(:placeholder-shown) {
         padding: calc(var(--sh-padding) * 0.75) calc(var(--sh-padding) * 0.5);
+      }
+      [data-sh-editor] [data-sh-code],
+      [data-sh-editor] pre,
+      [data-sh-editor] code,
+      [data-sh-editor] textarea {
+        font-size: inherit;
+        line-height: inherit;
+        letter-spacing: inherit;
       }
       [data-sh-editor] code,
       [data-sh-editor] textarea {
@@ -272,8 +290,6 @@ describe('Code', () => {
         line-break: anywhere;
         overflow-wrap: break-word;
         scrollbar-width: none;
-        line-height: 1.5;
-        font-size: var(--sh-font-size);
         caret-color: var(--sh-caret-color, CanvasText);
         border: none;
         outline: none;
@@ -433,9 +449,19 @@ describe('Code', () => {
         justify-content: stretch;
         scrollbar-width: none;
         font-size: var(--sh-font-size);
+        line-height: 1.5;
+        letter-spacing: 0;
       }
       [data-sh-editor] textarea:not(:placeholder-shown) {
         padding: calc(var(--sh-padding) * 0.75) calc(var(--sh-padding) * 0.5);
+      }
+      [data-sh-editor] [data-sh-code],
+      [data-sh-editor] pre,
+      [data-sh-editor] code,
+      [data-sh-editor] textarea {
+        font-size: inherit;
+        line-height: inherit;
+        letter-spacing: inherit;
       }
       [data-sh-editor] code,
       [data-sh-editor] textarea {
@@ -443,8 +469,6 @@ describe('Code', () => {
         line-break: anywhere;
         overflow-wrap: break-word;
         scrollbar-width: none;
-        line-height: 1.5;
-        font-size: var(--sh-font-size);
         caret-color: var(--sh-caret-color, CanvasText);
         border: none;
         outline: none;

--- a/packages/react/src/editor/editor.test.tsx
+++ b/packages/react/src/editor/editor.test.tsx
@@ -99,13 +99,13 @@ describe('Code', () => {
       }
       [data-sh-editor] [data-sh-code],
       [data-sh-editor] pre,
-      [data-sh-editor] code,
+      [data-sh-editor] [data-sh-code] code,
       [data-sh-editor] textarea {
         font-size: inherit;
         line-height: inherit;
         letter-spacing: inherit;
       }
-      [data-sh-editor] code,
+      [data-sh-editor] [data-sh-code] code,
       [data-sh-editor] textarea {
         font-family: var(--sh-font-family);
         line-break: anywhere;
@@ -278,13 +278,13 @@ describe('Code', () => {
       }
       [data-sh-editor] [data-sh-code],
       [data-sh-editor] pre,
-      [data-sh-editor] code,
+      [data-sh-editor] [data-sh-code] code,
       [data-sh-editor] textarea {
         font-size: inherit;
         line-height: inherit;
         letter-spacing: inherit;
       }
-      [data-sh-editor] code,
+      [data-sh-editor] [data-sh-code] code,
       [data-sh-editor] textarea {
         font-family: var(--sh-font-family);
         line-break: anywhere;
@@ -457,13 +457,13 @@ describe('Code', () => {
       }
       [data-sh-editor] [data-sh-code],
       [data-sh-editor] pre,
-      [data-sh-editor] code,
+      [data-sh-editor] [data-sh-code] code,
       [data-sh-editor] textarea {
         font-size: inherit;
         line-height: inherit;
         letter-spacing: inherit;
       }
-      [data-sh-editor] code,
+      [data-sh-editor] [data-sh-code] code,
       [data-sh-editor] textarea {
         font-family: var(--sh-font-family);
         line-break: anywhere;


### PR DESCRIPTION
Editor hard-coded typography on its inner layers, so setting line height on the root did not update the textarea and highlighted code consistently. The site also has a global code font rule with the same specificity as the old editor rule: when it loads later, the highlighted layer uses a different font from the textarea, producing horizontal selection drift. Editor typography now has sufficient specificity to override those global code styles. Both layers now inherit font size, line height, and letter spacing from the root: `style={{ fontSize: 14, lineHeight: 1.6 }}` controls them together. Existing fontSize and fontFamily props remain supported, and a patch Changeset documents the fix.

Convert the browser layout script into named Node tests and compare highlighted character positions against a plain-text mirror of the textarea at multiple widths, with and without line numbers, including conflicting global typography loaded after component styles. A separate CI job installs pinned agent-browser 0.36.0 and runs only on pushes to main, including merged PRs. Missing tooling skips locally and fails in CI.

Validation:
- `pnpm test` passed (217 tests).
- `pnpm --filter '!site' build` passed; excluded the site production build per development-server verification instructions.
- Browser suite passed locally in about 3 seconds; deliberately shifting textarea padding makes the geometry check fail.
- Verified root typography changes and Chrome text selection on `/react` at localhost:3000, including the site font rule loaded last. The new regression fails before the specificity fix and passes afterward. Also captured native selected textarea text and highlighted text separately in the same color and position: every dark glyph pixel matched within one pixel in both directions; remaining raster differences are antialiasing.
- Verified missing-browser behavior locally and in CI mode; `git diff --check` passed.
- React benchmark: root entry 36.00 KiB minified / 12.55 KiB gzip; core + python 9.56 KiB / 3.75 KiB.

Direct visual verification of the protected Vercel preview remains unavailable; the screenshot comparison was performed on the local development server. The GitHub Actions browser installation has not been exercised locally. The browser job intentionally does not run on PRs.
