### PR TITLE
fix: harden file tree display across layouts and themes

### DIFF
--- a/.changeset/orange-suns-trade.md
+++ b/.changeset/orange-suns-trade.md
@@ -5,3 +5,5 @@
 Keep file tree row backgrounds, focus outlines, and click targets aligned with long filenames and deeply nested paths when scrolling horizontally.
 
 Preserve the selected file's background while hovering.
+
+Keep the tree contained in narrow or short panels and give larger filename text a consistent line height.

--- a/.changeset/orange-suns-trade.md
+++ b/.changeset/orange-suns-trade.md
@@ -1,0 +1,5 @@
+---
+'@sugar-high/react': patch
+---
+
+Keep file tree row backgrounds, focus outlines, and click targets aligned with long filenames and deeply nested paths when scrolling horizontally.

--- a/.changeset/orange-suns-trade.md
+++ b/.changeset/orange-suns-trade.md
@@ -7,3 +7,5 @@ Keep file tree row backgrounds, focus outlines, and click targets aligned with l
 Preserve the selected file's background while hovering.
 
 Keep the tree contained in narrow or short panels and give larger filename text a consistent line height.
+
+Isolate filename text direction and mirror indentation and disclosure arrows in right-to-left trees.

--- a/.changeset/orange-suns-trade.md
+++ b/.changeset/orange-suns-trade.md
@@ -3,3 +3,5 @@
 ---
 
 Keep file tree row backgrounds, focus outlines, and click targets aligned with long filenames and deeply nested paths when scrolling horizontally.
+
+Preserve the selected file's background while hovering.

--- a/.changeset/orange-suns-trade.md
+++ b/.changeset/orange-suns-trade.md
@@ -9,3 +9,5 @@ Preserve the selected file's background while hovering.
 Keep the tree contained in narrow or short panels and give larger filename text a consistent line height.
 
 Isolate filename text direction and mirror indentation and disclosure arrows in right-to-left trees.
+
+Use the theme foreground for selection and focus contrast, and system selection colors in forced-color mode.

--- a/packages/react/scripts/test-layout.mjs
+++ b/packages/react/scripts/test-layout.mjs
@@ -81,6 +81,17 @@ test('built React components preserve layout', { skip: missingBrowser && 'agent-
       assert(layout.rows.every(row => row.containsLabel && row.hit), JSON.stringify(layout))
       assert(layout.rows.every(row => row.width === layout.rows[0].width))
     })
