### PR TITLE
fix: align blank lines in code and editor

### DIFF
--- a/.changeset/heavy-pianos-check.md
+++ b/.changeset/heavy-pianos-check.md
@@ -1,0 +1,5 @@
+---
+"@sugar-high/react": minor
+---
+
+Render highlighted lines in Code and Editor as blocks to prevent extra baseline spacing after blank lines and keep editor selection aligned. Custom styles relying on inline-block line alignment should be reviewed.

--- a/.changeset/polite-rules-begin.md
+++ b/.changeset/polite-rules-begin.md
@@ -1,5 +1,0 @@
----
-"@sugar-high/react": patch
----
-
-Fix editor selection drift after blank lines by rendering highlighted lines as blocks instead of inline blocks.

--- a/.changeset/polite-rules-begin.md
+++ b/.changeset/polite-rules-begin.md
@@ -1,0 +1,5 @@
+---
+"@sugar-high/react": patch
+---
+
+Fix editor selection drift after blank lines by rendering highlighted lines as blocks instead of inline blocks.

--- a/apps/site/app/react/page.css
+++ b/apps/site/app/react/page.css
@@ -192,10 +192,6 @@
   vertical-align: baseline;
 }
 
-.react-product [data-sh-code] .sh__line {
-  display: block;
-}
-
 .react-product [data-highlight] {
   background: #dff1ff;
 }

--- a/apps/site/app/react/page.css
+++ b/apps/site/app/react/page.css
@@ -192,7 +192,7 @@
   vertical-align: baseline;
 }
 
-.react-product .sh__line {
+.react-product [data-sh-code] .sh__line {
   display: block;
 }
 

--- a/packages/react/scripts/test-layout.mjs
+++ b/packages/react/scripts/test-layout.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
+import { readFileSync } from 'node:fs'
 import { execFileSync, spawnSync } from 'node:child_process'
 
 const detected = spawnSync('agent-browser', ['--version'], { encoding: 'utf8', timeout: 10000 })
@@ -31,7 +32,7 @@ function render(style, codeProps, editorProps, css) {
     h(Editor, { fontFamily: 'monospace', value: source, ...editorProps }),
   ))
   browser(['eval', '--stdin'], `(() => {
-    document.open(); document.write(${JSON.stringify('<!doctype html>' + html)}); document.close();
+    document.open(); document.write(${JSON.stringify(html)}); document.close();
     const style = document.createElement('style'); style.textContent = ${JSON.stringify(css)}; document.head.append(style);
   })()`)
 }
