### PR TITLE
fix: install sugar-high with framework packages

### DIFF
--- a/.changeset/calm-cats-install.md
+++ b/.changeset/calm-cats-install.md
@@ -1,0 +1,6 @@
+---
+"@sugar-high/react": patch
+"@sugar-high/remark": patch
+---
+
+Install Sugar High as a runtime dependency of the React package instead of requiring applications to declare it as a peer dependency. Document the simplified React and Remark installation commands.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -5,7 +5,7 @@ Lightweight React code blocks and editors powered by Sugar High.
 ## Install
 
 ```sh
-npm install @sugar-high/react sugar-high react
+npm install @sugar-high/react react
 ```
 
 ## Editor

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -37,16 +37,17 @@
     "prepublishOnly": "pnpm build",
     "test:browser": "node --test scripts/test-layout.mjs"
   },
-  "peerDependencies": {
-    "react": "^18.0.0 || ^19.0.0",
+  "dependencies": {
     "sugar-high": "workspace:^"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.0",
     "bunchee": "^7.0.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "sugar-high": "workspace:*",
     "typescript": "^6.0.2",
     "vitest": "^3.2.4"
   },

--- a/packages/remark/README.md
+++ b/packages/remark/README.md
@@ -5,7 +5,7 @@ Remark plugin for the [Sugar High](https://sugar-high.vercel.app) syntax highlig
 ## Install
 
 ```sh
-npm install @sugar-high/remark sugar-high
+npm install @sugar-high/remark
 ```
 
 ## Usage

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,6 +194,10 @@ importers:
         version: 6.0.2
 
   packages/react:
+    dependencies:
+      sugar-high:
+        specifier: workspace:^
+        version: link:../sugar-high
     devDependencies:
       '@types/react':
         specifier: ^19.2.0
@@ -207,9 +211,6 @@ importers:
       react-dom:
         specifier: ^19.2.0
         version: 19.2.0(react@19.2.0)
-      sugar-high:
-        specifier: workspace:*
-        version: link:../sugar-high
       typescript:
         specifier: ^6.0.2
         version: 6.0.2

--- a/skills/sugar-high/references/react.md
+++ b/skills/sugar-high/references/react.md
@@ -1,9 +1,9 @@
 # `@sugar-high/react` API
 
-Install it with its peer dependencies:
+Install it with React:
 
 ```sh
-npm install @sugar-high/react sugar-high react
+npm install @sugar-high/react react
 ```
 
 The default entry point is client-oriented and includes Sugar High's complete language registry.

--- a/skills/sugar-high/references/remark.md
+++ b/skills/sugar-high/references/remark.md
@@ -1,9 +1,9 @@
 # `@sugar-high/remark` API
 
-Install the plugin with Sugar High and add it to a Remark processor:
+Install the plugin and add it to a Remark processor:
 
 ```sh
-npm install @sugar-high/remark sugar-high
+npm install @sugar-high/remark
 ```
 
 ```js


### PR DESCRIPTION
## Summary

- make sugar-high a direct runtime dependency of @sugar-high/react
- simplify the React and Remark install instructions
- add patch changesets for @sugar-high/react and @sugar-high/remark

## Release impact

- @sugar-high/react: 2.3.0 → 2.3.1
- @sugar-high/remark: 1.0.1 → 1.0.2
- sugar-high remains at 2.3.1

## Testing

- pnpm test
- pnpm build
- pnpm check:packages
- git diff --check