+    await t.test('hover preserves file tree selection', () => {
+      renderTree({ paths: ['a.ts', 'b.ts'], activeFile: 'a.ts' })
+      browser(['hover', 'body'])
+      const selected = () => getComputedStyle(document.querySelector('[aria-selected=true]')).backgroundColor
+      const background = read(selected)
+      browser(['hover', '[aria-selected=true]'])
+      assert.equal(read(selected), background)
+      browser(['hover', '[aria-label="b.ts"]'])
+      assert.notEqual(read(() => getComputedStyle(document.querySelector('[aria-label="b.ts"]')).backgroundColor), background)
+    })
+
     await t.test('React page editor stays aligned regardless of stylesheet order', () => {
       const siteCss = ['global.css', 'styles.css', 'react/page.css']
         .map(file => readFileSync(new URL(`../../../apps/site/app/${file}`, import.meta.url), 'utf8'))

--- a/packages/react/scripts/test-layout.mjs
+++ b/packages/react/scripts/test-layout.mjs
@@ -14,7 +14,7 @@ if (!missingBrowser && (detected.error || detected.status !== 0)) {
 const { createElement: h } = await import('react')
 const { renderToString } = await import('react-dom/server')
 let Code, Editor, FileTree
-const session = `sugar-layout-${process.pid}`
+let session = `sugar-layout-${process.pid}`
 const source = "import { Button } from './components/button'\n\nexport default Button\n"
 
 function browser(args, input) {
@@ -138,6 +138,33 @@ test('built React components preserve layout', { skip: missingBrowser && 'agent-
           assert.equal(label.x - labels[0].x, dir === 'rtl' ? -16 : 16)
           assert.equal(label.direction, /^[\u0590-\u06ff]/u.test(label.name) ? 'rtl' : 'ltr')
         }
+      }
+    })
+
+    await t.test('file tree selection and focus remain visible on light and dark themes', () => {
+      for (const theme of [
+        { background: '#ffffff', foreground: '#222222' },
+        { background: '#111111', foreground: '#eeeeee' },
+      ]) {
+        renderTree({ paths: ['a.ts', 'b.ts'], activeFile: 'a.ts', theme })
+        browser(['press', 'Tab'])
+        const colors = read(() => {
+          const tree = document.querySelector('[data-sh-file-tree]')
+          const selected = tree.querySelector('[aria-selected=true]')
+          const style = getComputedStyle(selected)
+          return {
+            focused: selected.matches(':focus-visible'),
+            foreground: style.color,
+            outline: style.outlineColor,
+            outlineStyle: style.outlineStyle,
+            background: style.backgroundColor,
+            plain: getComputedStyle(tree.querySelector('[aria-selected=false]')).backgroundColor,
+          }
+        })
+        assert(colors.focused)
+        assert.equal(colors.outlineStyle, 'solid')
+        assert.equal(colors.outline, colors.foreground)
+        assert.notEqual(colors.background, colors.plain)
       }
     })
 
@@ -293,6 +320,37 @@ test('built React components preserve layout', { skip: missingBrowser && 'agent-
         overflow: element.scrollWidth > element.clientWidth,
       })))
       assert.deepEqual(frames, [{ whiteSpace: 'pre', overflow: true }, { whiteSpace: 'pre', overflow: true }])
+    })
+    await t.test('forced colors retain file tree selection and keyboard focus', () => {
+      browser(['close'])
+      session += '-forced'
+      browser(['--args', '--force-high-contrast', 'open', 'about:blank'])
+      renderTree({ paths: ['a.ts', 'b.ts'], activeFile: 'a.ts' })
+      browser(['press', 'Tab'])
+      const colors = read(() => {
+        const selected = document.querySelector('[aria-selected=true]')
+        const style = getComputedStyle(selected)
+        const probe = document.createElement('div')
+        probe.style.cssText = 'forced-color-adjust:none;background:Highlight;color:HighlightText'
+        document.body.append(probe)
+        const system = getComputedStyle(probe)
+        return {
+          forced: matchMedia('(forced-colors: active)').matches,
+          focused: selected.matches(':focus-visible'),
+          background: style.backgroundColor,
+          foreground: style.color,
+          outline: style.outlineColor,
+          outlineStyle: style.outlineStyle,
+          systemBackground: system.backgroundColor,
+          systemForeground: system.color,
+        }
+      })
+      assert(colors.forced && colors.focused)
+      assert.equal(colors.background, colors.systemBackground)
+      assert.equal(colors.foreground, colors.systemForeground)
+      assert.notEqual(colors.background, colors.foreground)
+      assert.equal(colors.outline, colors.foreground)
+      assert.equal(colors.outlineStyle, 'solid')
     })
   } finally {
     browser(['close'], undefined)

--- a/packages/react/scripts/test-layout.mjs
+++ b/packages/react/scripts/test-layout.mjs
@@ -118,6 +118,29 @@ test('built React components preserve layout', { skip: missingBrowser && 'agent-
       }
     })
 