@@ -46,6 +47,28 @@ test('built React components preserve layout', { skip: missingBrowser && 'agent-
   Editor = components.Editor
   try {
     browser(['open', 'about:blank'], undefined)
+    await t.test('React page editor stays aligned regardless of stylesheet order', () => {
+      const siteCss = ['global.css', 'styles.css', 'react/page.css']
+        .map(file => readFileSync(new URL(`../../../apps/site/app/${file}`, import.meta.url), 'utf8'))
+        .join('\n')
+      for (const lineNumbers of [true, false]) {
+        for (const siteFirst of [true, false]) {
+          const html = renderToString(h('div', { className: 'react-product' },
+            h(Editor, { className: 'react-demo__editor', value: source, lineNumbers })))
+          const style = `<style>${siteCss}</style>`
+          const documentHtml = '<!doctype html>' + (siteFirst ? style + html : html + style)
+          browser(['eval', '--stdin'], `document.open(); document.write(${JSON.stringify(documentHtml)}); document.close();`)
+          const rows = read(() => [...document.querySelectorAll('[data-sh-editor] .sh__line')]
+            .map(element => ({ top: element.getBoundingClientRect().top, height: element.getBoundingClientRect().height })))
+          assert(rows.length >= 3)
+          for (let index = 1; index < rows.length; index++) {
+            assert.equal(rows[index].top, rows[index - 1].top + rows[index - 1].height,
+              `Page editor has a baseline gap (lineNumbers=${lineNumbers}, siteFirst=${siteFirst})`)
+          }
+        }
+      }
+    })
+
     await t.test('fontSize applies to source and headers', () => {
       render({ fontFamily: 'monospace', fontSize: 18 },
         { title: 'index.tsx', fontSize: 13 }, { title: 'index.tsx', fontSize: 13 }, '')
@@ -77,22 +100,17 @@ test('built React components preserve layout', { skip: missingBrowser && 'agent-
 
     await t.test('empty lines and wrapped text retain matching geometry', () => {
       for (const lineNumbers of [true, false]) {
-        render({ fontFamily: 'Consolas, Monaco, monospace', fontSize: 15, lineHeight: '22.5px' },
-          { lineNumbers }, { lineNumbers, fontFamily: 'Consolas, Monaco, monospace' },
-          '* { box-sizing: border-box } .sh__line { min-height: 1em } [data-sh-code-line-number] { position: absolute }')
+        render({ fontFamily: 'monospace', fontSize: 13, lineHeight: '22px' },
+          { lineNumbers }, { lineNumbers },
+          '.sh__line { display: block; min-height: 1em } [data-sh-code-line-number] { position: absolute }')
         const rows = read(() => [...document.querySelectorAll('code')].map(block =>
           [...block.querySelectorAll('.sh__line')].map(element => ({
-            top: element.getBoundingClientRect().top,
             height: element.getBoundingClientRect().height,
             lineHeight: parseFloat(getComputedStyle(element).lineHeight),
           }))))
         for (const block of rows) {
           assert(block.length >= 3)
           assert(block.every(row => row.height >= row.lineHeight), `Empty rows must retain line height (lineNumbers=${lineNumbers})`)
-          for (let index = 1; index < block.length; index++) {
-            assert.equal(block[index].top, block[index - 1].top + block[index - 1].height,
-              `Blank lines must not add baseline gaps (lineNumbers=${lineNumbers}, line=${index + 1})`)
-          }
         }
 
         for (const width of [240, 390, 600]) {
@@ -121,7 +139,7 @@ test('built React components preserve layout', { skip: missingBrowser && 'agent-
           const overlayPositions = read(() => {
             // Site styles can load after component styles in a deployed page.
             const siteStyle = document.createElement('style')
-            siteStyle.textContent = '[data-codice-code] code { font-family: serif; font-size: 12px; line-height: 2; letter-spacing: 1px } [data-sh-code-line-number] { position: absolute }'
+            siteStyle.textContent = '[data-codice-code] code { font-family: serif; font-size: 12px; line-height: 2; letter-spacing: 1px }'
             document.head.append(siteStyle)
             const editor = document.querySelector('[data-sh-editor]')
             const textarea = editor.querySelector('textarea')

--- a/packages/react/scripts/test-layout.mjs
+++ b/packages/react/scripts/test-layout.mjs
@@ -31,7 +31,7 @@ function render(style, codeProps, editorProps, css) {
     h(Editor, { fontFamily: 'monospace', value: source, ...editorProps }),
   ))
   browser(['eval', '--stdin'], `(() => {
-    document.open(); document.write(${JSON.stringify(html)}); document.close();
+    document.open(); document.write(${JSON.stringify('<!doctype html>' + html)}); document.close();
     const style = document.createElement('style'); style.textContent = ${JSON.stringify(css)}; document.head.append(style);
   })()`)
 }
@@ -77,17 +77,22 @@ test('built React components preserve layout', { skip: missingBrowser && 'agent-
 
     await t.test('empty lines and wrapped text retain matching geometry', () => {
       for (const lineNumbers of [true, false]) {
-        render({ fontFamily: 'monospace', fontSize: 13, lineHeight: '22px' },
-          { lineNumbers }, { lineNumbers },
-          '.sh__line { display: block; min-height: 1em } [data-sh-code-line-number] { position: absolute }')
+        render({ fontFamily: 'Consolas, Monaco, monospace', fontSize: 15, lineHeight: '22.5px' },
+          { lineNumbers }, { lineNumbers, fontFamily: 'Consolas, Monaco, monospace' },
+          '* { box-sizing: border-box } .sh__line { min-height: 1em } [data-sh-code-line-number] { position: absolute }')
         const rows = read(() => [...document.querySelectorAll('code')].map(block =>
           [...block.querySelectorAll('.sh__line')].map(element => ({
+            top: element.getBoundingClientRect().top,
             height: element.getBoundingClientRect().height,
             lineHeight: parseFloat(getComputedStyle(element).lineHeight),
           }))))
         for (const block of rows) {
           assert(block.length >= 3)
           assert(block.every(row => row.height >= row.lineHeight), `Empty rows must retain line height (lineNumbers=${lineNumbers})`)
+          for (let index = 1; index < block.length; index++) {
+            assert.equal(block[index].top, block[index - 1].top + block[index - 1].height,
+              `Blank lines must not add baseline gaps (lineNumbers=${lineNumbers}, line=${index + 1})`)
+          }
         }
 
         for (const width of [240, 390, 600]) {
@@ -116,7 +121,7 @@ test('built React components preserve layout', { skip: missingBrowser && 'agent-
           const overlayPositions = read(() => {
             // Site styles can load after component styles in a deployed page.
             const siteStyle = document.createElement('style')
-            siteStyle.textContent = '[data-codice-code] code { font-family: serif; font-size: 12px; line-height: 2; letter-spacing: 1px }'
+            siteStyle.textContent = '[data-codice-code] code { font-family: serif; font-size: 12px; line-height: 2; letter-spacing: 1px } [data-sh-code-line-number] { position: absolute }'
             document.head.append(siteStyle)
             const editor = document.querySelector('[data-sh-editor]')
             const textarea = editor.querySelector('textarea')

--- a/packages/react/scripts/test-layout.mjs
+++ b/packages/react/scripts/test-layout.mjs
@@ -32,7 +32,7 @@ function render(style, codeProps, editorProps, css) {
     h(Editor, { fontFamily: 'monospace', value: source, ...editorProps }),
   ))
   browser(['eval', '--stdin'], `(() => {
-    document.open(); document.write(${JSON.stringify(html)}); document.close();
+    document.open(); document.write(${JSON.stringify('<!doctype html>' + html)}); document.close();
     const style = document.createElement('style'); style.textContent = ${JSON.stringify(css)}; document.head.append(style);
   })()`)
 }
@@ -100,17 +100,22 @@ test('built React components preserve layout', { skip: missingBrowser && 'agent-
 
     await t.test('empty lines and wrapped text retain matching geometry', () => {
       for (const lineNumbers of [true, false]) {
-        render({ fontFamily: 'monospace', fontSize: 13, lineHeight: '22px' },
+        render({ fontFamily: 'monospace', fontSize: 15, lineHeight: '22.5px' },
           { lineNumbers }, { lineNumbers },
-          '.sh__line { display: block; min-height: 1em } [data-sh-code-line-number] { position: absolute }')
+          '* { box-sizing: border-box } .sh__line { min-height: 1em } [data-sh-code-line-number] { position: absolute }')
         const rows = read(() => [...document.querySelectorAll('code')].map(block =>
           [...block.querySelectorAll('.sh__line')].map(element => ({
+            top: element.getBoundingClientRect().top,
             height: element.getBoundingClientRect().height,
             lineHeight: parseFloat(getComputedStyle(element).lineHeight),
           }))))
         for (const block of rows) {
           assert(block.length >= 3)
           assert(block.every(row => row.height >= row.lineHeight), `Empty rows must retain line height (lineNumbers=${lineNumbers})`)
+          for (let index = 1; index < block.length; index++) {
+            assert.equal(block[index].top, block[index - 1].top + block[index - 1].height,
+              `Blank lines must not add baseline gaps (lineNumbers=${lineNumbers}, line=${index + 1})`)
+          }
         }
 
         for (const width of [240, 390, 600]) {
@@ -139,7 +144,7 @@ test('built React components preserve layout', { skip: missingBrowser && 'agent-
           const overlayPositions = read(() => {
             // Site styles can load after component styles in a deployed page.
             const siteStyle = document.createElement('style')
-            siteStyle.textContent = '[data-codice-code] code { font-family: serif; font-size: 12px; line-height: 2; letter-spacing: 1px }'
+            siteStyle.textContent = '[data-codice-code] code { font-family: serif; font-size: 12px; line-height: 2; letter-spacing: 1px } [data-sh-code-line-number] { position: absolute }'
             document.head.append(siteStyle)
             const editor = document.querySelector('[data-sh-editor]')
             const textarea = editor.querySelector('textarea')

--- a/packages/react/src/code/code.test.tsx
+++ b/packages/react/src/code/code.test.tsx
@@ -80,7 +80,7 @@ describe('Code', () => {
         overflow-wrap: break-word;
       }
       [data-sh-code] .sh__line {
-        display: inline-block;
+        display: block;
         width: 100%;
         min-height: 1lh;
       }
@@ -147,7 +147,7 @@ describe('Code', () => {
         overflow-wrap: break-word;
       }
       [data-sh-code] .sh__line {
-        display: inline-block;
+        display: block;
         width: 100%;
         min-height: 1lh;
       }
@@ -254,7 +254,7 @@ describe('Code', () => {
         overflow-wrap: break-word;
       }
       [data-sh-code] .sh__line {
-        display: inline-block;
+        display: block;
         width: 100%;
         min-height: 1lh;
       }
@@ -361,7 +361,7 @@ describe('Code', () => {
         overflow-wrap: break-word;
       }
       [data-sh-code] .sh__line {
-        display: inline-block;
+        display: block;
         width: 100%;
         min-height: 1lh;
       }
@@ -426,7 +426,7 @@ describe('Code', () => {
         overflow-wrap: break-word;
       }
       [data-sh-code] .sh__line {
-        display: inline-block;
+        display: block;
         width: 100%;
         min-height: 1lh;
       }

--- a/packages/react/src/code/code.test.tsx
+++ b/packages/react/src/code/code.test.tsx
@@ -80,7 +80,7 @@ describe('Code', () => {
         overflow-wrap: break-word;
       }
       [data-sh-code] .sh__line {
-        display: block;
+        display: inline-block;
         width: 100%;
         min-height: 1lh;
       }
@@ -147,7 +147,7 @@ describe('Code', () => {
         overflow-wrap: break-word;
       }
       [data-sh-code] .sh__line {
-        display: block;
+        display: inline-block;
         width: 100%;
         min-height: 1lh;
       }
@@ -254,7 +254,7 @@ describe('Code', () => {
         overflow-wrap: break-word;
       }
       [data-sh-code] .sh__line {
-        display: block;
+        display: inline-block;
         width: 100%;
         min-height: 1lh;
       }
@@ -361,7 +361,7 @@ describe('Code', () => {
         overflow-wrap: break-word;
       }
       [data-sh-code] .sh__line {
-        display: block;
+        display: inline-block;
         width: 100%;
         min-height: 1lh;
       }
@@ -426,7 +426,7 @@ describe('Code', () => {
         overflow-wrap: break-word;
       }
       [data-sh-code] .sh__line {
-        display: block;
+        display: inline-block;
         width: 100%;
         min-height: 1lh;
       }

--- a/packages/react/src/code/css.ts
+++ b/packages/react/src/code/css.ts
@@ -37,7 +37,7 @@ ${C} code {
   overflow-wrap: break-word;
 }
 ${C} .sh__line {
-  display: block;
+  display: inline-block;
   width: 100%;
   min-height: 1lh;
 }

--- a/packages/react/src/code/css.ts
+++ b/packages/react/src/code/css.ts
@@ -37,7 +37,7 @@ ${C} code {
   overflow-wrap: break-word;
 }
 ${C} .sh__line {
-  display: inline-block;
+  display: block;
   width: 100%;
   min-height: 1lh;
 }

--- a/packages/react/src/editor/editor.test.tsx
+++ b/packages/react/src/editor/editor.test.tsx
@@ -221,7 +221,7 @@ describe('Code', () => {
         overflow-wrap: break-word;
       }
       [data-sh-code] .sh__line {
-        display: block;
+        display: inline-block;
         width: 100%;
         min-height: 1lh;
       }
@@ -400,7 +400,7 @@ describe('Code', () => {
         overflow-wrap: break-word;
       }
       [data-sh-code] .sh__line {
-        display: block;
+        display: inline-block;
         width: 100%;
         min-height: 1lh;
       }
@@ -539,7 +539,7 @@ describe('Code', () => {
         overflow-wrap: break-word;
       }
       [data-sh-code] .sh__line {
-        display: block;
+        display: inline-block;
         width: 100%;
         min-height: 1lh;
       }

--- a/packages/react/src/editor/editor.test.tsx
+++ b/packages/react/src/editor/editor.test.tsx
@@ -221,7 +221,7 @@ describe('Code', () => {
         overflow-wrap: break-word;
       }
       [data-sh-code] .sh__line {
-        display: inline-block;
+        display: block;
         width: 100%;
         min-height: 1lh;
       }
@@ -400,7 +400,7 @@ describe('Code', () => {
         overflow-wrap: break-word;
       }
       [data-sh-code] .sh__line {
-        display: inline-block;
+        display: block;
         width: 100%;
         min-height: 1lh;
       }
@@ -539,7 +539,7 @@ describe('Code', () => {
         overflow-wrap: break-word;
       }
       [data-sh-code] .sh__line {
-        display: inline-block;
+        display: block;
         width: 100%;
         min-height: 1lh;
       }


### PR DESCRIPTION
Code and Editor can add extra baseline spacing after blank lines because highlighted rows use inline-block. On the production `/react` Editor, each affected blank line added 6.5px, making selection and the caret drift from the highlighted text.

Render shared highlighted rows as blocks in both components. Remove the redundant `/react` display override so the package owns this behavior. Include a minor Changeset because custom CSS relying on inline-block line alignment may need adjustment; tokens and line-number spans retain their existing display styles.

Run layout fixtures in standards mode with `<!doctype html>`, matching actual pages. Assert that adjacent lines have no gaps in both Code and Editor, with line numbers on/off and absolutely positioned numbers. Retain the page regression with actual site CSS loaded in both orders, as well as wrapping and textarea geometry checks.

Validation:
- `pnpm test` passed (217 tests).
- `pnpm --filter '!site' build` passed; used the development server for site verification.
- `pnpm --filter @sugar-high/react test:browser` passed. Restoring inline-block makes the blank-line regression fail.
- Verified 41 lines across three Code/Editor blocks on localhost:3000/react with zero gaps, including selected Editor text, after removing the page workaround.
- Reproduced the original issue on the public production page and verified the block declaration through a temporary browser override; this PR has not been deployed.
- `git diff --check` passed.
- React bundle measurement: root entry 35.99 KiB minified / 12.55 KiB gzip; core + python 9.56 KiB / 3.75 KiB.