+    await t.test('file tree labels preserve Unicode names and follow tree indentation in either direction', () => {
+      const names = ['.env', 'two words.ts', '🧪.tsx', '组件.tsx', 'مرحبا.ts', 'שלום-test.ts']
+      for (const dir of ['ltr', 'rtl']) {
+        renderTree({ paths: names.map(name => `src/${name}`), dir }, { width: 600 })
+        const labels = read(() => [...document.querySelectorAll('[role=treeitem]')].map(row => {
+          const label = row.querySelector('span')
+          const icon = row.querySelector('svg').getBoundingClientRect()
+          return {
+            name: label.textContent,
+            direction: getComputedStyle(label).direction,
+            indent: getComputedStyle(row).paddingInlineStart,
+            x: icon.x,
+          }
+        }))
+        assert.deepEqual(labels.slice(1).map(label => label.name).sort(), [...names].sort())
+        for (const label of labels.slice(1)) {
+          assert.equal(label.indent, '22px')
+          assert.equal(label.x - labels[0].x, dir === 'rtl' ? -16 : 16)
+          assert.equal(label.direction, /^[\u0590-\u06ff]/u.test(label.name) ? 'rtl' : 'ltr')
+        }
+      }
+    })
+
     await t.test('React page editor stays aligned regardless of stylesheet order', () => {
       const siteCss = ['global.css', 'styles.css', 'react/page.css']
         .map(file => readFileSync(new URL(`../../../apps/site/app/${file}`, import.meta.url), 'utf8'))

--- a/packages/react/scripts/test-layout.mjs
+++ b/packages/react/scripts/test-layout.mjs
@@ -13,7 +13,7 @@ if (!missingBrowser && (detected.error || detected.status !== 0)) {
 // Use the built package, so verification also exercises its emitted styles.
 const { createElement: h } = await import('react')
 const { renderToString } = await import('react-dom/server')
-let Code, Editor
+let Code, Editor, FileTree
 const session = `sugar-layout-${process.pid}`
 const source = "import { Button } from './components/button'\n\nexport default Button\n"
 
@@ -41,12 +41,46 @@ function read(fn) {
   return browser(['eval', '--stdin'], `(${fn.toString()})()`).result
 }
 
+function renderTree(props = {}, style = { width: 180 }, css = '') {
+  const html = renderToString(h('div', { style }, h(FileTree, {
+    paths: ['src/components/deeply/nested/a-very-long-component-filename.tsx', 'readme.md'],
+    activeFile: 'src/components/deeply/nested/a-very-long-component-filename.tsx',
+    onActiveFileChange() {},
+    ...props,
+  })))
+  browser(['eval', '--stdin'], `document.open(); document.write(${JSON.stringify('<!doctype html>' + html + `<style>${css}</style>`)}); document.close();`)
+}
+
 test('built React components preserve layout', { skip: missingBrowser && 'agent-browser is not installed' }, async t => {
   const components = await import('../dist/index.js')
   Code = components.Code
   Editor = components.Editor
+  FileTree = components.FileTree
   try {
     browser(['open', 'about:blank'], undefined)
+    await t.test('file tree rows cover overflowing names and share a full-width hit area', () => {
+      renderTree()
+      const layout = read(() => {
+        const tree = document.querySelector('[data-sh-file-tree]')
+        const rows = [...tree.querySelectorAll('[role=treeitem]')]
+        tree.scrollLeft = tree.scrollWidth
+        return {
+          scrolled: tree.scrollLeft > 0,
+          rows: rows.map(row => {
+            const rect = row.getBoundingClientRect()
+            const label = row.querySelector('span').getBoundingClientRect()
+            return {
+              width: rect.width,
+              containsLabel: rect.right >= label.right,
+              hit: document.elementFromPoint(rect.right - 4, rect.y + rect.height / 2)?.closest('[role=treeitem]') === row,
+            }
+          }),
+        }
+      })
+      assert(layout.scrolled)
+      assert(layout.rows.every(row => row.containsLabel && row.hit), JSON.stringify(layout))
+      assert(layout.rows.every(row => row.width === layout.rows[0].width))
+    })
     await t.test('React page editor stays aligned regardless of stylesheet order', () => {
       const siteCss = ['global.css', 'styles.css', 'react/page.css']
         .map(file => readFileSync(new URL(`../../../apps/site/app/${file}`, import.meta.url), 'utf8'))

--- a/packages/react/scripts/test-layout.mjs
+++ b/packages/react/scripts/test-layout.mjs
@@ -92,6 +92,32 @@ test('built React components preserve layout', { skip: missingBrowser && 'agent-
       assert.notEqual(read(() => getComputedStyle(document.querySelector('[aria-label="b.ts"]')).backgroundColor), background)
     })
 
+    await t.test('file trees fit constrained panels with enlarged text', () => {
+      for (const display of ['flex', 'grid']) {
+        for (const zoom of [1, 2]) {
+          renderTree({ style: { width: '100%', height: '100%', fontSize: 26, fontFamily: 'serif' } },
+            { display, width: 120, height: 100, zoom })
+          const layout = read(() => {
+            const tree = document.querySelector('[data-sh-file-tree]')
+            const bounds = tree.getBoundingClientRect()
+            const panel = tree.parentElement.getBoundingClientRect()
+            return {
+              contained: bounds.right <= panel.right && bounds.bottom <= panel.bottom,
+              scrolls: tree.scrollWidth > tree.clientWidth && tree.scrollHeight > tree.clientHeight,
+              rows: [...tree.querySelectorAll('[role=treeitem]')].map(row => {
+                const bounds = row.getBoundingClientRect()
+                const label = row.querySelector('span').getBoundingClientRect()
+                const icons = [...row.querySelectorAll('svg')].map(icon => icon.getBoundingClientRect())
+                return label.top >= bounds.top && label.bottom <= bounds.bottom && icons.every(icon =>
+                  Math.abs((icon.top + icon.bottom) / 2 - (bounds.top + bounds.bottom) / 2) < 0.5)
+              }),
+            }
+          })
+          assert(layout.contained && layout.scrolls && layout.rows.every(Boolean), JSON.stringify({ display, zoom, layout }))
+        }
+      }
+    })
+
     await t.test('React page editor stays aligned regardless of stylesheet order', () => {
       const siteCss = ['global.css', 'styles.css', 'react/page.css']
         .map(file => readFileSync(new URL(`../../../apps/site/app/${file}`, import.meta.url), 'utf8'))

--- a/packages/react/src/file-tree/index.tsx
+++ b/packages/react/src/file-tree/index.tsx
@@ -12,7 +12,7 @@ export type FileTreeProps = {
   theme?: Theme
 } & Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'onChange'>
 
-const css = `[data-sh-file-tree]{padding:8px;overflow:auto;font-family:var(--sh-font-family,ui-monospace,monospace);font-size:var(--sh-font-size,13px)}
+const css = `[data-sh-file-tree]{display:grid;grid-template-columns:minmax(max-content,1fr);align-content:start;padding:8px;overflow:auto;font-family:var(--sh-font-family,ui-monospace,monospace);font-size:var(--sh-font-size,13px)}
 [data-sh-file-tree] [role=treeitem]{display:flex;align-items:center;gap:6px;min-height:30px;padding-right:8px;border-radius:4px;cursor:pointer;white-space:nowrap;outline:none;user-select:none}
 [data-sh-file-tree] [role=treeitem]:hover{background:color-mix(in srgb,#888 7%,transparent)}
 [data-sh-file-tree] [aria-selected=true]{background:color-mix(in srgb,#888 13%,transparent)}

--- a/packages/react/src/file-tree/index.tsx
+++ b/packages/react/src/file-tree/index.tsx
@@ -13,12 +13,13 @@ export type FileTreeProps = {
 } & Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'onChange'>
 
 const css = `[data-sh-file-tree]{display:grid;grid-template-columns:minmax(max-content,1fr);grid-auto-rows:max-content;align-content:start;min-width:0;min-height:0;box-sizing:border-box;line-height:1.5;padding:8px;overflow:auto;font-family:var(--sh-font-family,ui-monospace,monospace);font-size:var(--sh-font-size,13px)}
-[data-sh-file-tree] [role=treeitem]{display:flex;align-items:center;gap:6px;min-height:30px;padding-right:8px;border-radius:4px;cursor:pointer;white-space:nowrap;outline:none;user-select:none}
+[data-sh-file-tree] [role=treeitem]{display:flex;align-items:center;gap:6px;min-height:30px;padding-inline-end:8px;border-radius:4px;cursor:pointer;white-space:nowrap;outline:none;user-select:none}
 [data-sh-file-tree] [role=treeitem]:not([aria-selected=true]):hover{background:color-mix(in srgb,#888 7%,transparent)}
 [data-sh-file-tree] [aria-selected=true]{background:color-mix(in srgb,#888 13%,transparent)}
 [data-sh-file-tree] [role=treeitem]:focus-visible{outline:1px solid color-mix(in srgb,currentColor 45%,transparent);outline-offset:-1px}
 [data-sh-file-tree] svg{width:16px;height:16px;flex:none}
-[data-sh-file-tree] [data-sh-chevron]{width:10px}`
+[data-sh-file-tree] [data-sh-chevron]{width:10px}
+[data-sh-file-tree] [data-sh-chevron]:dir(rtl){transform:scaleX(-1)}`
 
 export function FileTree({ paths, activeFile, onActiveFileChange, theme, style, ...props }: FileTreeProps) {
   const items = useMemo(() => treeItems(paths), [paths])
@@ -63,7 +64,7 @@ export function FileTree({ paths, activeFile, onActiveFileChange, theme, style, 
             aria-expanded={item.directory ? expanded : undefined}
             aria-selected={!item.directory && item.path === activeFile}
             tabIndex={current === item ? 0 : -1}
-            style={{ paddingLeft: 6 + item.depth * 16 }}
+            style={{ paddingInlineStart: 6 + item.depth * 16 }}
             ref={node => { if (node) refs.current.set(item.path, node); else refs.current.delete(item.path) }}
             onFocus={() => setFocused(item.path)}
             onClick={() => { focus(item); activate(item) }}
@@ -96,7 +97,7 @@ export function FileTree({ paths, activeFile, onActiveFileChange, theme, style, 
             <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeLinejoin="round">
               <path d={item.directory ? 'M2 4h4l2 2h6v7H2Z' : 'M4 2h5l3 3v9H4Z M9 2v4h3'} />
             </svg>
-            <span>{item.name}</span>
+            <span dir="auto">{item.name}</span>
           </div>
         )
       })}

--- a/packages/react/src/file-tree/index.tsx
+++ b/packages/react/src/file-tree/index.tsx
@@ -14,12 +14,13 @@ export type FileTreeProps = {
 
 const css = `[data-sh-file-tree]{display:grid;grid-template-columns:minmax(max-content,1fr);grid-auto-rows:max-content;align-content:start;min-width:0;min-height:0;box-sizing:border-box;line-height:1.5;padding:8px;overflow:auto;font-family:var(--sh-font-family,ui-monospace,monospace);font-size:var(--sh-font-size,13px)}
 [data-sh-file-tree] [role=treeitem]{display:flex;align-items:center;gap:6px;min-height:30px;padding-inline-end:8px;border-radius:4px;cursor:pointer;white-space:nowrap;outline:none;user-select:none}
-[data-sh-file-tree] [role=treeitem]:not([aria-selected=true]):hover{background:color-mix(in srgb,#888 7%,transparent)}
-[data-sh-file-tree] [aria-selected=true]{background:color-mix(in srgb,#888 13%,transparent)}
-[data-sh-file-tree] [role=treeitem]:focus-visible{outline:1px solid color-mix(in srgb,currentColor 45%,transparent);outline-offset:-1px}
+[data-sh-file-tree] [role=treeitem]:not([aria-selected=true]):hover{background:color-mix(in srgb,currentColor 7%,transparent)}
+[data-sh-file-tree] [aria-selected=true]{background:color-mix(in srgb,currentColor 13%,transparent)}
+[data-sh-file-tree] [role=treeitem]:focus-visible{outline:1px solid currentColor;outline-offset:-1px}
 [data-sh-file-tree] svg{width:16px;height:16px;flex:none}
 [data-sh-file-tree] [data-sh-chevron]{width:10px}
-[data-sh-file-tree] [data-sh-chevron]:dir(rtl){transform:scaleX(-1)}`
+[data-sh-file-tree] [data-sh-chevron]:dir(rtl){transform:scaleX(-1)}
+@media(forced-colors:active){[data-sh-file-tree] [aria-selected=true]{forced-color-adjust:none;background:Highlight;color:HighlightText}}`
 
 export function FileTree({ paths, activeFile, onActiveFileChange, theme, style, ...props }: FileTreeProps) {
   const items = useMemo(() => treeItems(paths), [paths])

--- a/packages/react/src/file-tree/index.tsx
+++ b/packages/react/src/file-tree/index.tsx
@@ -14,7 +14,7 @@ export type FileTreeProps = {
 
 const css = `[data-sh-file-tree]{display:grid;grid-template-columns:minmax(max-content,1fr);align-content:start;padding:8px;overflow:auto;font-family:var(--sh-font-family,ui-monospace,monospace);font-size:var(--sh-font-size,13px)}
 [data-sh-file-tree] [role=treeitem]{display:flex;align-items:center;gap:6px;min-height:30px;padding-right:8px;border-radius:4px;cursor:pointer;white-space:nowrap;outline:none;user-select:none}
-[data-sh-file-tree] [role=treeitem]:hover{background:color-mix(in srgb,#888 7%,transparent)}
+[data-sh-file-tree] [role=treeitem]:not([aria-selected=true]):hover{background:color-mix(in srgb,#888 7%,transparent)}
 [data-sh-file-tree] [aria-selected=true]{background:color-mix(in srgb,#888 13%,transparent)}
 [data-sh-file-tree] [role=treeitem]:focus-visible{outline:1px solid color-mix(in srgb,currentColor 45%,transparent);outline-offset:-1px}
 [data-sh-file-tree] svg{width:16px;height:16px;flex:none}

--- a/packages/react/src/file-tree/index.tsx
+++ b/packages/react/src/file-tree/index.tsx
@@ -12,7 +12,7 @@ export type FileTreeProps = {
   theme?: Theme
 } & Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'onChange'>
 
-const css = `[data-sh-file-tree]{display:grid;grid-template-columns:minmax(max-content,1fr);align-content:start;padding:8px;overflow:auto;font-family:var(--sh-font-family,ui-monospace,monospace);font-size:var(--sh-font-size,13px)}
+const css = `[data-sh-file-tree]{display:grid;grid-template-columns:minmax(max-content,1fr);grid-auto-rows:max-content;align-content:start;min-width:0;min-height:0;box-sizing:border-box;line-height:1.5;padding:8px;overflow:auto;font-family:var(--sh-font-family,ui-monospace,monospace);font-size:var(--sh-font-size,13px)}
 [data-sh-file-tree] [role=treeitem]{display:flex;align-items:center;gap:6px;min-height:30px;padding-right:8px;border-radius:4px;cursor:pointer;white-space:nowrap;outline:none;user-select:none}
 [data-sh-file-tree] [role=treeitem]:not([aria-selected=true]):hover{background:color-mix(in srgb,#888 7%,transparent)}
 [data-sh-file-tree] [aria-selected=true]{background:color-mix(in srgb,#888 13%,transparent)}


### PR DESCRIPTION
File tree rows could stop short of long filenames when scrolling, selected rows lost their background on hover, and constrained panels could compress enlarged text. Keep every row as wide as the longest path and preserve content height, selection, and focus across these cases.

- Contain scrolling in narrow or short panels, including enlarged text and 200% CSS zoom.
- Preserve Unicode filenames, isolate label text direction, and mirror indentation and disclosure arrows in right-to-left trees.
- Use theme foreground colors for hover, selection, and focus, with system selection colors in forced-color mode.

Includes five focused commits, browser regression coverage, and a patch Changeset for `@sugar-high/react`. No new public API.

Validation: `pnpm test` (220 tests), `pnpm build`, `pnpm --filter @sugar-high/react test:browser` (12 passing checks), and `git diff --check` all pass. Browser checks use the built package and cover overflow hit areas, hover, constrained layouts, Unicode/RTL, light/dark themes, and forced colors.

Measured with `pnpm --filter @sugar-high/react benchmark`: FileTree entry 35.95 KiB minified / 12.65 KiB gzip; Editor + FileTree 42.86 KiB minified / 15.14 KiB gzip.
